### PR TITLE
Initial work with the support for syncing java classes from Keycloak

### DIFF
--- a/.github/copy_templates/admin-client
+++ b/.github/copy_templates/admin-client
@@ -1,0 +1,1 @@
+src/main/java/org/keycloak/admin/client/*

--- a/.github/copy_templates/common
+++ b/.github/copy_templates/common
@@ -1,0 +1,8 @@
+src/main/java/org/keycloak/common/util/Base64.java
+src/main/java/org/keycloak/common/util/CollectionUtil.java
+src/main/java/org/keycloak/common/util/MultivaluedHashMap.java
+src/main/java/org/keycloak/common/util/MultivaluedMap.java
+src/main/java/org/keycloak/common/util/ObjectUtil.java
+src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+src/main/java/org/keycloak/common/util/SystemEnvProperties.java
+src/main/java/org/keycloak/common/util/Time.java

--- a/.github/copy_templates/core
+++ b/.github/copy_templates/core
@@ -1,0 +1,12 @@
+src/main/java/org/keycloak/crypto/KeyUse.java
+src/main/java/org/keycloak/json/*.java
+src/main/java/org/keycloak/representations/adapters/action/GlobalRequestResult.java
+src/main/java/org/keycloak/representations/idm/*
+src/main/java/org/keycloak/representations/info/*.java
+src/main/java/org/keycloak/representations/userprofile/config/*.java
+src/main/java/org/keycloak/representations/AccessToken.java
+src/main/java/org/keycloak/representations/AccessTokenResponse.java
+src/main/java/org/keycloak/representations/AddressClaimSet.java
+src/main/java/org/keycloak/representations/IDToken.java
+src/main/java/org/keycloak/representations/JsonWebToken.java
+src/main/java/org/keycloak/representations/KeyStoreConfig.java

--- a/.github/scripts/sync-keycloak-sources.sh
+++ b/.github/scripts/sync-keycloak-sources.sh
@@ -1,0 +1,115 @@
+#!/bin/bash -e
+
+CLIENT_REPOSITORY_ROOT_DIR=keycloak-client
+KC_REPOSITORY_ROOT_DIR=keycloak
+
+TARGET_REMOTE=upstream
+CLIENT_REPO_DIR_PATH=$PWD
+
+KC_TARGET_BRANCH=$1
+KEYCLOAK_SOURCES_DIR_PATH=$2
+if [ "$KEYCLOAK_SOURCES_DIR_PATH" == "" ]; then
+  KEYCLOAK_SOURCES_DIR_PATH=$CLIENT_REPO_DIR_PATH/../keycloak
+fi
+TARGET_REMOTE=$3
+if [ "$TARGET_REMOTE" == "" ]; then
+  TARGET_REMOTE=upstream
+fi
+
+function revert() {
+  if [ -n "$KC_WORK_BRANCH" ]; then
+    echo_header "Returning back to branch '$KC_WORK_BRANCH' in the keycloak repository";
+    git checkout $KC_WORK_BRANCH;
+  fi;
+
+  echo "Returning back to directory $CLIENT_REPO_DIR_PATH";
+  cd $CLIENT_REPO_DIR_PATH;
+}
+
+function echo_header() {
+  echo ""
+  echo "======================================================================="
+  echo "$1"
+  echo "-----------------------------------------------------------------------"
+}
+
+function error() {
+  echo "======================================================================="
+  echo "Error"
+  echo "-----------------------------------------------------------------------"
+  echo "$1"
+  echo ""
+  revert;
+  exit 1
+}
+
+function checkChangesInCurrentBranch() {
+  # Check if no changes or any untracked files in current keycloak-client directory
+  REPO=$1;
+
+  COUNT=$(git diff | wc -l)
+  if [[ ! $COUNT == 0 ]]; then
+    error "There are uncommited changes in the '$REPO' repository. Please commit (or revert) everything first before executing this script.";
+  fi;
+  COUNT=$(git status | grep "Untracked files" | wc -l)
+  if [[ ! $COUNT == 0 ]]; then
+    error "There are untracked files in the '$REPO' repository. Please commit everything first before executing this script.";
+  fi;
+}
+
+function copyFiles() {
+  TEMPLATE=$1;
+  KC_FROM=$2
+  KC_CLIENT_TO=$3
+  echo_header "Copying files from '$KC_REPOSITORY_ROOT_DIR/$KC_FROM' to '$CLIENT_REPOSITORY_ROOT_DIR/$KC_CLIENT_TO' with the use of template '$TEMPLATE'";
+  for I in $(cat $CLIENT_REPO_DIR_PATH/.github/copy_templates/$TEMPLATE); do
+      FROM=$KEYCLOAK_SOURCES_DIR_PATH/$KC_FROM/$I;
+      # Helper variable
+      TT=$(echo $I | sed -r 's/\*/FFFFF/g');
+      TO=$(echo $CLIENT_REPO_DIR_PATH/$KC_CLIENT_TO/$TT | awk '{split($0,a,"FFFFF"); print a[1]}')
+      echo "Copying $FROM to $TO";
+      cp -r $FROM $TO;
+  done
+}
+
+# Check if inside keycloak-client directory
+if [[ ! $CLIENT_REPO_DIR_PATH == *$CLIENT_REPOSITORY_ROOT_DIR ]]; then
+  error "The script is supposed to be executed in the root of '$CLIENT_REPOSITORY_ROOT_DIR' repository";
+fi;
+
+
+# Check if no changes or any untracked files in current keycloak-client repository
+checkChangesInCurrentBranch $CLIENT_REPOSITORY_ROOT_DIR
+
+if [ "$KC_TARGET_BRANCH" == "" ]; then
+  error "Usage: sync-keycloak-sources.sh <KEYCLOAK BRANCH> <KEYCLOAK SOURCES DIRECTORY> <TARGET REMOTE>
+  KEYCLOAK SOURCES DIRECTORY is optional and by default it is '../keycloak'
+  TARGET REMOTE is optional and points to the reference of the repository (output of 'git remote' referencing repository). Default value is 'upstream'"
+fi
+
+if [ -d "$KEYCLOAK_SOURCES_DIR_PATH" ]; then
+  echo_header "Using directory '$KEYCLOAK_SOURCES_DIR_PATH' with keycloak sources";
+else
+  error "Directory '$KEYCLOAK_SOURCES_DIR_PATH' does not exists";
+fi
+
+cd $KEYCLOAK_SOURCES_DIR_PATH;
+
+# Check if keycloak repository is set to some real branch and there are no uncommited changes
+KC_WORK_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$KC_WORK_BRANCH" == "HEAD" ]; then
+  error "Repository '$KC_REPOSITORY_ROOT_DIR' is set to the detached HEAD. Please save all uncommited changes and use 'git checkout <some branch>' or 'git checkout -b <some branch>' in the $KC_REPOSITORY_ROOT_DIR repository before running this script";
+fi
+
+# Check if no changes or any untracked files in keycloak repository
+checkChangesInCurrentBranch $KC_REPOSITORY_ROOT_DIR
+
+# Checkout to the target branch in 'keycloak' repository
+git checkout $TARGET_REMOTE/$KC_TARGET_BRANCH;
+
+copyFiles common common client-common
+copyFiles core core client-core
+copyFiles admin-client integration/admin-client-jee integration/admin-client-jee
+copyFiles admin-client integration/admin-client integration/admin-client
+
+revert;

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,111 @@
+# OS stuff
+###################
+.DS_Store
+
+# Intellij
+###################
+.idea
+*.iml
+!.idea/icon.png
+
+# Eclipse #
+###########
+.project
+.settings
+.classpath
+# reverting this as e.g. /distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/
+# should not be ignored
+#bin/
+.factorypath
+
+
+# NetBeans #
+############
+nbactions.xml
+nb-configuration.xml
+catalog.xml
+nbproject
+
+# VS Code #
+###########
+*.code-workspace
+*.vscode
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Python byte-compiled files #
+##############################
+*.pyc
+
+# Logs and databases #
+######################
+*.log
+.attach_pid*
+
+# Maven #
+#########
+target
+bin
+
+# Maven shade
+#############
+*dependency-reduced-pom.xml
+
+# testsuite #
+#############
+*offline-token.txt
+
+# Quarkus ephemeral data #
+##########################
+quarkus/data/*.db
+
+# Jakarta transformed sources #
+###############################
+/integration/admin-client/src/
+/adapters/saml/jakarta-servlet-filter/src/
+/adapters/oidc/jakarta-servlet-filter/src/
+/.metadata/
+
+# Git ephemeral files
+*.versionsBackup
+
+# frontend-maven-plugin
+node
+
+# Wireit
+.wireit
+
+# Vite
+dist
+
+# ESLint
+.eslintcache
+
+# NPM
+node_modules
+
+# SDKMAM environment file
+.sdkmanrc
+
+# JENV
+.java-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,150 @@
+# Keycloak Community
+
+Keycloak is an Open Source Identity and Access Management solution for modern Applications and Services.
+
+## Building and working with the codebase
+
+Details for building from source and working with the codebase are provided in the [building and working with the code base](docs/building.md) guide.
+
+## Contributing to Keycloak
+
+Keycloak is an Open Source community-driven project and we welcome contributions as well as feedback from the community. We do have a few guidelines in place to help you be successful with your contribution to Keycloak.
+
+Firstly, if you want to contribute a larger change to Keycloak we ask that you open a 
+discussion first. For minor changes you can skip this part and go straight ahead to sending a contribution. Bear in mind that if you open a discussion first you can identify if the change will be accepted, as well as getting early feedback.  
+
+Here's a quick checklist for a good PR, more details below:
+
+1. A discussion around the change (https://github.com/keycloak/keycloak/discussions/categories/ideas)
+2. A GitHub Issue with a good description associated with the PR
+3. One feature/change per PR
+4. One commit per PR
+5. PR rebased on main (`git rebase`, not `git pull`) 
+5. [Good descriptive commit message, with link to issue](#commit-messages-and-issue-linking)
+6. No changes to code not directly related to your PR
+7. Includes functional/integration test
+8. Includes documentation
+
+Once you have submitted your PR please monitor it for comments/feedback. We reserve the right to close inactive PRs if
+you do not respond within 2 weeks (bear in mind you can always open a new PR if it is closed due to inactivity).
+
+Also, please remember that we do receive a fairly large amount of PRs and also have code to write ourselves, so we may
+not be able to respond to your PR immediately. The best place to ping us is on the thread you started on the dev mailing list.
+
+### Finding something to work on
+
+If you would like to contribute to Keycloak, but are not sure exactly what to work on, you can find a number of open
+issues that are awaiting contributions in  
+[issues](https://github.com/keycloak/keycloak/issues).
+
+### Open a discussion on a proposed change
+
+As Keycloak is a community-driven project we require contributors to open a discussion on what they are planning to contribute.
+
+Discussions should first and foremost be done through [GitHub Discussions](https://github.com/keycloak/keycloak/discussions/categories/ideas).
+
+The [Keycloak Dev Mailing List](https://groups.google.com/forum/#!forum/keycloak-dev) can be used to notify the community on your new discussion, and can also be used for more low-level implementation discussions.
+
+For very large proposals it can be inefficient to capture all the information in the GitHub Discussion. In this cases a separate design proposal can be sent to the [Keycloak Community repository](https://github.com/keycloak/keycloak-community/tree/main/design), and linked to from the GitHub Discussion.
+
+### Create an issue
+
+Take your time to write a proper issue including a good summary and description. 
+
+Remember this may be the first thing a reviewer of your PR will look at to get an idea of what you are proposing 
+and it will also be used by the community in the future to find about what new features and enhancements are included in 
+new releases.
+
+### Implementing
+
+Details for building from source and working with the codebase are provided in the 
+[building and working with the code base](docs/building.md) guide.
+
+Do not format or refactor code that is not directly related to your contribution. If you do this it will significantly
+increase our effort in reviewing your PR. If you have a strong need to refactor code then submit a separate PR for the
+refactoring.
+
+### Testing
+
+Details for implementing tests are provided in the [writing tests](docs/tests-development.md) guide.
+
+Do not add mock frameworks or other testing frameworks that are not already part of the testsuite. Please write tests
+in the same way as we have written our tests.
+
+### Documentation
+
+We require contributions to include relevant documentation. Before submitting your code changes, please take the time to review the [documentation](docs/documentation/README.md) guide and ensure that any necessary documentation changes are included in your pull request.
+
+### Submitting your PR
+
+When preparing your PR make sure you have a single commit and your branch is rebased on the main branch from the 
+project repository.
+
+This means use the `git rebase` command and not `git pull` when integrating changes from main to your branch. See
+[Git Documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) for more details.
+
+We require that you squash to a single commit. You can do this with the `git rebase -i HEAD~X` command where X
+is the number of commits you want to squash. See the [Git Documentation](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+for more details.
+
+The above helps us review your PR and also makes it easier for us to maintain the repository. It is also required by
+our automatic merging process. 
+
+Please, also provide a good description [commit message, with a link to the issue](#commit-messages-and-issue-linking).
+We also require that the commit message includes a link to the issue ([linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)).
+
+### Developer's Certificate of Origin
+
+Any contributions to Keycloak must only contain code that can legally be contributed to Keycloak, and which the Keycloak
+project can distribute under its license.
+
+Prior to contributing to Keycloak please read the [Developer's Certificate of Origin](https://developercertificate.org/)
+and sign-off all commits with the `--signoff` option provided by `git commit`. For example:
+
+```
+git commit --signoff --message "This is the commit message"
+```
+
+This option adds a `Signed-off-by` trailer at the end of the commit log message.
+
+### Commit messages and issue linking
+
+The format for a commit message should look like:
+
+```
+A brief descriptive summary
+
+Optionally, more details around how it was implemented
+
+Closes #1234
+``` 
+
+The very last part of the commit message should be a link to the GitHub issue, when done correctly GitHub will automatically link the issue with the PR. There are 3 alternatives provided by GitHub here:
+
+* Closes: Issues in the same repository
+* Fixes: Issues in a different repository (this shouldn't be used, as issues should be created in the correct repository instead)
+* Resolves: When multiple issues are resolved (this should be avoided)
+
+Although, GitHub allows alternatives (close, closed, fix, fixed), please only use the above formats.
+
+Creating multi line commit messages with `git` can be done with:
+
+```
+git commit -m "Summary" -m "Optional description" -m "Closes #1234"
+```
+
+Alternatively, `shift + enter` can be used to add line breaks:
+
+```
+$ git commit -m "Summary
+> 
+> Optional description
+> 
+> Closes #1234"
+```
+
+For more information linking PRs to issues refer to the [GitHub Documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+### Contributing Translations
+
+In order to provide translations for Keycloak, kindly follow the instructions provided in [Translation Docs](./docs/translation.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,112 @@
+# Keycloak Governance
+
+* [Vision](#vision) 
+* [Maintainers](#maintainers) 
+* [Contributing](#contributing)
+
+## Vision
+
+Keycloak aims to be easy to use and lightweight. The project was founded to make it easy for application developers 
+to secure modern applications and services.
+
+The 80/20 rule, that states 80% of requirements come from around 20% of use cases, is a core part of the vision behind 
+Keycloak. We strongly believe if Keycloak would support all use cases by default it would become bloated and hard to use.
+
+Keycloak aims to be opinionated and make it as easy as possible to achieve the common use cases, while still
+enabling the less common use cases through custom extensions.
+
+
+## Projects
+
+Keycloak consists of several projects:
+
+* [Keycloak](https://github.com/keycloak/keycloak) - Keycloak Server and Java adapters
+* [Keycloak QuickStarts](https://github.com/keycloak/keycloak-quickstarts) - QuickStarts for getting started with Keycloak
+* [Keycloak Benchmark](https://github.com/keycloak/keycloak-benchmark) - Load tests for benchmarking Keycloak
+* [Keycloak Community](https://github.com/keycloak/keycloak-community) - Keycloak design documents
+* [Keycloak Web](https://github.com/keycloak/keycloak-web) - Website keycloak.org
+
+The same governance model applies to all projects. However, the list of maintainers may vary per project. 
+
+
+## Maintainers
+
+The list of maintainers can be found in the [MAINTAINERS.md](MAINTAINERS.md) file in the repository for the individual 
+projects listed in the [Projects](#projects) section.
+
+### Maintainer Responsibilities
+
+A maintainer is someone who has shown deep knowledge of vision, features and codebase. It is their 
+responsibility to drive the project forward, encourage collaboration and contributions, and generally help the 
+community.
+
+Responsibilities of a maintainer include, but are not limited to:
+
+* Engage in design discussions
+* Actively monitor mailing lists, user forum and chat
+* Contribute high quality code
+* Maintain deep knowledge of vision, features and codebase
+* Review pull requests either personally or delegate to experts in the relevant area
+* Helping the community
+
+### Becoming a Maintainer
+
+To become a maintainer, you need to demonstrate the following:
+
+* Good understanding of vision, features and codebase
+* Contribution of larger features
+* Contribution of bug fixes
+* Participation in design discussions
+* Participation in pull request reviews
+* Ability to collaborate with the team
+* Helping the community
+
+A new maintainer must be proposed by sending an email to keycloak-maintainers(at)googlegroups.com.
+The email should include evidence of the above list.
+
+The existing maintainers will then discuss the proposal. If anyone objects or wants more information, the maintainers 
+will reach out to the nominee directly for further discussion. 
+
+For the nominee to be accepted as a maintainer at least 2/3 of existing maintainers have to approve the nominee.
+
+
+### Changes in Maintainership
+
+Every 6 months (March and September) active maintainers fill in a survey covering what they have been doing as a maintainer 
+for the last period, and what they are planning on focusing on in the next period. The survey is not made publicly 
+available, but is shared with existing maintainers. This serves two purposes; firstly for the maintainers group to better
+understand what each maintainer is focusing on, and secondly to identify maintainers that are no longer active.
+
+In the majority of cases a maintainer is removed by the maintainer stepping down themselves (by sending an email to
+keycloak-maintainers(at)googlegroups.com). However, in exceptional circumstances a maintainer can also be removed with
+2/3 of votes from existing maintainers.
+
+
+## Contributing Changes
+
+The process of reviewing proposed changes differs depending of the size and impact of the change.
+
+### Minor Changes
+
+A minor change is a bug fix, a smaller enhancement or a smaller addition to existing features.
+
+To propose a minor change, simply create an issue in our [issue tracker](https://github.com/keycloak/keycloak/issues) and
+send a pull request.
+
+A maintainer will be responsible for ultimately approving the pull request. The maintainer may do a deep review of the
+pull request or delegate to an expert in the corresponding area.
+
+If the change has a bigger impact it has to follow the process for larger changes.
+
+### Larger Changes
+
+For larger changes all maintainers and contributors should have a chance of reviewing the change. This is done through [GitHub Discussions](https://github.com/keycloak/keycloak/discussions/categories/ideas).
+
+For new features we highly recommend always opening a discussion in GitHub Discussions early.
+
+For very large proposals it can be inefficient to capture all the information in the GitHub Discussion. In this cases a separate design proposal can be sent to the [Keycloak Community repository](https://github.com/keycloak/keycloak-community/tree/main/design), and linked to from the GitHub Discussion.
+
+The contributor can decide to send a pull request prior to discussions. However, the change will not be accepted until it has been discussed through [GitHub Discussions](https://github.com/keycloak/keycloak/discussions/categories/ideas).
+
+If there are any objections to the change they can in most cases be resolved through discussions in [GitHub Discussions](https://github.com/keycloak/keycloak/discussions/categories/ideas), or
+in the pull request. If a resolution can not be made it can be accepted if at least 2/3 of maintainers approve the change.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Active maintainers
+
+* [Alexander Schwartz](https://github.com/ahus1)
+* [Bruno Oliveira da Silva](https://github.com/abstractj)
+* [Hynek Mlnařík](https://github.com/hmlnarik)
+* [Marek Posolda](https://github.com/mposolda)
+* [Michal Hajas](https://github.com/mhajas)
+* [Pedro Igor](https://github.com/pedroigor)
+* [Sebastian Schuster](https://github.com/sschu)
+* [Stan Silvert](https://github.com/ssilvert)
+* [Stian Thorgersen](https://github.com/stianst) (project lead)
+* [Takashi Norimatsu](https://github.com/tnorimat)
+* [Thomas Darimont](https://github.com/thomasdarimont)
+* [Václav Muzikář](https://github.com/vmuzikar)
+
+# Emeritus maintainers
+
+* [Pavel Drozd](https://github.com/pdrozd)
+

--- a/PR-CHECKLIST.md
+++ b/PR-CHECKLIST.md
@@ -1,0 +1,20 @@
+# Checklist for merging PRs
+
+Before merging a PR the PR should follow these rules:
+
+* The PR does not have the label "hold"
+* There is an associated GitHub Issue linked to the PR
+  * A GitHub Issue is not required if the PR is not introducing a new feature or enhancement to Keycloak, or is resolving a bug where released versions of Keycloak are not affected
+* There is sufficient test coverage
+* Required documentation is included in the PR or an associated PR. Including updates to release notes and upgrade guide if applicable
+* There are no unresolved negative reviews, or unresolved comments
+* The PR does not contain changes not relevant to the GitHub Issue
+* PRs has been reviewed by the relevant team, and approved by either a global maintainer or a team maintainer
+* All required status checks have passed successfully
+* If the PR is affected by unstable workflows or tests verify the issues are not introduced by the PR
+
+Merging a PR:
+
+* In most cases a PR should be merged by a team maintainer in the affected area
+* Global maintainers can merge any PRs, but this is considered a fallback
+* If a PR affects multiple areas it can be merged by any of the affected team maintainers as long as someone from each affected team has completed a review.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
+<<<<<<< HEAD
+<<<<<<< HEAD
 # keycloak-client
 Keycloak-client java modules
+=======
+# Keyloak standalone client
+=======
+# Keycloak standalone client
+>>>>>>> 41bb4f7 (Moving admin-client and the classes it needs from Keycloak to Keycloak-client)
+
+PoC showing a standalone Keycloak client that can be used without any direct dependencies on Keycloak.
+
+The modules `integration/admin-client` and `integration/admin-client-jee` are modules for Java Keycloak admin client. The modules `client-common` and `client-core`
+contain just subsets of the classes, from Keycloak modules `common` and `core`, which are needed by `admin-client`.
+
+In this prototype, the classes from `common` and `core` Keycloak modules were copied from Keycloak and classes from `admin-client-*` were also copied from Keycloak 
+
+### How to sync classes from Keycloak repository
+
+<<<<<<< HEAD
+Running `mvn dependency:tree -f test` will show that the example use of the admin client has no dependencies
+on Keycloak server JARs.
+>>>>>>> 8daf0a5 (PoC shaded admin client)
+=======
+- Tested with OpenJDK 17.0.11 and Maven 3.6.3
+
+- Go to `keycloak` repository with Keycloak sources and add the remote repository if not already present (TODO: Replace with `upstream` once https://github.com/keycloak/keycloak/pull/30588 is merged)
+```
+git remote add mposolda git@github.com:mposolda/keycloak.git
+```
+
+- Sync the Java classes from the specified branch of the `keycloak` repository
+```
+.github/scripts/sync-keycloak-sources.sh  keycloak-admin-client-orig ../keycloak mposolda
+```
+
+- Check the synced classes by running `git status` or `git diff` to see what Java classes were copied from the `keycloak` repository 
+
+- Run `mvn clean install` on this project
+
+- Run the tests (TODO: Should be done automatically and don't require manually start Keycloak server):
+  - Manually run Keycloak server `./kc.sh start-dev` and make sure that `admin/admin` exists
+  - Run manually tests like `TestAdminClient`
+
+- Send PR with the synced Java classes
+
+WARNING: Make sure to not include any quarkus dependencies OR any keycloak server dependencies to this project and to parent pom. The testsuite module is the only exception where Keycloak
+dependencies might be present.
+>>>>>>> 41bb4f7 (Moving admin-client and the classes it needs from Keycloak to Keycloak-client)

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,77 @@
+header:
+  schema-version: 1.0.0
+  expiration-date: '2025-02-14T01:00:00.000Z'
+  last-updated: '2024-02-14'
+  last-reviewed: '2024-02-14'
+  project-url: 'https://github.com/keycloak/keycloak'
+  license: 'https://github.com/keycloak/keycloak/blob/main/LICENSE.txt'
+project-lifecycle:
+  bug-fixes-only: false
+  core-maintainers:
+    - https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md
+  status: Active
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  automated-tools-list:
+    - automated-tool: dependabot
+      action: allowed
+      path:
+        - /
+  contributing-policy: 'https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md'
+  code-of-conduct:
+  - 'https://github.com/keycloak/keycloak?tab=coc-ov-file'
+documentation:
+  - 'https://www.keycloak.org/documentation'
+distribution-points:
+  - 'https://www.keycloak.org/downloads'
+  - 'https://github.com/keycloak/keycloak/releases'
+  - 'https://quay.io/repository/keycloak/keycloak'
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  tool-version: "2"
+  tool-url: https://github.com/dependabot
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false 
+- tool-type: sca
+  tool-name: Snyk
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false   
+- tool-type: sca
+  tool-name: CodeQL
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false
+- tool-type: sca
+  tool-name: Trivy
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false    
+security-contacts:
+- type: email
+  value: keycloak-security@googlegroups.com
+  primary: true
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  email-contact: keycloak-security@googlegroups.com
+  security-policy: 'https://www.keycloak.org/security'
+  bug-bounty-available: false
+  bug-bounty-url: ''
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+  - 'https://github.com/keycloak/keycloak/blob/main/pom.xml'
+  dependencies-lifecycle:
+    policy-url: 'https://www.keycloak.org/security'
+  env-dependencies-policy:
+    policy-url: ''

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-client-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-client-common</artifactId>
+    <name>Keycloak Client Common</name>
+    <packaging>jar</packaging>
+    <description>Keycloak Client Common description</description>
+
+    <dependencies>
+    </dependencies>
+    <build>
+    </build>
+
+</project>

--- a/client-common/src/main/java/org/keycloak/common/util/Base64.java
+++ b/client-common/src/main/java/org/keycloak/common/util/Base64.java
@@ -1,0 +1,1732 @@
+package org.keycloak.common.util;
+
+import java.io.IOException;
+
+/**
+ * <p>Encodes and decodes to and from Base64 notation.</p>
+ * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
+ *
+ * <p>Example:</p>
+ *
+ * <code>String encoded = Base64.encode( myByteArray );</code>
+ * <br />
+ * <code>byte[] myByteArray = Base64.decode( encoded );</code>
+ *
+ * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
+ * several pieces of information to the encoder. In the "higher level" methods such as
+ * encodeBytes( bytes, options ) the options parameter can be used to indicate such
+ * things as first gzipping the bytes before encoding them, not inserting linefeeds,
+ * and encoding using the URL-safe and Ordered dialects.</p>
+ *
+ * <p>Note, according to <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>,
+ * Section 2.1, implementations should not add line feeds unless explicitly told
+ * to do so. I've got Base64 set to this behavior now, although earlier versions
+ * broke lines by default.</p>
+ *
+ * <p>The constants defined in Base64 can be OR-ed together to combine options, so you
+ * might make a call like this:</p>
+ *
+ * <code>String encoded = Base64.encodeBytes( mybytes, Base64.GZIP | Base64.DO_BREAK_LINES );</code>
+ * <p>to compress the data before encoding it and then making the output have newline characters.</p>
+ * <p>Also...</p>
+ * <code>String encoded = Base64.encodeBytes( crazyString.getBytes() );</code>
+ *
+ *
+ *
+ * <p>
+ * Change Log:
+ * </p>
+ * <ul>
+ *  <li>v2.3.8 - Fixed automatic gzip decoding, based on the content,
+ *  as this may lead to unexpected behaviour. Request either gzipped
+ *  or non gzipped decoding as excepted. Automatic encoding is especially
+ *  problematic with generated input (see KEYCLOAK-18914 for a detailed case).</li>
+ *  <li>v2.3.7 - Fixed subtle bug when base 64 input stream contained the
+ *   value 01111111, which is an invalid base 64 character but should not
+ *   throw an ArrayIndexOutOfBoundsException either. Led to discovery of
+ *   mishandling (or potential for better handling) of other bad input
+ *   characters. You should now get an IOException if you try decoding
+ *   something that has bad characters in it.</li>
+ *  <li>v2.3.6 - Fixed bug when breaking lines and the final byte of the encoded
+ *   string ended in the last column; the buffer was not properly shrunk and
+ *   contained an extra (null) byte that made it into the string.</li>
+ *  <li>v2.3.5 - Fixed bug in {@link #encodeFromFile} where estimated buffer size
+ *   was wrong for files of size 31, 34, and 37 bytes.</li>
+ *  <li>v2.3.4 - Fixed bug when working with gzipped streams whereby flushing
+ *   the Base64.OutputStream closed the Base64 encoding (by padding with equals
+ *   signs) too soon. Also added an option to suppress the automatic decoding
+ *   of gzipped streams. Also added experimental support for specifying a
+ *   class loader when using the
+ *   {@link #decodeToObject(java.lang.String, int, java.lang.ClassLoader)}
+ *   method.</li>
+ *  <li>v2.3.3 - Changed default char encoding to US-ASCII which reduces the internal Java
+ *   footprint with its CharEncoders and so forth. Fixed some javadocs that were
+ *   inconsistent. Removed imports and specified things like java.io.IOException
+ *   explicitly inline.</li>
+ *  <li>v2.3.2 - Reduced memory footprint! Finally refined the "guessing" of how big the
+ *   final encoded data will be so that the code doesn't have to create two output
+ *   arrays: an oversized initial one and then a final, exact-sized one. Big win
+ *   when using the {@link #encodeBytesToBytes(byte[])} family of methods (and not
+ *   using the gzip options which uses a different mechanism with streams and stuff).</li>
+ *  <li>v2.3.1 - Added {@link #encodeBytesToBytes(byte[], int, int, int)} and some
+ *   similar helper methods to be more efficient with memory by not returning a
+ *   String but just a byte array.</li>
+ *  <li>v2.3 - <strong>This is not a drop-in replacement!</strong> This is two years of comments
+ *   and bug fixes queued up and finally executed. Thanks to everyone who sent
+ *   me stuff, and I'm sorry I wasn't able to distribute your fixes to everyone else.
+ *   Much bad coding was cleaned up including throwing exceptions where necessary
+ *   instead of returning null values or something similar. Here are some changes
+ *   that may affect you:
+ *   <ul>
+ *    <li><em>Does not break lines, by default.</em> This is to keep in compliance with
+ *      <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>.</li>
+ *    <li><em>Throws exceptions instead of returning null values.</em> Because some operations
+ *      (especially those that may permit the GZIP option) use IO streams, there
+ *      is a possibility of an java.io.IOException being thrown. After some discussion and
+ *      thought, I've changed the behavior of the methods to throw java.io.IOExceptions
+ *      rather than return null if ever there's an error. I think this is more
+ *      appropriate, though it will require some changes to your code. Sorry,
+ *      it should have been done this way to begin with.</li>
+ *    <li><em>Removed all references to System.out, System.err, and the like.</em>
+ *      Shame on me. All I can say is sorry they were ever there.</li>
+ *    <li><em>Throws NullPointerExceptions and IllegalArgumentExceptions</em> as needed
+ *      such as when passed arrays are null or offsets are invalid.</li>
+ *    <li>Cleaned up as much javadoc as I could to avoid any javadoc warnings.
+ *      This was especially annoying before for people who were thorough in their
+ *      own projects and then had gobs of javadoc warnings on this file.</li>
+ *   </ul>
+ *  <li>v2.2.1 - Fixed bug using URL_SAFE and ORDERED encodings. Fixed bug
+ *   when using very small files (~&lt; 40 bytes).</li>
+ *  <li>v2.2 - Added some helper methods for encoding/decoding directly from
+ *   one file to the next. Also added a main() method to support command line
+ *   encoding/decoding from one file to the next. Also added these Base64 dialects:
+ *   <ol>
+ *   <li>The default is RFC3548 format.</li>
+ *   <li>Calling Base64.setFormat(Base64.BASE64_FORMAT.URLSAFE_FORMAT) generates
+ *   URL and file name friendly format as described in Section 4 of RFC3548.
+ *   http://www.faqs.org/rfcs/rfc3548.html</li>
+ *   <li>Calling Base64.setFormat(Base64.BASE64_FORMAT.ORDERED_FORMAT) generates
+ *   URL and file name friendly format that preserves lexical ordering as described
+ *   in http://www.faqs.org/qa/rfcc-1940.html</li>
+ *   </ol>
+ *   Special thanks to Jim Kellerman at <a href="http://www.powerset.com/">http://www.powerset.com/</a>
+ *   for contributing the new Base64 dialects.
+ *  </li>
+ *
+ *  <li>v2.1 - Cleaned up javadoc comments and unused variables and methods. Added
+ *   some convenience methods for reading and writing to and from files.</li>
+ *  <li>v2.0.2 - Now specifies UTF-8 encoding in places where the code fails on systems
+ *   with other encodings (like EBCDIC).</li>
+ *  <li>v2.0.1 - Fixed an error when decoding a single byte, that is, when the
+ *   encoded data was a single byte.</li>
+ *  <li>v2.0 - I got rid of methods that used booleans to set options.
+ *   Now everything is more consolidated and cleaner. The code now detects
+ *   when data that's being decoded is gzip-compressed and will decompress it
+ *   automatically. Generally things are cleaner. You'll probably have to
+ *   change some method calls that you were making to support the new
+ *   options format (<tt>int</tt>s that you "OR" together).</li>
+ *  <li>v1.5.1 - Fixed bug when decompressing and decoding to a
+ *   byte[] using <tt>decode( String s, boolean gzipCompressed )</tt>.
+ *   Added the ability to "suspend" encoding in the Output Stream so
+ *   you can turn on and off the encoding if you need to embed base64
+ *   data in an otherwise "normal" stream (like an XML file).</li>
+ *  <li>v1.5 - Output stream pases on flush() command but doesn't do anything itself.
+ *      This helps when using GZIP streams.
+ *      Added the ability to GZip-compress objects before encoding them.</li>
+ *  <li>v1.4 - Added helper methods to read/write files.</li>
+ *  <li>v1.3.6 - Fixed OutputStream.flush() so that 'position' is reset.</li>
+ *  <li>v1.3.5 - Added flag to turn on and off line breaks. Fixed bug in input stream
+ *      where last buffer being read, if not completely full, was not returned.</li>
+ *  <li>v1.3.4 - Fixed when "improperly padded stream" error was thrown at the wrong time.</li>
+ *  <li>v1.3.3 - Fixed I/O streams which were totally messed up.</li>
+ * </ul>
+ *
+ * <p>
+ * I am placing this code in the Public Domain. Do with it as you will.
+ * This software comes with no guarantees or warranties but with
+ * plenty of well-wishing instead!
+ * Please visit <a href="http://iharder.net/base64">http://iharder.net/base64</a>
+ * periodically to check for updates or to contribute improvements.
+ * </p>
+ *
+ * @author Robert Harder
+ * @author rob@iharder.net
+ * @version 2.3.7
+ */
+public class Base64
+{
+
+/* ********  P U B L I C   F I E L D S  ******** */
+
+
+    /** No options specified. Value is zero. */
+    public final static int NO_OPTIONS = 0;
+
+    /** Specify encoding in first bit. Value is one. */
+    public final static int ENCODE = 1;
+
+
+    /** Specify decoding in first bit. Value is zero. */
+    public final static int DECODE = 0;
+
+
+    /** Specify that data should be gzip-compressed in second bit. Value is two. */
+    public final static int GZIP = 2;
+
+    /** Specify that data should be gunzipped. */
+    public final static int GUNZIP = 4;
+
+    /** Do break lines when encoding. Value is 8. */
+    public final static int DO_BREAK_LINES = 8;
+
+    /**
+     * Encode using Base64-like encoding that is URL- and Filename-safe as described
+     * in Section 4 of RFC3548:
+     * <a href="http://www.faqs.org/rfcs/rfc3548.html">http://www.faqs.org/rfcs/rfc3548.html</a>.
+     * It is important to note that data encoded this way is <em>not</em> officially valid Base64,
+     * or at the very least should not be called Base64 without also specifying that it
+     * was encoded using the URL- and Filename-safe dialect.
+     */
+    public final static int URL_SAFE = 16;
+
+
+    /**
+     * Encode using the special "ordered" dialect of Base64 described here:
+     * <a href="http://www.faqs.org/qa/rfcc-1940.html">http://www.faqs.org/qa/rfcc-1940.html</a>.
+     */
+    public final static int ORDERED = 32;
+
+
+/* ********  P R I V A T E   F I E L D S  ******** */
+
+
+    /** Maximum line length (76) of Base64 output. */
+    private final static int MAX_LINE_LENGTH = 76;
+
+
+    /** The equals sign (=) as a byte. */
+    private final static byte EQUALS_SIGN = (byte)'=';
+
+
+    /** The new line character (\n) as a byte. */
+    private final static byte NEW_LINE = (byte)'\n';
+
+
+    /** Preferred encoding. */
+    private final static String PREFERRED_ENCODING = "US-ASCII";
+
+
+    private final static byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
+    private final static byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
+
+
+/* ********  S T A N D A R D   B A S E 6 4   A L P H A B E T  ******** */
+
+    /** The 64 valid Base64 values. */
+    /* Host platform me be something funny like EBCDIC, so we hardcode these values. */
+    private final static byte[] _STANDARD_ALPHABET = {
+            (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
+            (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
+            (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U',
+            (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z',
+            (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
+            (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n',
+            (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
+            (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z',
+            (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5',
+            (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'+', (byte)'/'
+    };
+
+
+    /**
+     * Translates a Base64 value to either its 6-bit reconstruction value
+     * or a negative number indicating some other meaning.
+     **/
+    private final static byte[] _STANDARD_DECODABET = {
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
+            -5,-5,                                      // Whitespace: Tab and Linefeed
+            -9,-9,                                      // Decimal 11 - 12
+            -5,                                         // Whitespace: Carriage Return
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 14 - 26
+            -9,-9,-9,-9,-9,                             // Decimal 27 - 31
+            -5,                                         // Whitespace: Space
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,              // Decimal 33 - 42
+            62,                                         // Plus sign at decimal 43
+            -9,-9,-9,                                   // Decimal 44 - 46
+            63,                                         // Slash at decimal 47
+            52,53,54,55,56,57,58,59,60,61,              // Numbers zero through nine
+            -9,-9,-9,                                   // Decimal 58 - 60
+            -1,                                         // Equals sign at decimal 61
+            -9,-9,-9,                                      // Decimal 62 - 64
+            0,1,2,3,4,5,6,7,8,9,10,11,12,13,            // Letters 'A' through 'N'
+            14,15,16,17,18,19,20,21,22,23,24,25,        // Letters 'O' through 'Z'
+            -9,-9,-9,-9,-9,-9,                          // Decimal 91 - 96
+            26,27,28,29,30,31,32,33,34,35,36,37,38,     // Letters 'a' through 'm'
+            39,40,41,42,43,44,45,46,47,48,49,50,51,     // Letters 'n' through 'z'
+            -9,-9,-9,-9,-9                              // Decimal 123 - 127
+            ,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,       // Decimal 128 - 139
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 140 - 152
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 153 - 165
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 166 - 178
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 179 - 191
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 192 - 204
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 205 - 217
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 218 - 230
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 231 - 243
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255
+    };
+
+
+/* ********  U R L   S A F E   B A S E 6 4   A L P H A B E T  ******** */
+
+    /**
+     * Used in the URL- and Filename-safe dialect described in Section 4 of RFC3548:
+     * <a href="http://www.faqs.org/rfcs/rfc3548.html">http://www.faqs.org/rfcs/rfc3548.html</a>.
+     * Notice that the last two bytes become "hyphen" and "underscore" instead of "plus" and "slash."
+     */
+    private final static byte[] _URL_SAFE_ALPHABET = {
+            (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
+            (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
+            (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U',
+            (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z',
+            (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
+            (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n',
+            (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
+            (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z',
+            (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5',
+            (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'-', (byte)'_'
+    };
+
+    /**
+     * Used in decoding URL- and Filename-safe dialects of Base64.
+     */
+    private final static byte[] _URL_SAFE_DECODABET = {
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
+            -5,-5,                                      // Whitespace: Tab and Linefeed
+            -9,-9,                                      // Decimal 11 - 12
+            -5,                                         // Whitespace: Carriage Return
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 14 - 26
+            -9,-9,-9,-9,-9,                             // Decimal 27 - 31
+            -5,                                         // Whitespace: Space
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,              // Decimal 33 - 42
+            -9,                                         // Plus sign at decimal 43
+            -9,                                         // Decimal 44
+            62,                                         // Minus sign at decimal 45
+            -9,                                         // Decimal 46
+            -9,                                         // Slash at decimal 47
+            52,53,54,55,56,57,58,59,60,61,              // Numbers zero through nine
+            -9,-9,-9,                                   // Decimal 58 - 60
+            -1,                                         // Equals sign at decimal 61
+            -9,-9,-9,                                   // Decimal 62 - 64
+            0,1,2,3,4,5,6,7,8,9,10,11,12,13,            // Letters 'A' through 'N'
+            14,15,16,17,18,19,20,21,22,23,24,25,        // Letters 'O' through 'Z'
+            -9,-9,-9,-9,                                // Decimal 91 - 94
+            63,                                         // Underscore at decimal 95
+            -9,                                         // Decimal 96
+            26,27,28,29,30,31,32,33,34,35,36,37,38,     // Letters 'a' through 'm'
+            39,40,41,42,43,44,45,46,47,48,49,50,51,     // Letters 'n' through 'z'
+            -9,-9,-9,-9,-9                              // Decimal 123 - 127
+            ,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 128 - 139
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 140 - 152
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 153 - 165
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 166 - 178
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 179 - 191
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 192 - 204
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 205 - 217
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 218 - 230
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 231 - 243
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255
+    };
+
+
+
+/* ********  O R D E R E D   B A S E 6 4   A L P H A B E T  ******** */
+
+    /**
+     * I don't get the point of this technique, but someone requested it,
+     * and it is described here:
+     * <a href="http://www.faqs.org/qa/rfcc-1940.html">http://www.faqs.org/qa/rfcc-1940.html</a>.
+     */
+    private final static byte[] _ORDERED_ALPHABET = {
+            (byte)'-',
+            (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4',
+            (byte)'5', (byte)'6', (byte)'7', (byte)'8', (byte)'9',
+            (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
+            (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
+            (byte)'O', (byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U',
+            (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z',
+            (byte)'_',
+            (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
+            (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n',
+            (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u',
+            (byte)'v', (byte)'w', (byte)'x', (byte)'y', (byte)'z'
+    };
+
+    /**
+     * Used in decoding the "ordered" dialect of Base64.
+     */
+    private final static byte[] _ORDERED_DECODABET = {
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
+            -5,-5,                                      // Whitespace: Tab and Linefeed
+            -9,-9,                                      // Decimal 11 - 12
+            -5,                                         // Whitespace: Carriage Return
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 14 - 26
+            -9,-9,-9,-9,-9,                             // Decimal 27 - 31
+            -5,                                         // Whitespace: Space
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,              // Decimal 33 - 42
+            -9,                                         // Plus sign at decimal 43
+            -9,                                         // Decimal 44
+            0,                                          // Minus sign at decimal 45
+            -9,                                         // Decimal 46
+            -9,                                         // Slash at decimal 47
+            1,2,3,4,5,6,7,8,9,10,                       // Numbers zero through nine
+            -9,-9,-9,                                   // Decimal 58 - 60
+            -1,                                         // Equals sign at decimal 61
+            -9,-9,-9,                                   // Decimal 62 - 64
+            11,12,13,14,15,16,17,18,19,20,21,22,23,     // Letters 'A' through 'M'
+            24,25,26,27,28,29,30,31,32,33,34,35,36,     // Letters 'N' through 'Z'
+            -9,-9,-9,-9,                                // Decimal 91 - 94
+            37,                                         // Underscore at decimal 95
+            -9,                                         // Decimal 96
+            38,39,40,41,42,43,44,45,46,47,48,49,50,     // Letters 'a' through 'm'
+            51,52,53,54,55,56,57,58,59,60,61,62,63,     // Letters 'n' through 'z'
+            -9,-9,-9,-9,-9                                 // Decimal 123 - 127
+            ,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 128 - 139
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 140 - 152
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 153 - 165
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 166 - 178
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 179 - 191
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 192 - 204
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 205 - 217
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 218 - 230
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,     // Decimal 231 - 243
+            -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255
+    };
+
+
+/* ********  D E T E R M I N E   W H I C H   A L H A B E T  ******** */
+
+
+    /**
+     * Returns one of the _SOMETHING_ALPHABET byte arrays depending on
+     * the options specified.
+     * It's possible, though silly, to specify ORDERED <b>and</b> URLSAFE
+     * in which case one of them will be picked, though there is
+     * no guarantee as to which one will be picked.
+     */
+    private final static byte[] getAlphabet( int options ) {
+        if ((options & URL_SAFE) == URL_SAFE) {
+            return _URL_SAFE_ALPHABET;
+        } else if ((options & ORDERED) == ORDERED) {
+            return _ORDERED_ALPHABET;
+        } else {
+            return _STANDARD_ALPHABET;
+        }
+    }	// end getAlphabet
+
+
+    /**
+     * Returns one of the _SOMETHING_DECODABET byte arrays depending on
+     * the options specified.
+     * It's possible, though silly, to specify ORDERED and URL_SAFE
+     * in which case one of them will be picked, though there is
+     * no guarantee as to which one will be picked.
+     */
+    private final static byte[] getDecodabet( int options ) {
+        if( (options & URL_SAFE) == URL_SAFE) {
+            return _URL_SAFE_DECODABET;
+        } else if ((options & ORDERED) == ORDERED) {
+            return _ORDERED_DECODABET;
+        } else {
+            return _STANDARD_DECODABET;
+        }
+    }	// end getAlphabet
+
+
+
+    /** Defeats instantiation. */
+    private Base64(){}
+
+
+
+
+/* ********  E N C O D I N G   M E T H O D S  ******** */
+
+
+    /**
+     * Encodes up to the first three bytes of array <var>threeBytes</var>
+     * and returns a four-byte array in Base64 notation.
+     * The actual number of significant bytes in your array is
+     * given by <var>numSigBytes</var>.
+     * The array <var>threeBytes</var> needs only be as big as
+     * <var>numSigBytes</var>.
+     * Code can reuse a byte array by passing a four-byte array as <var>b4</var>.
+     *
+     * @param b4 A reusable byte array to reduce array instantiation
+     * @param threeBytes the array to convert
+     * @param numSigBytes the number of significant bytes in your array
+     * @return four byte array in Base64 notation.
+     * @since 1.5.1
+     */
+    private static byte[] encode3to4( byte[] b4, byte[] threeBytes, int numSigBytes, int options ) {
+        encode3to4( threeBytes, 0, numSigBytes, b4, 0, options );
+        return b4;
+    }   // end encode3to4
+
+
+    /**
+     * <p>Encodes up to three bytes of the array <var>source</var>
+     * and writes the resulting four Base64 bytes to <var>destination</var>.
+     * The source and destination arrays can be manipulated
+     * anywhere along their length by specifying
+     * <var>srcOffset</var> and <var>destOffset</var>.
+     * This method does not check to make sure your arrays
+     * are large enough to accommodate <var>srcOffset</var> + 3 for
+     * the <var>source</var> array or <var>destOffset</var> + 4 for
+     * the <var>destination</var> array.
+     * The actual number of significant bytes in your array is
+     * given by <var>numSigBytes</var>.</p>
+     * <p>This is the lowest level of the encoding methods with
+     * all possible parameters.</p>
+     *
+     * @param source the array to convert
+     * @param srcOffset the index where conversion begins
+     * @param numSigBytes the number of significant bytes in your array
+     * @param destination the array to hold the conversion
+     * @param destOffset the index where output will be put
+     * @return the <var>destination</var> array
+     * @since 1.3
+     */
+    private static byte[] encode3to4(
+            byte[] source, int srcOffset, int numSigBytes,
+            byte[] destination, int destOffset, int options ) {
+
+        byte[] ALPHABET = getAlphabet( options );
+
+        //           1         2         3
+        // 01234567890123456789012345678901 Bit position
+        // --------000000001111111122222222 Array position from threeBytes
+        // --------|    ||    ||    ||    | Six bit groups to index ALPHABET
+        //          >>18  >>12  >> 6  >> 0  Right shift necessary
+        //                0x3f  0x3f  0x3f  Additional AND
+
+        // Create buffer with zero-padding if there are only one or two
+        // significant bytes passed in the array.
+        // We have to shift left 24 in order to flush out the 1's that appear
+        // when Java treats a value as negative that is cast from a byte to an int.
+        int inBuff =   ( numSigBytes > 0 ? ((source[ srcOffset     ] << 24) >>>  8) : 0 )
+                | ( numSigBytes > 1 ? ((source[ srcOffset + 1 ] << 24) >>> 16) : 0 )
+                | ( numSigBytes > 2 ? ((source[ srcOffset + 2 ] << 24) >>> 24) : 0 );
+
+        switch( numSigBytes )
+        {
+            case 3:
+                destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+                destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
+                destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
+                destination[ destOffset + 3 ] = ALPHABET[ (inBuff       ) & 0x3f ];
+                return destination;
+
+            case 2:
+                destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+                destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
+                destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
+                destination[ destOffset + 3 ] = EQUALS_SIGN;
+                return destination;
+
+            case 1:
+                destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+                destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
+                destination[ destOffset + 2 ] = EQUALS_SIGN;
+                destination[ destOffset + 3 ] = EQUALS_SIGN;
+                return destination;
+
+            default:
+                return destination;
+        }   // end switch
+    }   // end encode3to4
+
+
+
+    /**
+     * Performs Base64 encoding on the <code>raw</code> ByteBuffer,
+     * writing it to the <code>encoded</code> ByteBuffer.
+     * This is an experimental feature. Currently it does not
+     * pass along any options (such as {@link #DO_BREAK_LINES}
+     * or {@link #GZIP}).
+     *
+     * @param raw input buffer
+     * @param encoded output buffer
+     * @since 2.3
+     */
+    public static void encode( java.nio.ByteBuffer raw, java.nio.ByteBuffer encoded ){
+        byte[] raw3 = new byte[3];
+        byte[] enc4 = new byte[4];
+
+        while( raw.hasRemaining() ){
+            int rem = Math.min(3,raw.remaining());
+            raw.get(raw3,0,rem);
+            Base64.encode3to4(enc4, raw3, rem, Base64.NO_OPTIONS);
+            encoded.put(enc4);
+        }   // end input remaining
+    }
+
+
+    /**
+     * Performs Base64 encoding on the <code>raw</code> ByteBuffer,
+     * writing it to the <code>encoded</code> CharBuffer.
+     * This is an experimental feature. Currently it does not
+     * pass along any options (such as {@link #DO_BREAK_LINES}
+     * or {@link #GZIP}.
+     *
+     * @param raw input buffer
+     * @param encoded output buffer
+     * @since 2.3
+     */
+    public static void encode( java.nio.ByteBuffer raw, java.nio.CharBuffer encoded ){
+        byte[] raw3 = new byte[3];
+        byte[] enc4 = new byte[4];
+
+        while( raw.hasRemaining() ){
+            int rem = Math.min(3,raw.remaining());
+            raw.get(raw3,0,rem);
+            Base64.encode3to4(enc4, raw3, rem, Base64.NO_OPTIONS );
+            for( int i = 0; i < 4; i++ ){
+                encoded.put( (char)(enc4[i] & 0xFF) );
+            }
+        }   // end input remaining
+    }
+
+
+
+
+    /**
+     * Serializes an object and returns the Base64-encoded
+     * version of that serialized object.
+     *
+     * <p>As of v 2.3, if the object
+     * cannot be serialized or there is another error,
+     * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
+     * In earlier versions, it just returned a null value, but
+     * in retrospect that's a pretty poor way to handle it.</p>
+     *
+     * The object is not GZip-compressed before being encoded.
+     *
+     * @param serializableObject The object to encode
+     * @return The Base64-encoded object
+     * @throws java.io.IOException if there is an error
+     * @throws NullPointerException if serializedObject is null
+     * @since 1.4
+     */
+    public static String encodeObject( java.io.Serializable serializableObject )
+            throws java.io.IOException {
+        return encodeObject( serializableObject, NO_OPTIONS );
+    }   // end encodeObject
+
+
+
+    /**
+     * Serializes an object and returns the Base64-encoded
+     * version of that serialized object.
+     *
+     * <p>As of v 2.3, if the object
+     * cannot be serialized or there is another error,
+     * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
+     * In earlier versions, it just returned a null value, but
+     * in retrospect that's a pretty poor way to handle it.</p>
+     *
+     * The object is not GZip-compressed before being encoded.
+     * <p>
+     * Example options:<pre>
+     *   GZIP: gzip-compresses object before encoding it.
+     *   DO_BREAK_LINES: break lines at 76 characters
+     * </pre>
+     * <p>
+     * Example: <code>encodeObject( myObj, Base64.GZIP )</code> or
+     * <p>
+     * Example: <code>encodeObject( myObj, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
+     *
+     * @param serializableObject The object to encode
+     * @param options Specified options
+     * @return The Base64-encoded object
+     * @see Base64#GZIP
+     * @see Base64#DO_BREAK_LINES
+     * @throws java.io.IOException if there is an error
+     * @since 2.0
+     */
+    public static String encodeObject( java.io.Serializable serializableObject, int options )
+            throws java.io.IOException {
+
+        if( serializableObject == null ){
+            throw new NullPointerException( "Cannot serialize a null object." );
+        }   // end if: null
+
+        // Streams
+        java.io.ByteArrayOutputStream  baos  = null;
+        java.io.OutputStream           b64os = null;
+        java.util.zip.GZIPOutputStream gzos  = null;
+        java.io.ObjectOutputStream     oos   = null;
+
+
+        try {
+            // ObjectOutputStream -> (GZIP) -> Base64 -> ByteArrayOutputStream
+            baos  = new java.io.ByteArrayOutputStream();
+            b64os = new Base64.OutputStream( baos, ENCODE | options );
+            if( (options & GZIP) != 0 ){
+                // Gzip
+                gzos = new java.util.zip.GZIPOutputStream(b64os);
+                oos = new java.io.ObjectOutputStream( gzos );
+            } else {
+                // Not gzipped
+                oos = new java.io.ObjectOutputStream( b64os );
+            }
+            oos.writeObject( serializableObject );
+        }   // end try
+        catch( java.io.IOException e ) {
+            // Catch it and then throw it immediately so that
+            // the finally{} block is called for cleanup.
+            throw e;
+        }   // end catch
+        finally {
+            try{ oos.close();   } catch( Exception e ){}
+            try{ gzos.close();  } catch( Exception e ){}
+            try{ b64os.close(); } catch( Exception e ){}
+            try{ baos.close();  } catch( Exception e ){}
+        }   // end finally
+
+        // Return value according to relevant encoding.
+        try {
+            return new String( baos.toByteArray(), PREFERRED_ENCODING );
+        }   // end try
+        catch (java.io.UnsupportedEncodingException uue){
+            // Fall back to some Java default
+            return new String( baos.toByteArray() );
+        }   // end catch
+
+    }   // end encode
+
+
+
+    /**
+     * Encodes a byte array into Base64 notation.
+     * Does not GZip-compress data.
+     *
+     * @param source The data to convert
+     * @return The data in Base64-encoded form
+     * @throws NullPointerException if source array is null
+     * @since 1.4
+     */
+    public static String encodeBytes( byte[] source ) {
+        // Since we're not going to have the GZIP encoding turned on,
+        // we're not going to have an java.io.IOException thrown, so
+        // we should not force the user to have to catch it.
+        String encoded = null;
+        try {
+            encoded = encodeBytes(source, 0, source.length, NO_OPTIONS);
+        } catch (java.io.IOException ex) {
+            assert false : ex.getMessage();
+        }   // end catch
+        assert encoded != null;
+        return encoded;
+    }   // end encodeBytes
+
+
+
+    /**
+     * Encodes a byte array into Base64 notation.
+     * <p>
+     * Example options:<pre>
+     *   GZIP: gzip-compresses object before encoding it.
+     *   DO_BREAK_LINES: break lines at 76 characters
+     *     <i>Note: Technically, without line break your encoding may become non-compliant (see rfc2045 and rfc4648).</i>
+     * </pre>
+     * <p>
+     * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
+     * <p>
+     * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
+     *
+     *
+     * <p>As of v 2.3, if there is an error with the GZIP stream,
+     * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
+     * In earlier versions, it just returned a null value, but
+     * in retrospect that's a pretty poor way to handle it.</p>
+     *
+     *
+     * @param source The data to convert
+     * @param options Specified options
+     * @return The Base64-encoded data as a String
+     * @see Base64#GZIP
+     * @see Base64#DO_BREAK_LINES
+     * @throws java.io.IOException if there is an error
+     * @throws NullPointerException if source array is null
+     * @since 2.0
+     */
+    public static String encodeBytes( byte[] source, int options ) throws java.io.IOException {
+        return encodeBytes( source, 0, source.length, options );
+    }   // end encodeBytes
+
+
+    /**
+     * Encodes a byte array into Base64 notation.
+     * Does not GZip-compress data.
+     *
+     * <p>As of v 2.3, if there is an error,
+     * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
+     * In earlier versions, it just returned a null value, but
+     * in retrospect that's a pretty poor way to handle it.</p>
+     *
+     *
+     * @param source The data to convert
+     * @param off Offset in array where conversion should begin
+     * @param len Length of data to convert
+     * @return The Base64-encoded data as a String
+     * @throws NullPointerException if source array is null
+     * @throws IllegalArgumentException if source array, offset, or length are invalid
+     * @since 1.4
+     */
+    public static String encodeBytes( byte[] source, int off, int len ) {
+        // Since we're not going to have the GZIP encoding turned on,
+        // we're not going to have an java.io.IOException thrown, so
+        // we should not force the user to have to catch it.
+        String encoded = null;
+        try {
+            encoded = encodeBytes( source, off, len, NO_OPTIONS );
+        } catch (java.io.IOException ex) {
+            assert false : ex.getMessage();
+        }   // end catch
+        assert encoded != null;
+        return encoded;
+    }   // end encodeBytes
+
+
+
+    /**
+     * Encodes a byte array into Base64 notation.
+     * <p>
+     * Example options:<pre>
+     *   GZIP: gzip-compresses object before encoding it.
+     *   DO_BREAK_LINES: break lines at 76 characters
+     *     <i>Note: Technically, this makes your encoding non-compliant.</i>
+     * </pre>
+     * <p>
+     * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
+     * <p>
+     * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
+     *
+     *
+     * <p>As of v 2.3, if there is an error with the GZIP stream,
+     * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
+     * In earlier versions, it just returned a null value, but
+     * in retrospect that's a pretty poor way to handle it.</p>
+     *
+     *
+     * @param source The data to convert
+     * @param off Offset in array where conversion should begin
+     * @param len Length of data to convert
+     * @param options Specified options
+     * @return The Base64-encoded data as a String
+     * @see Base64#GZIP
+     * @see Base64#DO_BREAK_LINES
+     * @throws java.io.IOException if there is an error
+     * @throws NullPointerException if source array is null
+     * @throws IllegalArgumentException if source array, offset, or length are invalid
+     * @since 2.0
+     */
+    public static String encodeBytes( byte[] source, int off, int len, int options ) throws java.io.IOException {
+        byte[] encoded = encodeBytesToBytes( source, off, len, options );
+
+        // Return value according to relevant encoding.
+        try {
+            return new String( encoded, PREFERRED_ENCODING );
+        }   // end try
+        catch (java.io.UnsupportedEncodingException uue) {
+            return new String( encoded );
+        }   // end catch
+
+    }   // end encodeBytes
+
+
+
+
+    /**
+     * Similar to {@link #encodeBytes(byte[])} but returns
+     * a byte array instead of instantiating a String. This is more efficient
+     * if you're working with I/O streams and have large data sets to encode.
+     *
+     *
+     * @param source The data to convert
+     * @return The Base64-encoded data as a byte[] (of ASCII characters)
+     * @throws NullPointerException if source array is null
+     * @since 2.3.1
+     */
+    public static byte[] encodeBytesToBytes( byte[] source ) {
+        byte[] encoded = null;
+        try {
+            encoded = encodeBytesToBytes( source, 0, source.length, Base64.NO_OPTIONS );
+        } catch( java.io.IOException ex ) {
+            assert false : "IOExceptions only come from GZipping, which is turned off: " + ex.getMessage();
+        }
+        return encoded;
+    }
+
+
+    /**
+     * Similar to {@link #encodeBytes(byte[], int, int, int)} but returns
+     * a byte array instead of instantiating a String. This is more efficient
+     * if you're working with I/O streams and have large data sets to encode.
+     *
+     *
+     * @param source The data to convert
+     * @param off Offset in array where conversion should begin
+     * @param len Length of data to convert
+     * @param options Specified options
+     * @return The Base64-encoded data as a String
+     * @see Base64#GZIP
+     * @see Base64#DO_BREAK_LINES
+     * @throws java.io.IOException if there is an error
+     * @throws NullPointerException if source array is null
+     * @throws IllegalArgumentException if source array, offset, or length are invalid
+     * @since 2.3.1
+     */
+    public static byte[] encodeBytesToBytes( byte[] source, int off, int len, int options ) throws java.io.IOException {
+
+        if( source == null ){
+            throw new NullPointerException( "Cannot serialize a null array." );
+        }   // end if: null
+
+        if( off < 0 ){
+            throw new IllegalArgumentException( "Cannot have negative offset: " + off );
+        }   // end if: off < 0
+
+        if( len < 0 ){
+            throw new IllegalArgumentException( "Cannot have length offset: " + len );
+        }   // end if: len < 0
+
+        if( off + len > source.length  ){
+            throw new IllegalArgumentException(
+                    String.format( "Cannot have offset of %d and length of %d with array of length %d", off,len,source.length));
+        }   // end if: off < 0
+
+
+
+        // Compress?
+        if( (options & GZIP) != 0 ) {
+            java.io.ByteArrayOutputStream  baos  = null;
+            java.util.zip.GZIPOutputStream gzos  = null;
+            Base64.OutputStream            b64os = null;
+
+            try {
+                // GZip -> Base64 -> ByteArray
+                baos = new java.io.ByteArrayOutputStream();
+                b64os = new Base64.OutputStream( baos, ENCODE | options );
+                gzos  = new java.util.zip.GZIPOutputStream( b64os );
+
+                gzos.write( source, off, len );
+                gzos.close();
+            }   // end try
+            catch( java.io.IOException e ) {
+                // Catch it and then throw it immediately so that
+                // the finally{} block is called for cleanup.
+                throw e;
+            }   // end catch
+            finally {
+                try{ gzos.close();  } catch( Exception e ){}
+                try{ b64os.close(); } catch( Exception e ){}
+                try{ baos.close();  } catch( Exception e ){}
+            }   // end finally
+
+            return baos.toByteArray();
+        }   // end if: compress
+
+        // Else, don't compress. Better not to use streams at all then.
+        else {
+            boolean breakLines = (options & DO_BREAK_LINES) != 0;
+
+            //int    len43   = len * 4 / 3;
+            //byte[] outBuff = new byte[   ( len43 )                      // Main 4:3
+            //                           + ( (len % 3) > 0 ? 4 : 0 )      // Account for padding
+            //                           + (breakLines ? ( len43 / MAX_LINE_LENGTH ) : 0) ]; // New lines
+            // Try to determine more precisely how big the array needs to be.
+            // If we get it right, we don't have to do an array copy, and
+            // we save a bunch of memory.
+            int encLen = ( len / 3 ) * 4 + ( len % 3 > 0 ? 4 : 0 ); // Bytes needed for actual encoding
+            if( breakLines ){
+                encLen += encLen / MAX_LINE_LENGTH; // Plus extra newline characters
+            }
+            byte[] outBuff = new byte[ encLen ];
+
+
+            int d = 0;
+            int e = 0;
+            int len2 = len - 2;
+            int lineLength = 0;
+            for( ; d < len2; d+=3, e+=4 ) {
+                encode3to4( source, d+off, 3, outBuff, e, options );
+
+                lineLength += 4;
+                if( breakLines && lineLength >= MAX_LINE_LENGTH )
+                {
+                    outBuff[e+4] = NEW_LINE;
+                    e++;
+                    lineLength = 0;
+                }   // end if: end of line
+            }   // en dfor: each piece of array
+
+            if( d < len ) {
+                encode3to4( source, d+off, len - d, outBuff, e, options );
+                e += 4;
+            }   // end if: some padding needed
+
+
+            // Only resize array if we didn't guess it right.
+            if( e <= outBuff.length - 1 ){
+                // If breaking lines and the last byte falls right at
+                // the line length (76 bytes per line), there will be
+                // one extra byte, and the array will need to be resized.
+                // Not too bad of an estimate on array size, I'd say.
+                byte[] finalOut = new byte[e];
+                System.arraycopy(outBuff,0, finalOut,0,e);
+                //System.err.println("Having to resize array from " + outBuff.length + " to " + e );
+                return finalOut;
+            } else {
+                //System.err.println("No need to resize array.");
+                return outBuff;
+            }
+
+        }   // end else: don't compress
+
+    }   // end encodeBytesToBytes
+
+
+
+
+
+/* ********  D E C O D I N G   M E T H O D S  ******** */
+
+
+    /**
+     * Decodes four bytes from array <var>source</var>
+     * and writes the resulting bytes (up to three of them)
+     * to <var>destination</var>.
+     * The source and destination arrays can be manipulated
+     * anywhere along their length by specifying
+     * <var>srcOffset</var> and <var>destOffset</var>.
+     * This method does not check to make sure your arrays
+     * are large enough to accommodate <var>srcOffset</var> + 4 for
+     * the <var>source</var> array or <var>destOffset</var> + 3 for
+     * the <var>destination</var> array.
+     * This method returns the actual number of bytes that
+     * were converted from the Base64 encoding.
+     * <p>This is the lowest level of the decoding methods with
+     * all possible parameters.</p>
+     *
+     *
+     * @param source the array to convert
+     * @param srcOffset the index where conversion begins
+     * @param destination the array to hold the conversion
+     * @param destOffset the index where output will be put
+     * @param options alphabet type is pulled from this (standard, url-safe, ordered)
+     * @return the number of decoded bytes converted
+     * @throws NullPointerException if source or destination arrays are null
+     * @throws IllegalArgumentException if srcOffset or destOffset are invalid
+     *         or there is not enough room in the array.
+     * @since 1.3
+     */
+    private static int decode4to3(
+            byte[] source, int srcOffset,
+            byte[] destination, int destOffset, int options ) {
+
+        // Lots of error checking and exception throwing
+        if( source == null ){
+            throw new NullPointerException( "Source array was null." );
+        }   // end if
+        if( destination == null ){
+            throw new NullPointerException( "Destination array was null." );
+        }   // end if
+        if( srcOffset < 0 || srcOffset + 3 >= source.length ){
+            throw new IllegalArgumentException( String.format(
+                    "Source array with length %d cannot have offset of %d and still process four bytes.", source.length, srcOffset ) );
+        }   // end if
+        if( destOffset < 0 || destOffset +2 >= destination.length ){
+            throw new IllegalArgumentException( String.format(
+                    "Destination array with length %d cannot have offset of %d and still store three bytes.", destination.length, destOffset ) );
+        }   // end if
+
+
+        byte[] DECODABET = getDecodabet( options );
+
+        // Example: Dk==
+        if( source[ srcOffset + 2] == EQUALS_SIGN ) {
+            // Two ways to do the same thing. Don't know which way I like best.
+            //int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] << 24 ) >>>  6 )
+            //              | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
+            int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] & 0xFF ) << 18 )
+                    | ( ( DECODABET[ source[ srcOffset + 1] ] & 0xFF ) << 12 );
+
+            destination[ destOffset ] = (byte)( outBuff >>> 16 );
+            return 1;
+        }
+
+        // Example: DkL=
+        else if( source[ srcOffset + 3 ] == EQUALS_SIGN ) {
+            // Two ways to do the same thing. Don't know which way I like best.
+            //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
+            //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
+            //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 );
+            int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] & 0xFF ) << 18 )
+                    | ( ( DECODABET[ source[ srcOffset + 1 ] ] & 0xFF ) << 12 )
+                    | ( ( DECODABET[ source[ srcOffset + 2 ] ] & 0xFF ) <<  6 );
+
+            destination[ destOffset     ] = (byte)( outBuff >>> 16 );
+            destination[ destOffset + 1 ] = (byte)( outBuff >>>  8 );
+            return 2;
+        }
+
+        // Example: DkLE
+        else {
+            // Two ways to do the same thing. Don't know which way I like best.
+            //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
+            //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
+            //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 )
+            //              | ( ( DECODABET[ source[ srcOffset + 3 ] ] << 24 ) >>> 24 );
+            int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] & 0xFF ) << 18 )
+                    | ( ( DECODABET[ source[ srcOffset + 1 ] ] & 0xFF ) << 12 )
+                    | ( ( DECODABET[ source[ srcOffset + 2 ] ] & 0xFF ) <<  6)
+                    | ( ( DECODABET[ source[ srcOffset + 3 ] ] & 0xFF )      );
+
+
+            destination[ destOffset     ] = (byte)( outBuff >> 16 );
+            destination[ destOffset + 1 ] = (byte)( outBuff >>  8 );
+            destination[ destOffset + 2 ] = (byte)( outBuff       );
+
+            return 3;
+        }
+    }   // end decodeToBytes
+
+
+
+
+
+    /**
+     * Low-level access to decoding ASCII characters in
+     * the form of a byte array. <strong>Ignores GUNZIP option, if
+     * it's set.</strong> This is not generally a recommended method,
+     * although it is used internally as part of the decoding process.
+     * Special case: if len = 0, an empty array is returned. Still,
+     * if you need more speed and reduced memory footprint (and aren't
+     * gzipping), consider this method.
+     *
+     * @param source The Base64 encoded data
+     * @return decoded data
+     * @since 2.3.1
+     */
+    public static byte[] decode( byte[] source ) throws java.io.IOException {
+        return decode( source, 0, source.length, Base64.NO_OPTIONS );
+    }
+
+
+
+    /**
+     * Low-level access to decoding ASCII characters in
+     * the form of a byte array. <strong>Ignores GUNZIP option, if
+     * it's set.</strong> This is not generally a recommended method,
+     * although it is used internally as part of the decoding process.
+     * Special case: if len = 0, an empty array is returned. Still,
+     * if you need more speed and reduced memory footprint (and aren't
+     * gzipping), consider this method.
+     *
+     * @param source The Base64 encoded data
+     * @param off    The offset of where to begin decoding
+     * @param len    The length of characters to decode
+     * @param options Can specify options such as alphabet type to use
+     * @return decoded data
+     * @throws java.io.IOException If bogus characters exist in source data
+     * @since 1.3
+     */
+    public static byte[] decode( byte[] source, int off, int len, int options )
+            throws java.io.IOException {
+
+        // Lots of error checking and exception throwing
+        if( source == null ){
+            throw new NullPointerException( "Cannot decode null source array." );
+        }   // end if
+        if( off < 0 || off + len > source.length ){
+            throw new IllegalArgumentException( String.format(
+                    "Source array with length %d cannot have offset of %d and process %d bytes.", source.length, off, len ) );
+        }   // end if
+
+        if( len == 0 ){
+            return new byte[0];
+        }else if( len < 4 ){
+            throw new IllegalArgumentException(
+                    "Base64-encoded string must have at least four characters, but length specified was " + len );
+        }   // end if
+
+        byte[] DECODABET = getDecodabet( options );
+
+        int    len34   = len * 3 / 4;       // Estimate on array size
+        byte[] outBuff = new byte[ len34 ]; // Upper limit on size of output
+        int    outBuffPosn = 0;             // Keep track of where we're writing
+
+        byte[] b4        = new byte[4];     // Four byte buffer from source, eliminating white space
+        int    b4Posn    = 0;               // Keep track of four byte input buffer
+        int    i         = 0;               // Source array counter
+        byte   sbiDecode = 0;               // Special value from DECODABET
+
+        for( i = off; i < off+len; i++ ) {  // Loop through source
+
+            sbiDecode = DECODABET[ source[i]&0xFF ];
+
+            // White space, Equals sign, or legit Base64 character
+            // Note the values such as -5 and -9 in the
+            // DECODABETs at the top of the file.
+            if( sbiDecode >= WHITE_SPACE_ENC )  {
+                if( sbiDecode >= EQUALS_SIGN_ENC ) {
+                    b4[ b4Posn++ ] = source[i];         // Save non-whitespace
+                    if( b4Posn > 3 ) {                  // Time to decode?
+                        outBuffPosn += decode4to3( b4, 0, outBuff, outBuffPosn, options );
+                        b4Posn = 0;
+
+                        // If that was the equals sign, break out of 'for' loop
+                        if( source[i] == EQUALS_SIGN ) {
+                            break;
+                        }   // end if: equals sign
+                    }   // end if: quartet built
+                }   // end if: equals sign or better
+            }   // end if: white space, equals sign or better
+            else {
+                // There's a bad input character in the Base64 stream.
+                throw new java.io.IOException( String.format(
+                        "Bad Base64 input character decimal %d in array position %d", ((int)source[i])&0xFF, i ) );
+            }   // end else:
+        }   // each input character
+
+        byte[] out = new byte[ outBuffPosn ];
+        System.arraycopy( outBuff, 0, out, 0, outBuffPosn );
+        return out;
+    }   // end decode
+
+
+
+
+    /**
+     * Decodes data from Base64 notation, automatically
+     * detecting gzip-compressed data and decompressing it.
+     *
+     * @param s the string to decode
+     * @return the decoded data
+     * @throws java.io.IOException If there is a problem
+     * @since 1.4
+     */
+    public static byte[] decode( String s ) throws java.io.IOException {
+        return decode( s, NO_OPTIONS );
+    }
+
+
+
+    /**
+     * Decodes data from Base64 notation, automatically
+     * detecting gzip-compressed data and decompressing it.
+     *
+     * @param s the string to decode
+     * @param options decode options such as URL_SAFE or GUNZIP
+     * @return the decoded data
+     * @throws java.io.IOException if there is an error (invalid character in source string or gunzip error)
+     * @throws NullPointerException if <tt>s</tt> is null
+     * @since 1.4
+     */
+    public static byte[] decode( String s, int options ) throws java.io.IOException {
+
+        if( s == null ){
+            throw new NullPointerException( "Input string was null." );
+        }   // end if
+
+        byte[] bytes;
+        try {
+            bytes = s.getBytes( PREFERRED_ENCODING );
+        }   // end try
+        catch( java.io.UnsupportedEncodingException uee ) {
+            bytes = s.getBytes();
+        }   // end catch
+        //</change>
+
+        // Decode
+        bytes = decode( bytes, 0, bytes.length, options );
+
+        // Check to see if it's gzip-compressed
+        // GZIP Magic Two-Byte Number: 0x8b1f (35615)
+        boolean doGunzip = (options & GUNZIP) != 0;
+        if( (bytes != null) && (bytes.length >= 4) && doGunzip ) {
+
+            int head = ((int)bytes[0] & 0xff) | ((bytes[1] << 8) & 0xff00);
+            if( java.util.zip.GZIPInputStream.GZIP_MAGIC != head )  {
+                throw new IOException("Provided data has no GZIP magic header.");
+            }
+            java.io.ByteArrayInputStream  bais = null;
+            java.util.zip.GZIPInputStream gzis = null;
+            java.io.ByteArrayOutputStream baos = null;
+            byte[] buffer = new byte[2048];
+            int    length = 0;
+
+            try {
+                baos = new java.io.ByteArrayOutputStream();
+                bais = new java.io.ByteArrayInputStream( bytes );
+                gzis = new java.util.zip.GZIPInputStream( bais );
+
+                while( ( length = gzis.read( buffer ) ) >= 0 ) {
+                    baos.write(buffer,0,length);
+                }   // end while: reading input
+
+                // No error? Get new bytes.
+                bytes = baos.toByteArray();
+
+            }   // end try
+            catch( java.io.IOException e ) {
+                throw new IOException("Failed to gunzip", e);
+            }   // end catch
+            finally {
+                try{ baos.close(); } catch( Exception e ){}
+                try{ gzis.close(); } catch( Exception e ){}
+                try{ bais.close(); } catch( Exception e ){}
+            }   // end finally
+
+        }   // end if: bytes.length >= 2
+
+        return bytes;
+    }   // end decode
+
+    /* ********  I N N E R   C L A S S   I N P U T S T R E A M  ******** */
+
+    /**
+     * A {@link Base64.InputStream} will read data from another
+     * <tt>java.io.InputStream</tt>, given in the constructor,
+     * and encode/decode to/from Base64 notation on the fly.
+     *
+     * @see Base64
+     * @since 1.3
+     */
+    public static class InputStream extends java.io.FilterInputStream {
+
+        private boolean encode;         // Encoding or decoding
+        private int     position;       // Current position in the buffer
+        private byte[]  buffer;         // Small buffer holding converted data
+        private int     bufferLength;   // Length of buffer (3 or 4)
+        private int     numSigBytes;    // Number of meaningful bytes in the buffer
+        private int     lineLength;
+        private boolean breakLines;     // Break lines at less than 80 characters
+        private int     options;        // Record options used to create the stream.
+        private byte[]  decodabet;      // Local copies to avoid extra method calls
+
+
+        /**
+         * Constructs a {@link Base64.InputStream} in DECODE mode.
+         *
+         * @param in the <tt>java.io.InputStream</tt> from which to read data.
+         * @since 1.3
+         */
+        public InputStream( java.io.InputStream in ) {
+            this( in, DECODE );
+        }   // end constructor
+
+
+        /**
+         * Constructs a {@link Base64.InputStream} in
+         * either ENCODE or DECODE mode.
+         * <p>
+         * Valid options:<pre>
+         *   ENCODE or DECODE: Encode or Decode as data is read.
+         *   DO_BREAK_LINES: break lines at 76 characters
+         *     (only meaningful when encoding)</i>
+         * </pre>
+         * <p>
+         * Example: <code>new Base64.InputStream( in, Base64.DECODE )</code>
+         *
+         *
+         * @param in the <tt>java.io.InputStream</tt> from which to read data.
+         * @param options Specified options
+         * @see Base64#ENCODE
+         * @see Base64#DECODE
+         * @see Base64#DO_BREAK_LINES
+         * @since 2.0
+         */
+        public InputStream( java.io.InputStream in, int options ) {
+
+            super( in );
+            this.options      = options; // Record for later
+            this.breakLines   = (options & DO_BREAK_LINES) > 0;
+            this.encode       = (options & ENCODE) > 0;
+            this.bufferLength = encode ? 4 : 3;
+            this.buffer       = new byte[ bufferLength ];
+            this.position     = -1;
+            this.lineLength   = 0;
+            this.decodabet    = getDecodabet(options);
+        }   // end constructor
+
+        /**
+         * Reads enough of the input stream to convert
+         * to/from Base64 and returns the next byte.
+         *
+         * @return next byte
+         * @since 1.3
+         */
+        @Override
+        public int read() throws java.io.IOException  {
+
+            // Do we need to get data?
+            if( position < 0 ) {
+                if( encode ) {
+                    byte[] b3 = new byte[3];
+                    int numBinaryBytes = 0;
+                    for( int i = 0; i < 3; i++ ) {
+                        int b = in.read();
+
+                        // If end of stream, b is -1.
+                        if( b >= 0 ) {
+                            b3[i] = (byte)b;
+                            numBinaryBytes++;
+                        } else {
+                            break; // out of for loop
+                        }   // end else: end of stream
+
+                    }   // end for: each needed input byte
+
+                    if( numBinaryBytes > 0 ) {
+                        encode3to4( b3, 0, numBinaryBytes, buffer, 0, options );
+                        position = 0;
+                        numSigBytes = 4;
+                    }   // end if: got data
+                    else {
+                        return -1;  // Must be end of stream
+                    }   // end else
+                }   // end if: encoding
+
+                // Else decoding
+                else {
+                    byte[] b4 = new byte[4];
+                    int i = 0;
+                    for( i = 0; i < 4; i++ ) {
+                        // Read four "meaningful" bytes:
+                        int b = 0;
+                        do{ b = in.read(); }
+                        while( b >= 0 && decodabet[ b & 0x7f ] <= WHITE_SPACE_ENC );
+
+                        if( b < 0 ) {
+                            break; // Reads a -1 if end of stream
+                        }   // end if: end of stream
+
+                        b4[i] = (byte)b;
+                    }   // end for: each needed input byte
+
+                    if( i == 4 ) {
+                        numSigBytes = decode4to3( b4, 0, buffer, 0, options );
+                        position = 0;
+                    }   // end if: got four characters
+                    else if( i == 0 ){
+                        return -1;
+                    }   // end else if: also padded correctly
+                    else {
+                        // Must have broken out from above.
+                        throw new java.io.IOException( "Improperly padded Base64 input." );
+                    }   // end
+
+                }   // end else: decode
+            }   // end else: get data
+
+            // Got data?
+            if( position >= 0 ) {
+                // End of relevant data?
+                if( /*!encode &&*/ position >= numSigBytes ){
+                    return -1;
+                }   // end if: got data
+
+                if( encode && breakLines && lineLength >= MAX_LINE_LENGTH ) {
+                    lineLength = 0;
+                    return '\n';
+                }   // end if
+                else {
+                    lineLength++;   // This isn't important when decoding
+                    // but throwing an extra "if" seems
+                    // just as wasteful.
+
+                    int b = buffer[ position++ ];
+
+                    if( position >= bufferLength ) {
+                        position = -1;
+                    }   // end if: end
+
+                    return b & 0xFF; // This is how you "cast" a byte that's
+                    // intended to be unsigned.
+                }   // end else
+            }   // end if: position >= 0
+
+            // Else error
+            else {
+                throw new java.io.IOException( "Error in Base64 code reading stream." );
+            }   // end else
+        }   // end read
+
+
+        /**
+         * Calls {@link #read()} repeatedly until the end of stream
+         * is reached or <var>len</var> bytes are read.
+         * Returns number of bytes read into array or -1 if
+         * end of stream is encountered.
+         *
+         * @param dest array to hold values
+         * @param off offset for array
+         * @param len max number of bytes to read into array
+         * @return bytes read into array or -1 if end of stream is encountered.
+         * @since 1.3
+         */
+        @Override
+        public int read( byte[] dest, int off, int len )
+                throws java.io.IOException {
+            int i;
+            int b;
+            for( i = 0; i < len; i++ ) {
+                b = read();
+
+                if( b >= 0 ) {
+                    dest[off + i] = (byte) b;
+                }
+                else if( i == 0 ) {
+                    return -1;
+                }
+                else {
+                    break; // Out of 'for' loop
+                } // Out of 'for' loop
+            }   // end for: each byte read
+            return i;
+        }   // end read
+
+    }   // end inner class InputStream
+
+
+
+
+
+
+    /* ********  I N N E R   C L A S S   O U T P U T S T R E A M  ******** */
+
+
+
+    /**
+     * A {@link Base64.OutputStream} will write data to another
+     * <tt>java.io.OutputStream</tt>, given in the constructor,
+     * and encode/decode to/from Base64 notation on the fly.
+     *
+     * @see Base64
+     * @since 1.3
+     */
+    public static class OutputStream extends java.io.FilterOutputStream {
+
+        private boolean encode;
+        private int     position;
+        private byte[]  buffer;
+        private int     bufferLength;
+        private int     lineLength;
+        private boolean breakLines;
+        private byte[]  b4;         // Scratch used in a few places
+        private boolean suspendEncoding;
+        private int     options;    // Record for later
+        private byte[]  decodabet;  // Local copies to avoid extra method calls
+
+        /**
+         * Constructs a {@link Base64.OutputStream} in ENCODE mode.
+         *
+         * @param out the <tt>java.io.OutputStream</tt> to which data will be written.
+         * @since 1.3
+         */
+        public OutputStream( java.io.OutputStream out ) {
+            this( out, ENCODE );
+        }   // end constructor
+
+
+        /**
+         * Constructs a {@link Base64.OutputStream} in
+         * either ENCODE or DECODE mode.
+         * <p>
+         * Valid options:<pre>
+         *   ENCODE or DECODE: Encode or Decode as data is read.
+         *   DO_BREAK_LINES: don't break lines at 76 characters
+         *     (only meaningful when encoding)</i>
+         * </pre>
+         * <p>
+         * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>
+         *
+         * @param out the <tt>java.io.OutputStream</tt> to which data will be written.
+         * @param options Specified options.
+         * @see Base64#ENCODE
+         * @see Base64#DECODE
+         * @see Base64#DO_BREAK_LINES
+         * @since 1.3
+         */
+        public OutputStream( java.io.OutputStream out, int options ) {
+            super( out );
+            this.breakLines   = (options & DO_BREAK_LINES) != 0;
+            this.encode       = (options & ENCODE) != 0;
+            this.bufferLength = encode ? 3 : 4;
+            this.buffer       = new byte[ bufferLength ];
+            this.position     = 0;
+            this.lineLength   = 0;
+            this.suspendEncoding = false;
+            this.b4           = new byte[4];
+            this.options      = options;
+            this.decodabet    = getDecodabet(options);
+        }   // end constructor
+
+
+        /**
+         * Writes the byte to the output stream after
+         * converting to/from Base64 notation.
+         * When encoding, bytes are buffered three
+         * at a time before the output stream actually
+         * gets a write() call.
+         * When decoding, bytes are buffered four
+         * at a time.
+         *
+         * @param theByte the byte to write
+         * @since 1.3
+         */
+        @Override
+        public void write(int theByte)
+                throws java.io.IOException {
+            // Encoding suspended?
+            if( suspendEncoding ) {
+                this.out.write( theByte );
+                return;
+            }   // end if: supsended
+
+            // Encode?
+            if( encode ) {
+                buffer[ position++ ] = (byte)theByte;
+                if( position >= bufferLength ) { // Enough to encode.
+
+                    this.out.write( encode3to4( b4, buffer, bufferLength, options ) );
+
+                    lineLength += 4;
+                    if( breakLines && lineLength >= MAX_LINE_LENGTH ) {
+                        this.out.write( NEW_LINE );
+                        lineLength = 0;
+                    }   // end if: end of line
+
+                    position = 0;
+                }   // end if: enough to output
+            }   // end if: encoding
+
+            // Else, Decoding
+            else {
+                // Meaningful Base64 character?
+                if( decodabet[ theByte & 0x7f ] > WHITE_SPACE_ENC ) {
+                    buffer[ position++ ] = (byte)theByte;
+                    if( position >= bufferLength ) { // Enough to output.
+
+                        int len = Base64.decode4to3( buffer, 0, b4, 0, options );
+                        out.write( b4, 0, len );
+                        position = 0;
+                    }   // end if: enough to output
+                }   // end if: meaningful base64 character
+                else if( decodabet[ theByte & 0x7f ] != WHITE_SPACE_ENC ) {
+                    throw new java.io.IOException( "Invalid character in Base64 data." );
+                }   // end else: not white space either
+            }   // end else: decoding
+        }   // end write
+
+
+
+        /**
+         * Calls {@link #write(int)} repeatedly until <var>len</var>
+         * bytes are written.
+         *
+         * @param theBytes array from which to read bytes
+         * @param off offset for array
+         * @param len max number of bytes to read into array
+         * @since 1.3
+         */
+        @Override
+        public void write( byte[] theBytes, int off, int len )
+                throws java.io.IOException {
+            // Encoding suspended?
+            if( suspendEncoding ) {
+                this.out.write( theBytes, off, len );
+                return;
+            }   // end if: supsended
+
+            for( int i = 0; i < len; i++ ) {
+                write( theBytes[ off + i ] );
+            }   // end for: each byte written
+
+        }   // end write
+
+
+
+        /**
+         * Method added by PHIL. [Thanks, PHIL. -Rob]
+         * This pads the buffer without closing the stream.
+         * @throws java.io.IOException  if there's an error.
+         */
+        public void flushBase64() throws java.io.IOException  {
+            if( position > 0 ) {
+                if( encode ) {
+                    out.write( encode3to4( b4, buffer, position, options ) );
+                    position = 0;
+                }   // end if: encoding
+                else {
+                    throw new java.io.IOException( "Base64 input not properly padded." );
+                }   // end else: decoding
+            }   // end if: buffer partially full
+
+        }   // end flush
+
+
+        /**
+         * Flushes and closes (I think, in the superclass) the stream.
+         *
+         * @since 1.3
+         */
+        @Override
+        public void close() throws java.io.IOException {
+            // 1. Ensure that pending characters are written
+            flushBase64();
+
+            // 2. Actually close the stream
+            // Base class both flushes and closes.
+            super.close();
+
+            buffer = null;
+            out    = null;
+        }   // end close
+
+
+
+        /**
+         * Suspends encoding of the stream.
+         * May be helpful if you need to embed a piece of
+         * base64-encoded data in a stream.
+         *
+         * @throws java.io.IOException  if there's an error flushing
+         * @since 1.5.1
+         */
+        public void suspendEncoding() throws java.io.IOException  {
+            flushBase64();
+            this.suspendEncoding = true;
+        }   // end suspendEncoding
+
+
+        /**
+         * Resumes encoding of the stream.
+         * May be helpful if you need to embed a piece of
+         * base64-encoded data in a stream.
+         *
+         * @since 1.5.1
+         */
+        public void resumeEncoding() {
+            this.suspendEncoding = false;
+        }   // end resumeEncoding
+
+
+
+    }   // end inner class OutputStream
+
+
+}   // end class Base64

--- a/client-common/src/main/java/org/keycloak/common/util/CollectionUtil.java
+++ b/client-common/src/main/java/org/keycloak/common/util/CollectionUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:jeroen.rosenberg@gmail.com">Jeroen Rosenberg</a>
+ */
+public class CollectionUtil {
+
+    public static String join(Collection<String> strings) {
+        return join(strings, ", ");
+    }
+
+    public static String join(Collection<String> strings, String separator) {
+        return strings.stream().collect(Collectors.joining(String.valueOf(separator)));
+    }
+
+    // Return true if all items from col1 are in col2 and viceversa. Order is not taken into account
+    public static <T> boolean collectionEquals(Collection<T> col1, Collection<T> col2) {
+        if (col1.size()!=col2.size()) {
+            return false;
+        }
+        Map<T, Integer> countMap = new HashMap<>();
+        for(T o : col1) {
+            countMap.merge(o, 1, (v1, v2) -> v1 + v2);
+        }
+        for(T o : col2) {
+            Integer v = countMap.get(o);
+            if (v==null) {
+                return false;
+            }
+            if (v == 1) {
+                countMap.remove(o);
+            } else {
+                countMap.put(o, v-1);
+            }
+        }
+        return countMap.isEmpty();
+    }
+
+    public static boolean isEmpty(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    public static boolean isNotEmpty(Collection<?> collection) {
+        return !isEmpty(collection);
+    }
+
+    public static <T> Set<T> collectionToSet(Collection<T> collection) {
+        return collection == null ? null : new HashSet<>(collection);
+    }
+}

--- a/client-common/src/main/java/org/keycloak/common/util/MultivaluedHashMap.java
+++ b/client-common/src/main/java/org/keycloak/common/util/MultivaluedHashMap.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+@SuppressWarnings("serial")
+public class MultivaluedHashMap<K, V> extends HashMap<K, List<V>> implements MultivaluedMap<K, V>
+{
+   public MultivaluedHashMap() {
+   }
+
+   public MultivaluedHashMap(Map<K, List<V>> map) {
+      if (map == null) {
+         throw new IllegalArgumentException("Map can not be null");
+      }
+      putAll(map);
+   }
+
+
+   public MultivaluedHashMap(MultivaluedHashMap<K, V> config) {
+      addAll(config);
+   }
+}

--- a/client-common/src/main/java/org/keycloak/common/util/MultivaluedMap.java
+++ b/client-common/src/main/java/org/keycloak/common/util/MultivaluedMap.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface MultivaluedMap<K, V> extends Map<K, List<V>> {
+
+    public default void putSingle(K key, V value) {
+        List<V> list = createListInstance();
+        list.add(value);
+        put(key, list); // Just override with new List instance
+    }
+
+    public default void addAll(K key, V... newValues) {
+        for (V value : newValues) {
+            add(key, value);
+        }
+    }
+
+    public default void addAll(K key, List<V> valueList) {
+        for (V value : valueList) {
+            add(key, value);
+        }
+    }
+
+    public default void addFirst(K key, V value) {
+        getList(key).add(0, value);
+    }
+
+    public default void add(K key, V value) {
+        getList(key).add(value);
+    }
+
+    public default void addMultiple(K key, Collection<V> values) {
+        getList(key).addAll(values);
+    }
+
+    public default V getFirst(K key) {
+        return Optional.ofNullable(get(key)).filter(l -> !l.isEmpty()).map(l -> l.get(0)).orElse(null);
+    }
+
+    public default List<V> getList(K key) {
+        return compute(key, (k, v) -> v != null ? v : createListInstance());
+    }
+
+    public default void addAll(MultivaluedMap<K, V> other) {
+        for (Entry<K, List<V>> entry : other.entrySet()) {
+            getList(entry.getKey()).addAll(entry.getValue());
+        }
+    }
+
+    public default boolean equalsIgnoreValueOrder(MultivaluedMap<K, V> omap) {
+       if (this == omap) {
+          return true;
+       }
+       if (!keySet().equals(omap.keySet())) {
+          return false;
+       }
+       for (Map.Entry<K, List<V>> e : entrySet()) {
+           List<V> list = e.getValue();
+           List<V> olist = omap.get(e.getKey());
+           if (!CollectionUtil.collectionEquals(list, olist)) {
+               return false;
+           }
+       }
+       return true;
+    }
+
+    public default List<V> createListInstance() {
+        return new ArrayList<>();
+    }
+
+}

--- a/client-common/src/main/java/org/keycloak/common/util/ObjectUtil.java
+++ b/client-common/src/main/java/org/keycloak/common/util/ObjectUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ObjectUtil {
+
+    private ObjectUtil() {}
+
+    /**
+     *
+     * @param str1
+     * @param str2
+     * @return true if both strings are null or equal
+     */
+    public static boolean isEqualOrBothNull(Object str1, Object str2) {
+        if (str1 == null && str2 == null) {
+            return true;
+        }
+
+        if ((str1 != null && str2 == null) || (str1 == null && str2 != null)) {
+            return false;
+        }
+
+        return str1.equals(str2);
+    }
+
+
+    public static String capitalize(String str) {
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
+    }
+
+
+    /**
+     * Forked from apache-commons StringUtils
+     *
+     * <p>Checks if a CharSequence is whitespace, empty ("") or null.</p>
+     *
+     * <pre>
+     * ObjectUtil.isBlank(null)      = true
+     * ObjectUtil.isBlank("")        = true
+     * ObjectUtil.isBlank(" ")       = true
+     * ObjectUtil.isBlank("bob")     = false
+     * ObjectUtil.isBlank("  bob  ") = false
+     * </pre>
+     *
+     * @param cs
+     * @return {@code true} if the CharSequence is null, empty or whitespace
+     */
+    public static boolean isBlank(final CharSequence cs) {
+        int strLen;
+        if (cs == null || (strLen = cs.length()) == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/client-common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/client-common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.common.util;
+
+import java.io.File;
+import java.util.Properties;
+
+/**
+ * A utility class for replacing properties in strings. 
+ *
+ * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
+ * @author <a href="Scott.Stark@jboss.org">Scott Stark</a>
+ * @author <a href="claudio.vesco@previnet.it">Claudio Vesco</a>
+ * @author <a href="mailto:adrian@jboss.com">Adrian Brock</a>
+ * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
+ * @version <tt>$Revision: 2898 $</tt> 
+ */
+public final class StringPropertyReplacer
+{
+    /** New line string constant */
+    public static final String NEWLINE = System.getProperty("line.separator", "\n");
+
+    /** File separator value */
+    private static final String FILE_SEPARATOR = File.separator;
+
+    /** Path separator value */
+    private static final String PATH_SEPARATOR = File.pathSeparator;
+
+    /** File separator alias */
+    private static final String FILE_SEPARATOR_ALIAS = "/";
+
+    /** Path separator alias */
+    private static final String PATH_SEPARATOR_ALIAS = ":";
+
+    // States used in property parsing
+    private static final int NORMAL = 0;
+    private static final int SEEN_DOLLAR = 1;
+    private static final int IN_BRACKET = 2;
+
+    private static final Properties systemEnvProperties = new SystemEnvProperties();
+
+    /**
+     * Go through the input string and replace any occurrence of ${p} with
+     * the System.getProperty(p) value. If there is no such property p defined,
+     * then the ${p} reference will remain unchanged.
+     *
+     * If the property reference is of the form ${p:v} and there is no such property p,
+     * then the default value v will be returned.
+     *
+     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then
+     * the primary and the secondary properties will be tried in turn, before
+     * returning either the unchanged input, or the default value.
+     *
+     * The property ${/} is replaced with System.getProperty("file.separator")
+     * value and the property ${:} is replaced with System.getProperty("path.separator").
+     *
+     * @param string - the string with possible ${} references
+     * @return the input string with all property references replaced if any.
+     *    If there are no valid references the input string will be returned.
+     */
+    public static String replaceProperties(final String string)
+    {
+        return replaceProperties(string, (Properties) null);
+    }
+
+    /**
+     * Go through the input string and replace any occurrence of ${p} with
+     * the props.getProperty(p) value. If there is no such property p defined,
+     * then the ${p} reference will remain unchanged.
+     *
+     * If the property reference is of the form ${p:v} and there is no such property p,
+     * then the default value v will be returned.
+     *
+     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then
+     * the primary and the secondary properties will be tried in turn, before
+     * returning either the unchanged input, or the default value.
+     *
+     * The property ${/} is replaced with System.getProperty("file.separator")
+     * value and the property ${:} is replaced with System.getProperty("path.separator").
+     *
+     * @param string - the string with possible ${} references
+     * @param props - the source for ${x} property ref values, null means use System.getProperty()
+     * @return the input string with all property references replaced if any.
+     *    If there are no valid references the input string will be returned.
+     */
+    public static String replaceProperties(final String string, final Properties props) {
+        if (props == null) {
+            return replaceProperties(string, (PropertyResolver) null);
+        }
+        return replaceProperties(string, new PropertyResolver() {
+            @Override
+            public String resolve(String property) {
+                return props.getProperty(property);
+            }
+        });
+    }
+
+    public static String replaceProperties(final String string, PropertyResolver resolver)
+    {
+        if(string == null) {
+            return null;
+        }
+        final char[] chars = string.toCharArray();
+        StringBuilder buffer = new StringBuilder();
+        boolean properties = false;
+        int state = NORMAL;
+        int start = 0;
+        int openBracketsCount = 0;
+        for (int i = 0; i < chars.length; ++i)
+        {
+            char c = chars[i];
+
+            // Dollar sign outside brackets
+            if (c == '$' && state != IN_BRACKET)
+                state = SEEN_DOLLAR;
+
+            // Open bracket immediately after dollar
+            else if (c == '{' && state == SEEN_DOLLAR)
+            {
+                buffer.append(string.substring(start, i - 1));
+                state = IN_BRACKET;
+                start = i - 1;
+                openBracketsCount = 1;
+            }
+
+            // Seeing open bracket after we already saw some open bracket without corresponding closed bracket. This causes "nested" expressions. For example ${foo:${bar}}
+            else if (c == '{' && state == IN_BRACKET)
+                openBracketsCount++;
+
+            // No open bracket after dollar
+            else if (state == SEEN_DOLLAR)
+                state = NORMAL;
+
+            // Seeing closed bracket, but we already saw more than one open bracket before. Hence "nested" expression is still not fully closed.
+            // For example expression ${foo:${bar}} is closed after the second closed bracket, not after the first closed bracket.
+            else if (c == '}' && state == IN_BRACKET && openBracketsCount > 1)
+                openBracketsCount--;
+
+                // Closed bracket after open bracket
+            else if (c == '}' && state == IN_BRACKET)
+            {
+                // No content
+                if (start + 2 == i)
+                {
+                    buffer.append("${}"); // REVIEW: Correct?
+                }
+                else // Collect the system property
+                {
+                    String value = null;
+
+                    String key = string.substring(start + 2, i);
+
+                    // check for alias
+                    if (FILE_SEPARATOR_ALIAS.equals(key))
+                    {
+                        value = FILE_SEPARATOR;
+                    }
+                    else if (PATH_SEPARATOR_ALIAS.equals(key))
+                    {
+                        value = PATH_SEPARATOR;
+                    }
+                    else
+                    {
+                        // check from the properties
+                        if (resolver != null)
+                            value = resolver.resolve(key);
+                        else
+                            value = systemEnvProperties.getProperty(key);
+
+                        if (value == null)
+                        {
+                            // Check for a default value ${key:default}
+                            int colon = key.indexOf(':');
+                            if (colon > 0)
+                            {
+                                String realKey = key.substring(0, colon);
+                                if (resolver != null)
+                                    value = resolver.resolve(realKey);
+                                else
+                                    value = systemEnvProperties.getProperty(realKey);
+
+                                if (value == null)
+                                {
+                                    // Check for a composite key, "key1,key2"
+                                    value = resolveCompositeKey(realKey, resolver);
+
+                                    // Not a composite key either, use the specified default
+                                    if (value == null)
+                                        value = key.substring(colon+1);
+                                }
+                            }
+                            else
+                            {
+                                // No default, check for a composite key, "key1,key2"
+                                value = resolveCompositeKey(key, resolver);
+                            }
+                        }
+                    }
+
+                    if (value != null)
+                    {
+                        properties = true;
+                        buffer.append(value);
+                    }
+                    else
+                    {
+                        buffer.append("${");
+                        buffer.append(key);
+                        buffer.append('}');
+                    }
+
+                }
+                start = i + 1;
+                state = NORMAL;
+            }
+        }
+
+        // No properties
+        if (!properties)
+            return string;
+
+        // Collect the trailing characters
+        if (start != chars.length)
+            buffer.append(string.substring(start, chars.length));
+
+        if (buffer.indexOf("${") != -1) {
+            try {
+                return replaceProperties(buffer.toString(), resolver);
+            } catch (StackOverflowError ex) {
+                throw new IllegalStateException("Infinite recursion happening when replacing properties on '" + buffer + "'");
+            }
+        }
+        
+        // Done
+        return buffer.toString();
+    }
+
+    /**
+     * Try to resolve a "key" from the provided properties by
+     * checking if it is actually a "key1,key2", in which case
+     * try first "key1", then "key2". If all fails, return null.
+     *
+     * It also accepts "key1," and ",key2".
+     *
+     * @param key the key to resolve
+     * @param props the properties to use
+     * @return the resolved key or null
+     */
+    private static String resolveCompositeKey(String key, final Properties props) {
+        if (props == null) {
+            return resolveCompositeKey(key, (PropertyResolver) null);
+        }
+        return resolveCompositeKey(key, new PropertyResolver() {
+            @Override
+            public String resolve(String property) {
+                return props.getProperty(property);
+            }
+        });        
+    }
+
+    private static String resolveCompositeKey(String key, PropertyResolver resolver)
+    {
+        String value = null;
+
+        // Look for the comma
+        int comma = key.indexOf(',');
+        if (comma > -1)
+        {
+            // If we have a first part, try resolve it
+            if (comma > 0)
+            {
+                // Check the first part
+                String key1 = key.substring(0, comma);
+                if (resolver != null)
+                    value = resolver.resolve(key1);
+                else
+                    value = systemEnvProperties.getProperty(key1);
+            }
+            // Check the second part, if there is one and first lookup failed
+            if (value == null && comma < key.length() - 1)
+            {
+                String key2 = key.substring(comma + 1);
+                if (resolver != null)
+                    value = resolver.resolve(key2);
+                else
+                    value = systemEnvProperties.getProperty(key2);
+            }
+        }
+        // Return whatever we've found or null
+        return value;
+    }
+    
+    public interface PropertyResolver {
+        String resolve(String property);
+    }
+}

--- a/client-common/src/main/java/org/keycloak/common/util/SystemEnvProperties.java
+++ b/client-common/src/main/java/org/keycloak/common/util/SystemEnvProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class SystemEnvProperties extends Properties {
+
+    private final Map<String, String> overrides;
+
+    public SystemEnvProperties(Map<String, String> overrides) {
+        this.overrides = overrides;
+    }
+
+    public SystemEnvProperties() {
+        this.overrides = Collections.EMPTY_MAP;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        if (overrides.containsKey(key)) {
+            return overrides.get(key);
+        } else if (key.startsWith("env.")) {
+            return System.getenv().get(key.substring(4));
+        } else {
+            return System.getProperty(key);
+        }
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        String value = getProperty(key);
+        return value != null ? value : defaultValue;
+    }
+
+}

--- a/client-common/src/main/java/org/keycloak/common/util/Time.java
+++ b/client-common/src/main/java/org/keycloak/common/util/Time.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import java.util.Date;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class Time {
+
+    private static volatile int offset;
+
+    /**
+     * Returns current time in seconds adjusted by adding {@link #offset) seconds.
+     * @return see description
+     */
+    public static int currentTime() {
+        return ((int) (System.currentTimeMillis() / 1000)) + offset;
+    }
+
+    /**
+     * Returns current time in milliseconds adjusted by adding {@link #offset) seconds.
+     * @return see description
+     */
+    public static long currentTimeMillis() {
+        return System.currentTimeMillis() + (offset * 1000L);
+    }
+
+    /**
+     * Returns {@link Date} object, its value set to time
+     * @param time Time in milliseconds since the epoch
+     * @return see description
+     */
+    public static Date toDate(int time) {
+        return new Date(time * 1000L);
+    }
+
+    /**
+     * Returns {@link Date} object, its value set to time
+     * @param time Time in milliseconds since the epoch
+     * @return see description
+     */
+    public static Date toDate(long time) {
+        return new Date(time);
+    }
+
+    /**
+     * Returns time in milliseconds for a time in seconds. No adjustment is made to the parameter.
+     * @param time Time in seconds since the epoch
+     * @return Time in milliseconds
+     */
+    public static long toMillis(long time) {
+        return time * 1000L;
+    }
+
+    /**
+     * @return Time offset in seconds that will be added to {@link #currentTime()} and {@link #currentTimeMillis()}.
+     */
+    public static int getOffset() {
+        return offset;
+    }
+
+    /**
+     * Sets time offset in seconds that will be added to {@link #currentTime()} and {@link #currentTimeMillis()}.
+     * @param offset Offset (in seconds)
+     */
+    public static void setOffset(int offset) {
+        Time.offset = offset;
+    }
+
+}

--- a/client-core/pom.xml
+++ b/client-core/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-client-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-client-core</artifactId>
+    <name>Keycloak Client Core</name>
+    <packaging>jar</packaging>
+    <description>Keycloak Client Core description</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+    </build>
+
+</project>

--- a/client-core/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/client-core/src/main/java/org/keycloak/OAuth2Constants.java
@@ -1,0 +1,142 @@
+package org.keycloak;
+
+/**
+ * TODO:mposolda remove most of the constants from this class, which are not needed by admin-client...
+ *
+ * Make this class in sync with org.keycloak.OAuth2Constants
+ *
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public interface OAuth2Constants {
+
+    String CODE = "code";
+
+    String TOKEN = "token";
+
+    String CLIENT_ID = "client_id";
+
+    String CLIENT_SECRET = "client_secret";
+
+    String ERROR = "error";
+
+    String ERROR_DESCRIPTION = "error_description";
+
+    String REDIRECT_URI = "redirect_uri";
+
+    String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
+
+    String ID_TOKEN_HINT = "id_token_hint";
+
+    String DISPLAY = "display";
+
+    String SCOPE = "scope";
+
+    String STATE = "state";
+
+    String GRANT_TYPE = "grant_type";
+
+    String RESPONSE_TYPE = "response_type";
+
+    String ACCESS_TOKEN = "access_token";
+
+    String TOKEN_TYPE = "token_type";
+
+    String EXPIRES_IN = "expires_in";
+
+    String ID_TOKEN = "id_token";
+
+    String REFRESH_TOKEN = "refresh_token";
+
+    String LOGOUT_TOKEN = "logout_token";
+
+    String AUTHORIZATION_CODE = "authorization_code";
+
+
+    String IMPLICIT = "implicit";
+
+    String USERNAME="username";
+
+    String PASSWORD = "password";
+
+    String CLIENT_CREDENTIALS = "client_credentials";
+
+    // https://tools.ietf.org/html/draft-ietf-oauth-assertions-01#page-5
+    String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    String CLIENT_ASSERTION = "client_assertion";
+
+    // https://tools.ietf.org/html/draft-jones-oauth-jwt-bearer-03#section-2.2
+    String CLIENT_ASSERTION_TYPE_JWT = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+    // http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
+    String OFFLINE_ACCESS = "offline_access";
+
+    // http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+    String SCOPE_OPENID = "openid";
+
+    // http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+    String SCOPE_PROFILE = "profile";
+    String SCOPE_EMAIL = "email";
+    String SCOPE_ADDRESS = "address";
+    String SCOPE_PHONE = "phone";
+
+    String ORGANIZATION = "organization";
+
+    String UI_LOCALES_PARAM = "ui_locales";
+
+    String PROMPT = "prompt";
+    String ACR_VALUES = "acr_values";
+
+    String MAX_AGE = "max_age";
+
+    // OIDC Session Management
+    String SESSION_STATE = "session_state";
+
+    String JWT = "JWT";
+
+    // https://tools.ietf.org/html/rfc7636#section-6.1
+    String CODE_VERIFIER = "code_verifier";
+    String CODE_CHALLENGE = "code_challenge";
+    String CODE_CHALLENGE_METHOD = "code_challenge_method";
+
+    // https://tools.ietf.org/html/rfc7636#section-6.2.2
+    String PKCE_METHOD_PLAIN = "plain";
+    String PKCE_METHOD_S256 = "S256";
+
+    // https://tools.ietf.org/html/rfc8693#section-2.1
+    String TOKEN_EXCHANGE_GRANT_TYPE="urn:ietf:params:oauth:grant-type:token-exchange";
+    String AUDIENCE="audience";
+    String RESOURCE="resource";
+    String REQUESTED_SUBJECT="requested_subject";
+    String SUBJECT_TOKEN="subject_token";
+    String SUBJECT_TOKEN_TYPE="subject_token_type";
+    String ACTOR_TOKEN="actor_token";
+    String ACTOR_TOKEN_TYPE="actor_token_type";
+    String REQUESTED_TOKEN_TYPE="requested_token_type";
+    String ISSUED_TOKEN_TYPE="issued_token_type";
+    String REQUESTED_ISSUER="requested_issuer";
+    String SUBJECT_ISSUER="subject_issuer";
+    String ACCESS_TOKEN_TYPE="urn:ietf:params:oauth:token-type:access_token";
+    String REFRESH_TOKEN_TYPE="urn:ietf:params:oauth:token-type:refresh_token";
+    String JWT_TOKEN_TYPE="urn:ietf:params:oauth:token-type:jwt";
+    String ID_TOKEN_TYPE="urn:ietf:params:oauth:token-type:id_token";
+    String SAML2_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:saml2";
+
+    String UMA_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket";
+
+    // https://tools.ietf.org/html/draft-ietf-oauth-device-flow-15#section-3.4
+    String DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+    String DEVICE_CODE = "device_code";
+
+    String CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
+
+    String INTERVAL = "interval";
+    String USER_CODE = "user_code";
+
+    // https://openid.net/specs/openid-financial-api-jarm-ID1.html
+    String RESPONSE = "response";
+
+    // https://www.rfc-editor.org/rfc/rfc9207.html
+    String ISSUER = "iss";
+
+    String AUTHENTICATOR_METHOD_REFERENCE = "amr";
+}

--- a/client-core/src/main/java/org/keycloak/Token.java
+++ b/client-core/src/main/java/org/keycloak/Token.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public interface Token {
+
+    @JsonIgnore
+    TokenCategory getCategory();
+
+}

--- a/client-core/src/main/java/org/keycloak/TokenCategory.java
+++ b/client-core/src/main/java/org/keycloak/TokenCategory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak;
+
+public enum TokenCategory {
+    INTERNAL,
+    ACCESS,
+    ID,
+    ADMIN,
+    USERINFO,
+    LOGOUT,
+    AUTHORIZATION_RESPONSE
+}

--- a/client-core/src/main/java/org/keycloak/TokenIdGenerator.java
+++ b/client-core/src/main/java/org/keycloak/TokenIdGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class TokenIdGenerator {
+    private static final AtomicLong counter = new AtomicLong();
+
+    public static String generateId() {
+        return UUID.randomUUID().toString() + "-" + System.currentTimeMillis();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/crypto/KeyUse.java
+++ b/client-core/src/main/java/org/keycloak/crypto/KeyUse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.crypto;
+
+public enum KeyUse {
+
+    SIG("sig"),
+    ENC("enc");
+
+    private String specName;
+
+    KeyUse(String specName) {
+        this.specName = specName;
+    }
+
+    public String getSpecName() {
+        return specName;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
+++ b/client-core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class StringListMapDeserializer extends JsonDeserializer<Object> {
+
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+        Iterator<Map.Entry<String, JsonNode>> itr = jsonNode.fields();
+        Map<String, List<String>> map = new HashMap<>();
+        while (itr.hasNext()) {
+            Map.Entry<String, JsonNode> e = itr.next();
+            List<String> values = new LinkedList<>();
+            if (!e.getValue().isArray()) {
+                values.add((e.getValue().isNull()) ? null : e.getValue().asText());
+            } else {
+                ArrayNode a = (ArrayNode) e.getValue();
+                Iterator<JsonNode> vitr = a.elements();
+                while (vitr.hasNext()) {
+                    JsonNode node = vitr.next();
+                    values.add((node.isNull() ? null : node.asText()));
+                }
+            }
+            map.put(e.getKey(), values);
+        }
+        return map;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/json/StringOrArrayDeserializer.java
+++ b/client-core/src/main/java/org/keycloak/json/StringOrArrayDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class StringOrArrayDeserializer extends JsonDeserializer<Object> {
+
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+        if (jsonNode.isArray()) {
+            ArrayList<String> a = new ArrayList<>(1);
+            Iterator<JsonNode> itr = jsonNode.iterator();
+            while (itr.hasNext()) {
+                a.add(itr.next().textValue());
+            }
+            return a.toArray(new String[a.size()]);
+        } else {
+            return new String[] { jsonNode.textValue() };
+        }
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/json/StringOrArraySerializer.java
+++ b/client-core/src/main/java/org/keycloak/json/StringOrArraySerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class StringOrArraySerializer extends JsonSerializer<Object> {
+    @Override
+    public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        String[] array = (String[]) o;
+        if (array == null) {
+            jsonGenerator.writeNull();
+        } else if (array.length == 1) {
+            jsonGenerator.writeString(array[0]);
+        } else {
+            jsonGenerator.writeStartArray();
+            for (String s : array) {
+                jsonGenerator.writeString(s);
+            }
+            jsonGenerator.writeEndArray();
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/AccessToken.java
+++ b/client-core/src/main/java/org/keycloak/representations/AccessToken.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.TokenCategory;
+import org.keycloak.representations.idm.authorization.Permission;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class AccessToken extends IDToken {
+    public static class Access implements Serializable {
+        @JsonProperty("roles")
+        protected Set<String> roles;
+        @JsonProperty("verify_caller")
+        protected Boolean verifyCaller;
+
+        public Access() {
+        }
+
+        public Access clone() {
+            Access access = new Access();
+            access.verifyCaller = verifyCaller;
+            if (roles != null) {
+                access.roles = new HashSet<>();
+                access.roles.addAll(roles);
+            }
+            return access;
+        }
+
+        public Set<String> getRoles() {
+            return roles;
+        }
+
+        public Access roles(Set<String> roles) {
+            this.roles = roles;
+            return this;
+        }
+
+        @JsonIgnore
+        public boolean isUserInRole(String role) {
+            if (roles == null) return false;
+            return roles.contains(role);
+        }
+
+        public Access addRole(String role) {
+            if (roles == null) roles = new HashSet<>();
+            roles.add(role);
+            return this;
+        }
+
+        public Boolean getVerifyCaller() {
+            return verifyCaller;
+        }
+
+        public Access verifyCaller(Boolean required) {
+            this.verifyCaller = required;
+            return this;
+        }
+    }
+
+    public static class Authorization implements Serializable {
+
+        @JsonProperty("permissions")
+        private Collection<Permission> permissions;
+
+        public Collection<Permission> getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(Collection<Permission> permissions) {
+            this.permissions = permissions;
+        }
+    }
+
+    // KEYCLOAK-6771 Certificate Bound Token
+    // https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-3.1
+    public static class Confirmation {
+        @JsonProperty("x5t#S256")
+        protected String certThumbprint;
+
+        @JsonProperty("jkt")
+        protected String keyThumbprint;
+
+        public String getCertThumbprint() {
+            return certThumbprint;
+        }
+
+        public void setCertThumbprint(String certThumbprint) {
+            this.certThumbprint = certThumbprint;
+        }
+
+        public String getKeyThumbprint() {
+            return keyThumbprint;
+    }
+
+    public void setKeyThumbprint(String keyThumbprint) {
+            this.keyThumbprint = keyThumbprint;
+        }
+    }
+
+    @JsonProperty("trusted-certs")
+    protected Set<String> trustedCertificates;
+
+    @JsonProperty("allowed-origins")
+    protected Set<String> allowedOrigins;
+
+    @JsonProperty("realm_access")
+    protected Access realmAccess;
+
+    @JsonProperty("resource_access")
+    protected Map<String, Access> resourceAccess;
+
+    @JsonProperty("authorization")
+    protected Authorization authorization;
+
+    @JsonProperty("cnf")
+    protected Confirmation confirmation;
+
+    @JsonProperty("scope")
+    protected String scope;
+
+    @JsonIgnore
+    public Map<String, Access> getResourceAccess() {
+        return resourceAccess == null ? Collections.<String, Access>emptyMap() : resourceAccess;
+    }
+
+    public void setResourceAccess(Map<String, Access> resourceAccess) {
+        this.resourceAccess = resourceAccess;
+    }
+
+
+
+
+    /**
+     * Does the realm require verifying the caller?
+     *
+     * @return
+     */
+    @JsonIgnore
+    public boolean isVerifyCaller() {
+        if (getRealmAccess() != null && getRealmAccess().getVerifyCaller() != null)
+            return getRealmAccess().getVerifyCaller().booleanValue();
+        return false;
+    }
+
+    /**
+     * Does the resource override the requirement of verifying the caller?
+     *
+     * @param resource
+     * @return
+     */
+    @JsonIgnore
+    public boolean isVerifyCaller(String resource) {
+        Access access = getResourceAccess(resource);
+        if (access != null && access.getVerifyCaller() != null) return access.getVerifyCaller().booleanValue();
+        return false;
+    }
+
+    @JsonIgnore
+    public Access getResourceAccess(String resource) {
+        return resourceAccess == null ? null : resourceAccess.get(resource);
+    }
+
+    public Access addAccess(String service) {
+        if (resourceAccess == null) {
+            resourceAccess = new HashMap<>();
+        }
+
+        Access access = resourceAccess.get(service);
+        if (access != null) return access;
+        access = new Access();
+        resourceAccess.put(service, access);
+        return access;
+    }
+
+    @Override
+    public AccessToken id(String id) {
+        return (AccessToken) super.id(id);
+    }
+
+    @Override
+    public AccessToken issuer(String issuer) {
+        return (AccessToken) super.issuer(issuer);
+    }
+
+    @Override
+    public AccessToken subject(String subject) {
+        return (AccessToken) super.subject(subject);
+    }
+
+    @Override
+    public AccessToken type(String type) {
+        return (AccessToken) super.type(type);
+    }
+
+    public Set<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(Set<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    public Access getRealmAccess() {
+        return realmAccess;
+    }
+
+    public void setRealmAccess(Access realmAccess) {
+        this.realmAccess = realmAccess;
+    }
+
+    public Set<String> getTrustedCertificates() {
+        return trustedCertificates;
+    }
+
+    public void setTrustedCertificates(Set<String> trustedCertificates) {
+        this.trustedCertificates = trustedCertificates;
+    }
+
+    @Override
+    public AccessToken issuedFor(String issuedFor) {
+        return (AccessToken)super.issuedFor(issuedFor);
+    }
+
+    public Authorization getAuthorization() {
+        return authorization;
+    }
+
+    public void setAuthorization(Authorization authorization) {
+        this.authorization = authorization;
+    }
+
+    public Confirmation getConfirmation() {
+        return confirmation;
+    }
+
+    public void setConfirmation(Confirmation confirmation) {
+        this.confirmation = confirmation;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public TokenCategory getCategory() {
+        return TokenCategory.ACCESS;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
+++ b/client-core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OAuth 2.0 Access Token Response json
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class AccessTokenResponse {
+    @JsonProperty("access_token")
+    protected String token;
+
+    @JsonProperty("expires_in")
+    protected long expiresIn;
+
+    @JsonProperty("refresh_expires_in")
+    protected long refreshExpiresIn;
+
+    @JsonProperty("refresh_token")
+    protected String refreshToken;
+
+    @JsonProperty("token_type")
+    protected String tokenType;
+
+    @JsonProperty("id_token")
+    protected String idToken;
+
+    @JsonProperty("not-before-policy")
+    protected int notBeforePolicy;
+
+    @JsonProperty("session_state")
+    protected String sessionState;
+
+    protected Map<String, Object> otherClaims = new HashMap<>();
+
+    // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+    @JsonProperty("scope")
+    protected String scope;
+
+    @JsonProperty("error")
+    protected String error;
+
+    @JsonProperty("error_description")
+    protected String errorDescription;
+
+    @JsonProperty("error_uri")
+    protected String errorUri;
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(long expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public long getRefreshExpiresIn() {
+        return refreshExpiresIn;
+    }
+
+    public void setRefreshExpiresIn(long refreshExpiresIn) {
+        this.refreshExpiresIn = refreshExpiresIn;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    public String getIdToken() {
+        return idToken;
+    }
+
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
+    }
+
+    public int getNotBeforePolicy() {
+        return notBeforePolicy;
+    }
+
+    public void setNotBeforePolicy(int notBeforePolicy) {
+        this.notBeforePolicy = notBeforePolicy;
+    }
+
+    public String getSessionState() {
+        return sessionState;
+    }
+
+    public void setSessionState(String sessionState) {
+        this.sessionState = sessionState;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getOtherClaims() {
+        return otherClaims;
+    }
+
+    @JsonAnySetter
+    public void setOtherClaims(String name, Object value) {
+        otherClaims.put(name, value);
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
+    public void setErrorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+
+    public String getErrorUri() {
+        return errorUri;
+    }
+
+    public void setErrorUri(String errorUri) {
+        this.errorUri = errorUri;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/AddressClaimSet.java
+++ b/client-core/src/main/java/org/keycloak/representations/AddressClaimSet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class AddressClaimSet {
+    public static final String FORMATTED = "formatted";
+    public static final String STREET_ADDRESS = "street_address";
+    public static final String LOCALITY = "locality";
+    public static final String REGION = "region";
+    public static final String POSTAL_CODE = "postal_code";
+    public static final String COUNTRY = "country";
+
+    @JsonProperty(FORMATTED)
+    protected String formattedAddress;
+
+    @JsonProperty(STREET_ADDRESS)
+    protected String streetAddress;
+
+    @JsonProperty(LOCALITY)
+    protected String locality;
+
+    @JsonProperty(REGION)
+    protected String region;
+
+    @JsonProperty(POSTAL_CODE)
+    protected String postalCode;
+
+    @JsonProperty(COUNTRY)
+    protected String country;
+
+    public String getFormattedAddress() {
+        return this.formattedAddress;
+    }
+
+    public void setFormattedAddress(String formattedAddress) {
+        this.formattedAddress = formattedAddress;
+    }
+
+    public String getStreetAddress() {
+        return this.streetAddress;
+    }
+
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getLocality() {
+        return this.locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public String getRegion() {
+        return this.region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getPostalCode() {
+        return this.postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/IDToken.java
+++ b/client-core/src/main/java/org/keycloak/representations/IDToken.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.TokenCategory;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class IDToken extends JsonWebToken {
+    public static final String NONCE = "nonce";
+    public static final String AUTH_TIME = "auth_time";
+    public static final String SESSION_STATE = "session_state";
+    public static final String AT_HASH = "at_hash";
+    public static final String C_HASH = "c_hash";
+    public static final String NAME = "name";
+    public static final String GIVEN_NAME = "given_name";
+    public static final String FAMILY_NAME = "family_name";
+    public static final String MIDDLE_NAME = "middle_name";
+    public static final String NICKNAME = "nickname";
+    public static final String PREFERRED_USERNAME = "preferred_username";
+    public static final String PROFILE = "profile";
+    public static final String PICTURE = "picture";
+    public static final String WEBSITE = "website";
+    public static final String EMAIL = "email";
+    public static final String EMAIL_VERIFIED = "email_verified";
+    public static final String GENDER = "gender";
+    public static final String BIRTHDATE = "birthdate";
+    public static final String ZONEINFO = "zoneinfo";
+    public static final String LOCALE = "locale";
+    public static final String PHONE_NUMBER = "phone_number";
+    public static final String PHONE_NUMBER_VERIFIED = "phone_number_verified";
+    public static final String ADDRESS = "address";
+    public static final String UPDATED_AT = "updated_at";
+    public static final String CLAIMS_LOCALES = "claims_locales";
+    public static final String ACR = "acr";
+    public static final String SESSION_ID = "sid";
+
+    // Financial API - Part 2: Read and Write API Security Profile
+    // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
+    public static final String S_HASH = "s_hash";
+
+    // NOTE!!!  WE used to use @JsonUnwrapped on a UserClaimSet object.  This screws up otherClaims and the won't work
+    // anymore.  So don't have any @JsonUnwrapped!
+    @JsonProperty(NONCE)
+    protected String nonce;
+
+    protected Long auth_time;
+
+    @JsonProperty(SESSION_ID)
+    protected String sessionId;
+
+    @JsonProperty(AT_HASH)
+    protected String accessTokenHash;
+
+    @JsonProperty(C_HASH)
+    protected String codeHash;
+
+    @JsonProperty(NAME)
+    protected String name;
+
+    @JsonProperty(GIVEN_NAME)
+    protected String givenName;
+
+    @JsonProperty(FAMILY_NAME)
+    protected String familyName;
+
+    @JsonProperty(MIDDLE_NAME)
+    protected String middleName;
+
+    @JsonProperty(NICKNAME)
+    protected String nickName;
+
+    @JsonProperty(PREFERRED_USERNAME)
+    protected String preferredUsername;
+
+    @JsonProperty(PROFILE)
+    protected String profile;
+
+    @JsonProperty(PICTURE)
+    protected String picture;
+
+    @JsonProperty(WEBSITE)
+    protected String website;
+
+    @JsonProperty(EMAIL)
+    protected String email;
+
+    @JsonProperty(EMAIL_VERIFIED)
+    protected Boolean emailVerified;
+
+    @JsonProperty(GENDER)
+    protected String gender;
+
+    @JsonProperty(BIRTHDATE)
+    protected String birthdate;
+
+    @JsonProperty(ZONEINFO)
+    protected String zoneinfo;
+
+    @JsonProperty(LOCALE)
+    protected String locale;
+
+    @JsonProperty(PHONE_NUMBER)
+    protected String phoneNumber;
+
+    @JsonProperty(PHONE_NUMBER_VERIFIED)
+    protected Boolean phoneNumberVerified;
+
+    @JsonProperty(ADDRESS)
+    protected AddressClaimSet address;
+
+    @JsonProperty(UPDATED_AT)
+    protected Long updatedAt;
+
+    @JsonProperty(CLAIMS_LOCALES)
+    protected String claimsLocales;
+
+    @JsonProperty(ACR)
+    protected String acr;
+
+    // Financial API - Part 2: Read and Write API Security Profile
+    // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
+    @JsonProperty(S_HASH)
+    protected String stateHash; 
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public Long getAuth_time() {
+        return auth_time;
+    }
+
+    public void setAuth_time(Long auth_time) {
+        this.auth_time = auth_time;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    /**
+     * @deprecated Use {@link #getSessionId()} instead.
+     */
+    @Deprecated
+    @JsonIgnore
+    public String getSessionState() {
+        return sessionId;
+    }
+
+    public String getAccessTokenHash() {
+        return accessTokenHash;
+    }
+
+    public void setAccessTokenHash(String accessTokenHash) {
+        this.accessTokenHash = accessTokenHash;
+    }
+
+    public String getCodeHash() {
+        return codeHash;
+    }
+
+    public void setCodeHash(String codeHash) {
+        this.codeHash = codeHash;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getGivenName() {
+        return this.givenName;
+    }
+
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    public String getFamilyName() {
+        return this.familyName;
+    }
+
+    public void setFamilyName(String familyName) {
+        this.familyName = familyName;
+    }
+
+    public String getMiddleName() {
+        return this.middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getNickName() {
+        return this.nickName;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public String getPreferredUsername() {
+        return this.preferredUsername;
+    }
+
+    public void setPreferredUsername(String preferredUsername) {
+        this.preferredUsername = preferredUsername;
+    }
+
+    public String getProfile() {
+        return this.profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    public String getPicture() {
+        return this.picture;
+    }
+
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    public String getWebsite() {
+        return this.website;
+    }
+
+    public void setWebsite(String website) {
+        this.website = website;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Boolean getEmailVerified() {
+        return this.emailVerified;
+    }
+
+    public void setEmailVerified(Boolean emailVerified) {
+        this.emailVerified = emailVerified;
+    }
+
+    public String getGender() {
+        return this.gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public String getBirthdate() {
+        return this.birthdate;
+    }
+
+    public void setBirthdate(String birthdate) {
+        this.birthdate = birthdate;
+    }
+
+    public String getZoneinfo() {
+        return this.zoneinfo;
+    }
+
+    public void setZoneinfo(String zoneinfo) {
+        this.zoneinfo = zoneinfo;
+    }
+
+    public String getLocale() {
+        return this.locale;
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+    public String getPhoneNumber() {
+        return this.phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Boolean getPhoneNumberVerified() {
+        return this.phoneNumberVerified;
+    }
+
+    public void setPhoneNumberVerified(Boolean phoneNumberVerified) {
+        this.phoneNumberVerified = phoneNumberVerified;
+    }
+
+    public AddressClaimSet getAddress() {
+        return address;
+    }
+
+    public void setAddress(AddressClaimSet address) {
+        this.address = address;
+    }
+
+    public Long getUpdatedAt() {
+        return this.updatedAt;
+    }
+
+    public void setUpdatedAt(Long updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getClaimsLocales() {
+        return this.claimsLocales;
+    }
+
+    public void setClaimsLocales(String claimsLocales) {
+        this.claimsLocales = claimsLocales;
+    }
+
+    public String getAcr() {
+        return acr;
+    }
+
+    public void setAcr(String acr) {
+        this.acr = acr;
+    }
+
+    // Financial API - Part 2: Read and Write API Security Profile
+    // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
+    public String getStateHash() {
+        return stateHash;
+    }
+
+    public void setStateHash(String stateHash) {
+        this.stateHash = stateHash;
+    }
+
+    @Override
+    public TokenCategory getCategory() {
+        return TokenCategory.ID;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/JsonWebToken.java
+++ b/client-core/src/main/java/org/keycloak/representations/JsonWebToken.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.keycloak.Token;
+import org.keycloak.TokenCategory;
+import org.keycloak.common.util.Time;
+import org.keycloak.json.StringOrArrayDeserializer;
+import org.keycloak.json.StringOrArraySerializer;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class JsonWebToken implements Serializable, Token {
+    public static final String AZP = "azp";
+    public static final String SUBJECT = "sub";
+
+    @JsonProperty("jti")
+    protected String id;
+
+    protected Long exp;
+    protected Long nbf;
+    protected Long iat;
+
+    @JsonProperty("iss")
+    protected String issuer;
+    @JsonProperty("aud")
+    @JsonSerialize(using = StringOrArraySerializer.class)
+    @JsonDeserialize(using = StringOrArrayDeserializer.class)
+    protected String[] audience;
+    @JsonProperty(SUBJECT)
+    protected String subject;
+    @JsonProperty("typ")
+    protected String type;
+    @JsonProperty(AZP)
+    public String issuedFor;
+    protected Map<String, Object> otherClaims = new HashMap<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public JsonWebToken id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public Long getExp() {
+        return exp;
+    }
+
+    public JsonWebToken exp(Long exp) {
+        this.exp = exp;
+        return this;
+    }
+
+    @JsonIgnore
+    public boolean isExpired() {
+        return exp != null && exp != 0 && Time.currentTime() > exp;
+    }
+
+    public Long getNbf() {
+        return nbf;
+    }
+
+    public JsonWebToken nbf(Long nbf) {
+        this.nbf = nbf;
+        return this;
+    }
+
+    @JsonIgnore
+    public boolean isNotBefore(long allowedTimeSkew) {
+        return nbf == null || Time.currentTime() + allowedTimeSkew >= nbf;
+    }
+
+    /**
+     * Tests that the token is not expired and is not-before.
+     *
+     * @return
+     */
+    @JsonIgnore
+    public boolean isActive() {
+        return isActive(0);
+    }
+
+    @JsonIgnore
+    public boolean isActive(int allowedTimeSkew) {
+        return !isExpired() && isNotBefore(allowedTimeSkew);
+    }
+
+    /**
+     * @param sessionStarted Time in seconds
+     * @return true if the particular token was issued before the given session start time. Which means that token cannot be issued by the particular session
+     */
+    @JsonIgnore
+    public boolean isIssuedBeforeSessionStart(long sessionStarted) {
+        return getIat() + 1 < sessionStarted;
+    }
+
+    public Long getIat() {
+        return iat;
+    }
+
+    /**
+     * Set issuedAt to the current time
+     */
+    @JsonIgnore
+    public JsonWebToken issuedNow() {
+        iat = (long) Time.currentTime();
+        return this;
+    }
+
+    public JsonWebToken iat(Long iat) {
+        this.iat = iat;
+        return this;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public JsonWebToken issuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+
+    @JsonIgnore
+    public String[] getAudience() {
+        return audience;
+    }
+
+    public boolean hasAudience(String audience) {
+        if (this.audience == null) return false;
+        for (String a : this.audience) {
+            if (a.equals(audience)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean hasAnyAudience(List<String> audiences) {
+        String[] auds = getAudience();
+
+        if (auds == null) {
+            return false;
+        }
+
+        for (String aud : auds) {
+            if (audiences.contains(aud)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public JsonWebToken audience(String... audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    public JsonWebToken addAudience(String audience) {
+        if (this.audience == null) {
+            this.audience = new String[] { audience };
+        } else {
+            // Check if audience is already there
+            for (String aud : this.audience) {
+                if (audience.equals(aud)) {
+                    return this;
+                }
+            }
+
+            String[] newAudience = Arrays.copyOf(this.audience, this.audience.length + 1);
+            newAudience[this.audience.length] = audience;
+            this.audience = newAudience;
+        }
+        return this;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public JsonWebToken subject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public JsonWebToken type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * OAuth client the token was issued for.
+     *
+     * @return
+     */
+    public String getIssuedFor() {
+        return issuedFor;
+    }
+
+    public JsonWebToken issuedFor(String issuedFor) {
+        this.issuedFor = issuedFor;
+        return this;
+    }
+
+    /**
+     * This is a map of any other claims and data that might be in the IDToken.  Could be custom claims set up by the auth server
+     *
+     * @return
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getOtherClaims() {
+        return otherClaims;
+    }
+
+    @JsonAnySetter
+    public void setOtherClaims(String name, Object value) {
+        otherClaims.put(name, value);
+    }
+
+    @Override
+    public TokenCategory getCategory() {
+        return TokenCategory.INTERNAL;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/KeyStoreConfig.java
+++ b/client-core/src/main/java/org/keycloak/representations/KeyStoreConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.keycloak.representations;
+
+/**
+ * Configuration of KeyStore.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class KeyStoreConfig {
+
+    protected Boolean realmCertificate;
+    protected String storePassword;
+    protected String keyPassword;
+    protected String keyAlias;
+    protected String realmAlias;
+    protected String format;
+
+    public Boolean isRealmCertificate() {
+        return realmCertificate;
+    }
+
+    public void setRealmCertificate(Boolean realmCertificate) {
+        this.realmCertificate = realmCertificate;
+    }
+
+    public String getStorePassword() {
+        return storePassword;
+    }
+
+    public void setStorePassword(String storePassword) {
+        this.storePassword = storePassword;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+
+    public void setKeyPassword(String keyPassword) {
+        this.keyPassword = keyPassword;
+    }
+
+    public String getKeyAlias() {
+        return keyAlias;
+    }
+
+    public void setKeyAlias(String keyAlias) {
+        this.keyAlias = keyAlias;
+    }
+
+    public String getRealmAlias() {
+        return realmAlias;
+    }
+
+    public void setRealmAlias(String realmAlias) {
+        this.realmAlias = realmAlias;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/adapters/action/GlobalRequestResult.java
+++ b/client-core/src/main/java/org/keycloak/representations/adapters/action/GlobalRequestResult.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.adapters.action;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Result of the "global" request (like push notBefore or logoutAll), which is send to all cluster nodes
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class GlobalRequestResult {
+
+    private List<String> successRequests;
+    private List<String> failedRequests;
+
+    public void addSuccessRequest(String reqUri) {
+        if (successRequests == null) {
+            successRequests = new ArrayList<>();
+        }
+        successRequests.add(reqUri);
+    }
+
+    public void addFailedRequest(String reqUri) {
+        if (failedRequests == null) {
+            failedRequests = new ArrayList<>();
+        }
+        failedRequests.add(reqUri);
+    }
+
+    public void addAllSuccessRequests(List<String> reqUris) {
+        if (successRequests == null) {
+            successRequests = new ArrayList<>();
+        }
+        successRequests.addAll(reqUris);
+    }
+
+    public void addAllFailedRequests(List<String> reqUris) {
+        if (failedRequests == null) {
+            failedRequests = new ArrayList<>();
+        }
+        failedRequests.addAll(reqUris);
+    }
+
+    public void addAll(GlobalRequestResult merged) {
+        if (merged.getSuccessRequests() != null && merged.getSuccessRequests().size() > 0) {
+            addAllSuccessRequests(merged.getSuccessRequests());
+        }
+        if (merged.getFailedRequests() != null && merged.getFailedRequests().size() > 0) {
+            addAllFailedRequests(merged.getFailedRequests());
+        }
+    }
+
+    public List<String> getSuccessRequests() {
+        return successRequests;
+    }
+
+    public List<String> getFailedRequests() {
+        return failedRequests;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AbstractAuthenticationExecutionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AbstractAuthenticationExecutionRepresentation.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.io.Serializable;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public class AbstractAuthenticationExecutionRepresentation implements Serializable {
+
+    private String authenticatorConfig;
+    private String authenticator;
+    private boolean authenticatorFlow;
+    private String requirement;
+    private Integer priority;
+
+    public String getAuthenticatorConfig() {
+        return authenticatorConfig;
+    }
+
+    public void setAuthenticatorConfig(String authenticatorConfig) {
+        this.authenticatorConfig = authenticatorConfig;
+    }
+
+    public String getAuthenticator() {
+        return authenticator;
+    }
+
+    public void setAuthenticator(String authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    public String getRequirement() {
+        return requirement;
+    }
+
+    public void setRequirement(String requirement) {
+        this.requirement = requirement;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    /**
+     * Is the referenced authenticator a flow?
+     *
+     * @return
+     */
+    @Deprecated
+    private boolean autheticatorFlow;
+
+    @Deprecated
+    public boolean isAutheticatorFlow() {
+        return authenticatorFlow;
+    }
+
+    @Deprecated
+    public void setAutheticatorFlow(boolean autheticatorFlow) {
+        this.authenticatorFlow = autheticatorFlow;
+    }
+
+    /**
+     * Is the referenced authenticator a flow?
+     *
+     * @return
+     */
+    public boolean isAuthenticatorFlow() {
+        return authenticatorFlow;
+    }
+
+    public void setAuthenticatorFlow(boolean authenticatorFlow) {
+        this.authenticatorFlow = authenticatorFlow;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AbstractUserRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AbstractUserRepresentation.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.keycloak.json.StringListMapDeserializer;
+
+public abstract class AbstractUserRepresentation {
+
+    public static String USERNAME = "username";
+    public static String FIRST_NAME = "firstName";
+    public static String LAST_NAME = "lastName";
+    public static String EMAIL = "email";
+    public static String LOCALE = "locale";
+
+    protected String id;
+    protected String username;
+    protected String firstName;
+    protected String lastName;
+    protected String email;
+    protected Boolean emailVerified;
+    @JsonDeserialize(using = StringListMapDeserializer.class)
+    protected Map<String, List<String>> attributes;
+    private UserProfileMetadata userProfileMetadata;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Boolean isEmailVerified() {
+        return emailVerified;
+    }
+
+    public void setEmailVerified(Boolean emailVerified) {
+        this.emailVerified = emailVerified;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * Returns all the attributes set to this user except the root attributes.
+     *
+     * @return the user attributes.
+     */
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    /**
+     * Returns all the user attributes including the root attributes.
+     *
+     * @return all the user attributes.
+     */
+    @JsonIgnore
+    public Map<String, List<String>> getRawAttributes() {
+        Map<String, List<String>> attrs = new HashMap<>(Optional.ofNullable(attributes).orElse(new HashMap<>()));
+
+        if (username != null)
+            attrs.put(USERNAME, Collections.singletonList(getUsername()));
+        else
+            attrs.remove(USERNAME);
+
+        if (email != null)
+            attrs.put(EMAIL, Collections.singletonList(getEmail()));
+        else
+            attrs.remove(EMAIL);
+
+        if (lastName != null)
+            attrs.put(LAST_NAME, Collections.singletonList(getLastName()));
+
+        if (firstName != null)
+            attrs.put(FIRST_NAME, Collections.singletonList(getFirstName()));
+
+        return attrs;
+    }
+
+    public void setAttributes(Map<String, List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <R extends AbstractUserRepresentation> R singleAttribute(String name, String value) {
+        if (this.attributes == null) this.attributes=new HashMap<>();
+        attributes.put(name, (value == null ? Collections.emptyList() : Arrays.asList(value)));
+        return (R) this;
+    }
+
+    public String firstAttribute(String key) {
+        return this.attributes == null ? null : this.attributes.get(key) == null ? null : this.attributes.get(key).isEmpty()? null : this.attributes.get(key).get(0);
+    }
+
+    public void setUserProfileMetadata(UserProfileMetadata userProfileMetadata) {
+        this.userProfileMetadata = userProfileMetadata;
+    }
+
+    public UserProfileMetadata getUserProfileMetadata() {
+        return userProfileMetadata;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AdminEventRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AdminEventRepresentation.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class AdminEventRepresentation {
+
+    private long time;
+    private String realmId;
+    private AuthDetailsRepresentation authDetails;
+    private String operationType;
+    private String resourceType;
+    private String resourcePath;
+    private String representation;
+    private String error;
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
+    }
+
+    public AuthDetailsRepresentation getAuthDetails() {
+        return authDetails;
+    }
+
+    public void setAuthDetails(AuthDetailsRepresentation authDetails) {
+        this.authDetails = authDetails;
+    }
+
+    public String getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(String operationType) {
+        this.operationType = operationType;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getResourcePath() {
+        return resourcePath;
+    }
+
+    public void setResourcePath(String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+
+    public String getRepresentation() {
+        return representation;
+    }
+
+    public void setRepresentation(String representation) {
+        this.representation = representation;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ApplicationRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ApplicationRepresentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+@Deprecated
+public class ApplicationRepresentation extends ClientRepresentation {
+    protected String name;
+    @Deprecated
+    protected ClaimRepresentation claims;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ClaimRepresentation getClaims() {
+        return claims;
+    }
+
+    public void setClaims(ClaimRepresentation claims) {
+        this.claims = claims;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthDetailsRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthDetailsRepresentation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class AuthDetailsRepresentation {
+
+    private String realmId;
+    private String clientId;
+    private String userId;
+    private String ipAddress;
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionExportRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionExportRepresentation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class AuthenticationExecutionExportRepresentation extends AbstractAuthenticationExecutionRepresentation {
+
+    private String flowAlias;
+    private boolean userSetupAllowed;
+
+
+    public boolean isUserSetupAllowed() {
+        return userSetupAllowed;
+    }
+
+    public void setUserSetupAllowed(boolean userSetupAllowed) {
+        this.userSetupAllowed = userSetupAllowed;
+    }
+
+    /**
+     * If this execution is a flow, this is the flowId pointing to an AuthenticationFlowModel
+     *
+     * @return
+     */
+    public String getFlowAlias() {
+        return flowAlias;
+    }
+
+    public void setFlowAlias(String flowId) {
+        this.flowAlias = flowId;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionInfoRepresentation.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class AuthenticationExecutionInfoRepresentation implements Serializable {
+
+    protected String id;
+    protected String requirement;
+    protected String displayName;
+    protected String alias;
+    protected String description;
+    protected List<String> requirementChoices;
+    protected Boolean configurable;
+    protected Boolean authenticationFlow;
+    protected String providerId;
+    protected String authenticationConfig;
+    protected String flowId;
+    protected int level;
+    protected int index;
+    protected int priority;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String execution) {
+        this.id = execution;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRequirement() {
+        return requirement;
+    }
+
+    public void setRequirement(String requirement) {
+        this.requirement = requirement;
+    }
+
+    public List<String> getRequirementChoices() {
+        return requirementChoices;
+    }
+
+    public void setRequirementChoices(List<String> requirementChoices) {
+        this.requirementChoices = requirementChoices;
+    }
+
+    public Boolean getConfigurable() {
+        return configurable;
+    }
+
+    public void setConfigurable(Boolean configurable) {
+        this.configurable = configurable;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getAuthenticationConfig() {
+        return authenticationConfig;
+    }
+
+    public void setAuthenticationConfig(String authenticationConfig) {
+        this.authenticationConfig = authenticationConfig;
+    }
+
+    public Boolean getAuthenticationFlow() {
+        return authenticationFlow;
+    }
+
+    public void setAuthenticationFlow(Boolean authenticationFlow) {
+        this.authenticationFlow = authenticationFlow;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationExecutionRepresentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public class AuthenticationExecutionRepresentation extends AbstractAuthenticationExecutionRepresentation {
+
+    private String id;
+    private String flowId;
+    private String parentFlow;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    public String getParentFlow() {
+        return parentFlow;
+    }
+
+    public void setParentFlow(String parentFlow) {
+        this.parentFlow = parentFlow;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationFlowRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticationFlowRepresentation.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class AuthenticationFlowRepresentation implements Serializable {
+
+    private String id;
+    private String alias;
+    private String description;
+    private String providerId;
+    private boolean topLevel;
+    private boolean builtIn;
+    protected List<AuthenticationExecutionExportRepresentation> authenticationExecutions;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public boolean isTopLevel() {
+        return topLevel;
+    }
+
+    public void setTopLevel(boolean topLevel) {
+        this.topLevel = topLevel;
+    }
+
+    public boolean isBuiltIn() {
+        return builtIn;
+    }
+
+    public void setBuiltIn(boolean builtIn) {
+        this.builtIn = builtIn;
+    }
+
+    public List<AuthenticationExecutionExportRepresentation> getAuthenticationExecutions() {
+        return authenticationExecutions;
+    }
+
+    public void setAuthenticationExecutions(List<AuthenticationExecutionExportRepresentation> authenticationExecutions) {
+        this.authenticationExecutions = authenticationExecutions;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigInfoRepresentation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public class AuthenticatorConfigInfoRepresentation {
+
+    protected String name;
+    protected String providerId;
+    protected String helpText;
+
+    protected List<ConfigPropertyRepresentation> properties;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+}
+

--- a/client-core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigRepresentation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class AuthenticatorConfigRepresentation implements Serializable {
+
+    private String id;
+    private String alias;
+    private Map<String, String> config = new HashMap<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/CertificateRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/CertificateRepresentation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * PEM values of key and certificate
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class CertificateRepresentation {
+
+    protected String privateKey;
+    protected String publicKey;
+    protected String certificate;
+    protected String kid;
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public String getKid() {
+        return kid;
+    }
+
+    public void setKid(String kid) {
+        this.kid = kid;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClaimRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClaimRepresentation.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ClaimRepresentation {
+    protected boolean name;
+    protected boolean username;
+    protected boolean profile;
+    protected boolean picture;
+    protected boolean website;
+    protected boolean email;
+    protected boolean gender;
+    protected boolean locale;
+    protected boolean address;
+    protected boolean phone;
+
+    public boolean getName() {
+        return name;
+    }
+
+    public void setName(boolean name) {
+        this.name = name;
+    }
+
+    public boolean getUsername() {
+        return username;
+    }
+
+    public void setUsername(boolean username) {
+        this.username = username;
+    }
+
+    public boolean getProfile() {
+        return profile;
+    }
+
+    public void setProfile(boolean profile) {
+        this.profile = profile;
+    }
+
+    public boolean getPicture() {
+        return picture;
+    }
+
+    public void setPicture(boolean picture) {
+        this.picture = picture;
+    }
+
+    public boolean getWebsite() {
+        return website;
+    }
+
+    public void setWebsite(boolean website) {
+        this.website = website;
+    }
+
+    public boolean getEmail() {
+        return email;
+    }
+
+    public void setEmail(boolean email) {
+        this.email = email;
+    }
+
+    public boolean getGender() {
+        return gender;
+    }
+
+    public void setGender(boolean gender) {
+        this.gender = gender;
+    }
+
+    public boolean getLocale() {
+        return locale;
+    }
+
+    public void setLocale(boolean locale) {
+        this.locale = locale;
+    }
+
+    public boolean getAddress() {
+        return address;
+    }
+
+    public void setAddress(boolean address) {
+        this.address = address;
+    }
+
+    public boolean getPhone() {
+        return phone;
+    }
+
+    public void setPhone(boolean phone) {
+        this.phone = phone;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClaimRepresentation that = (ClaimRepresentation) o;
+
+        if (address != that.address) return false;
+        if (email != that.email) return false;
+        if (gender != that.gender) return false;
+        if (locale != that.locale) return false;
+        if (name != that.name) return false;
+        if (phone != that.phone) return false;
+        if (picture != that.picture) return false;
+        if (profile != that.profile) return false;
+        if (username != that.username) return false;
+        if (website != that.website) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (name ? 1 : 0);
+        result = 31 * result + (username ? 1 : 0);
+        result = 31 * result + (profile ? 1 : 0);
+        result = 31 * result + (picture ? 1 : 0);
+        result = 31 * result + (website ? 1 : 0);
+        result = 31 * result + (email ? 1 : 0);
+        result = 31 * result + (gender ? 1 : 0);
+        result = 31 * result + (locale ? 1 : 0);
+        result = 31 * result + (address ? 1 : 0);
+        result = 31 * result + (phone ? 1 : 0);
+        return result;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientInitialAccessCreatePresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientInitialAccessCreatePresentation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ClientInitialAccessCreatePresentation {
+
+    private Integer expiration;
+
+    private Integer count;
+
+    public ClientInitialAccessCreatePresentation() {
+    }
+
+    public ClientInitialAccessCreatePresentation(Integer expiration, Integer count) {
+        this.expiration = expiration;
+        this.count = count;
+    }
+
+    public Integer getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Integer expiration) {
+        this.expiration = expiration;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientInitialAccessPresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientInitialAccessPresentation.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ClientInitialAccessPresentation {
+
+    private String id;
+
+    private String token;
+
+    private Integer timestamp;
+
+    private Integer expiration;
+
+    private Integer count;
+
+    private Integer remainingCount;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Integer getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Integer timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Integer getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Integer expiration) {
+        this.expiration = expiration;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public Integer getRemainingCount() {
+        return remainingCount;
+    }
+
+    public void setRemainingCount(Integer remainingCount) {
+        this.remainingCount = remainingCount;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientMappingsRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientMappingsRepresentation.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ClientMappingsRepresentation {
+    protected String id;
+    protected String client;
+
+    protected List<RoleRepresentation> mappings;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    public List<RoleRepresentation> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<RoleRepresentation> mappings) {
+        this.mappings = mappings;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPoliciesRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPoliciesRepresentation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * Client Policies' (the set of all Client Policy) external representation class
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientPoliciesRepresentation {
+    protected List<ClientPolicyRepresentation> policies = new ArrayList<>();
+    private List<ClientPolicyRepresentation> globalPolicies;
+
+    public List<ClientPolicyRepresentation> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(List<ClientPolicyRepresentation> policies) {
+        this.policies = policies;
+    }
+
+    public List<ClientPolicyRepresentation> getGlobalPolicies() {
+        return globalPolicies;
+    }
+
+    public void setGlobalPolicies(List<ClientPolicyRepresentation> globalPolicies) {
+        this.globalPolicies = globalPolicies;
+    }
+
+    @Override
+    public int hashCode() {
+        return JsonSerialization.mapper.convertValue(this, JsonNode.class).hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ClientPoliciesRepresentation)) return false;
+        JsonNode jsonNode = JsonSerialization.mapper.convertValue(this, JsonNode.class);
+        JsonNode jsonNodeThat = JsonSerialization.mapper.convertValue(obj, JsonNode.class);
+        return jsonNode.equals(jsonNodeThat);
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionConfigurationRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionConfigurationRepresentation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Just adds some type-safety to the ClientPolicyConditionConfiguration
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientPolicyConditionConfigurationRepresentation {
+
+    private Map<String, Object> configAsMap = new HashMap<>();
+
+    @JsonProperty("is-negative-logic")
+    private Boolean negativeLogic;
+
+    public Boolean isNegativeLogic() {
+        return negativeLogic;
+    }
+
+    public void setNegativeLogic(Boolean negativeLogic) {
+        this.negativeLogic = negativeLogic;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getConfigAsMap() {
+        return configAsMap;
+    }
+
+    @JsonAnySetter
+    public void setConfigAsMap(String name, Object value) {
+        this.configAsMap.put(name, value);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyConditionRepresentation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ClientPolicyConditionRepresentation {
+
+    @JsonProperty("condition")
+    private String conditionProviderId;
+
+    @JsonProperty("configuration")
+    private JsonNode configuration;
+
+    public String getConditionProviderId() {
+        return conditionProviderId;
+    }
+
+    public void setConditionProviderId(String conditionProviderId) {
+        this.conditionProviderId = conditionProviderId;
+    }
+
+    public JsonNode getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(JsonNode configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientPolicyConditionRepresentation that = (ClientPolicyConditionRepresentation) o;
+        return Objects.equals(conditionProviderId, that.conditionProviderId) && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(conditionProviderId, configuration);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorConfigurationRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorConfigurationRepresentation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+/**
+ * Just adds some type-safety to the ClientPolicyExecutorConfiguration
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ClientPolicyExecutorConfigurationRepresentation {
+
+    private Map<String, Object> configAsMap = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getConfigAsMap() {
+        return configAsMap;
+    }
+
+    @JsonAnySetter
+    public void setConfigAsMap(String name, Object value) {
+        this.configAsMap.put(name, value);
+    }
+
+    public boolean validateConfig(){
+        return  true;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyExecutorRepresentation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ClientPolicyExecutorRepresentation {
+
+    @JsonProperty("executor")
+    private String executorProviderId;
+
+    @JsonProperty("configuration")
+    private JsonNode configuration;
+
+    public String getExecutorProviderId() {
+        return executorProviderId;
+    }
+
+    public void setExecutorProviderId(String providerId) {
+        this.executorProviderId = providerId;
+    }
+
+    public JsonNode getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(JsonNode configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientPolicyExecutorRepresentation that = (ClientPolicyExecutorRepresentation) o;
+        return Objects.equals(executorProviderId, that.executorProviderId) && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(executorProviderId, configuration);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientPolicyRepresentation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Client Policy's external representation class
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientPolicyRepresentation {
+
+    protected String name;
+    protected String description;
+    protected Boolean enabled;
+    protected List<ClientPolicyConditionRepresentation> conditions;
+    protected List<String> profiles;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<ClientPolicyConditionRepresentation> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List<ClientPolicyConditionRepresentation> conditions) {
+        this.conditions = conditions;
+    }
+
+    public List<String> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(List<String> profiles) {
+        this.profiles = profiles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientPolicyRepresentation that = (ClientPolicyRepresentation) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(enabled, that.enabled) && Objects.equals(conditions, that.conditions) && Objects.equals(profiles, that.profiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, enabled, conditions, profiles);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientProfileRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientProfileRepresentation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Client Profile's external representation class
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientProfileRepresentation {
+
+    protected String name;
+    protected String description;
+    protected List<ClientPolicyExecutorRepresentation> executors;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<ClientPolicyExecutorRepresentation> getExecutors() {
+        return executors;
+    }
+
+    public void setExecutors(List<ClientPolicyExecutorRepresentation> executors) {
+        this.executors = executors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientProfileRepresentation that = (ClientProfileRepresentation) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(executors, that.executors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, executors);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientProfilesRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientProfilesRepresentation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * Client Profiles' (the set of all Client Profile) external representation class
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientProfilesRepresentation {
+
+    private List<ClientProfileRepresentation> profiles = new ArrayList<>();
+
+    // Global profiles, which are builtin in Keycloak.
+    @JsonProperty("globalProfiles")
+    private List<ClientProfileRepresentation> globalProfiles;
+
+    public List<ClientProfileRepresentation> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(List<ClientProfileRepresentation> profiles) {
+        this.profiles = profiles;
+    }
+
+    public List<ClientProfileRepresentation> getGlobalProfiles() {
+        return globalProfiles;
+    }
+
+    public void setGlobalProfiles(List<ClientProfileRepresentation> globalProfiles) {
+        this.globalProfiles = globalProfiles;
+    }
+
+    @Override
+    public int hashCode() {
+        return JsonSerialization.mapper.convertValue(this, JsonNode.class).hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ClientProfilesRepresentation)) return false;
+        JsonNode jsonNode = JsonSerialization.mapper.convertValue(this, JsonNode.class);
+        JsonNode jsonNodeThat = JsonSerialization.mapper.convertValue(obj, JsonNode.class);
+        return jsonNode.equals(jsonNodeThat);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ClientRepresentation {
+    protected String id;
+    protected String clientId;
+    protected String name;
+    protected String description;
+    protected String type;
+    protected String rootUrl;
+    protected String adminUrl;
+    protected String baseUrl;
+    protected Boolean surrogateAuthRequired;
+    protected Boolean enabled;
+    protected Boolean alwaysDisplayInConsole;
+    protected String clientAuthenticatorType;
+    protected String secret;
+    protected String registrationAccessToken;
+    @Deprecated
+    protected String[] defaultRoles;
+    protected List<String> redirectUris;
+    protected List<String> webOrigins;
+    protected Integer notBefore;
+    protected Boolean bearerOnly;
+    protected Boolean consentRequired;
+    protected Boolean standardFlowEnabled;
+    protected Boolean implicitFlowEnabled;
+    protected Boolean directAccessGrantsEnabled;
+    protected Boolean serviceAccountsEnabled;
+    protected Boolean authorizationServicesEnabled;
+    @Deprecated
+    protected Boolean directGrantsOnly;
+    protected Boolean publicClient;
+    protected Boolean frontchannelLogout;
+    protected String protocol;
+    protected Map<String, String> attributes;
+    protected Map<String, String> authenticationFlowBindingOverrides;
+    protected Boolean fullScopeAllowed;
+    protected Integer nodeReRegistrationTimeout;
+    protected Map<String, Integer> registeredNodes;
+    protected List<ProtocolMapperRepresentation> protocolMappers;
+
+    @Deprecated
+    protected String clientTemplate;
+    @Deprecated
+    private Boolean useTemplateConfig;
+    @Deprecated
+    private Boolean useTemplateScope;
+    @Deprecated
+    private Boolean useTemplateMappers;
+
+    protected List<String> defaultClientScopes;
+    protected List<String> optionalClientScopes;
+
+    private ResourceServerRepresentation authorizationSettings;
+    private Map<String, Boolean> access;
+    protected String origin;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Boolean isAlwaysDisplayInConsole() {
+        return alwaysDisplayInConsole;
+    }
+
+    public void setAlwaysDisplayInConsole(Boolean alwaysDisplayInConsole) {
+        this.alwaysDisplayInConsole = alwaysDisplayInConsole;
+    }
+
+    public Boolean isSurrogateAuthRequired() {
+        return surrogateAuthRequired;
+    }
+
+    public void setSurrogateAuthRequired(Boolean surrogateAuthRequired) {
+        this.surrogateAuthRequired = surrogateAuthRequired;
+    }
+
+    public String getRootUrl() {
+        return rootUrl;
+    }
+
+    public void setRootUrl(String rootUrl) {
+        this.rootUrl = rootUrl;
+    }
+
+    public String getAdminUrl() {
+        return adminUrl;
+    }
+
+    public void setAdminUrl(String adminUrl) {
+        this.adminUrl = adminUrl;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getClientAuthenticatorType() {
+        return clientAuthenticatorType;
+    }
+
+    public void setClientAuthenticatorType(String clientAuthenticatorType) {
+        this.clientAuthenticatorType = clientAuthenticatorType;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getRegistrationAccessToken() {
+        return registrationAccessToken;
+    }
+
+    public void setRegistrationAccessToken(String registrationAccessToken) {
+        this.registrationAccessToken = registrationAccessToken;
+    }
+
+    public List<String> getRedirectUris() {
+        return redirectUris;
+    }
+
+    public void setRedirectUris(List<String> redirectUris) {
+        this.redirectUris = redirectUris;
+    }
+
+    public List<String> getWebOrigins() {
+        return webOrigins;
+    }
+
+    public void setWebOrigins(List<String> webOrigins) {
+        this.webOrigins = webOrigins;
+    }
+
+    @Deprecated
+    public String[] getDefaultRoles() {
+        return defaultRoles;
+    }
+
+    @Deprecated
+    public void setDefaultRoles(String[] defaultRoles) {
+        this.defaultRoles = defaultRoles;
+    }
+
+    public Integer getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(Integer notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    public Boolean isBearerOnly() {
+        return bearerOnly;
+    }
+
+    public void setBearerOnly(Boolean bearerOnly) {
+        this.bearerOnly = bearerOnly;
+    }
+
+    public Boolean isConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(Boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    public Boolean isStandardFlowEnabled() {
+        return standardFlowEnabled;
+    }
+
+    public void setStandardFlowEnabled(Boolean standardFlowEnabled) {
+        this.standardFlowEnabled = standardFlowEnabled;
+    }
+
+    public Boolean isImplicitFlowEnabled() {
+        return implicitFlowEnabled;
+    }
+
+    public void setImplicitFlowEnabled(Boolean implicitFlowEnabled) {
+        this.implicitFlowEnabled = implicitFlowEnabled;
+    }
+
+    public Boolean isDirectAccessGrantsEnabled() {
+        return directAccessGrantsEnabled;
+    }
+
+    public void setDirectAccessGrantsEnabled(Boolean directAccessGrantsEnabled) {
+        this.directAccessGrantsEnabled = directAccessGrantsEnabled;
+    }
+
+    public Boolean isServiceAccountsEnabled() {
+        return serviceAccountsEnabled;
+    }
+
+    public void setServiceAccountsEnabled(Boolean serviceAccountsEnabled) {
+        this.serviceAccountsEnabled = serviceAccountsEnabled;
+    }
+
+    public Boolean getAuthorizationServicesEnabled() {
+        if (authorizationSettings != null) {
+            return true;
+        }
+        return authorizationServicesEnabled;
+    }
+
+    public void setAuthorizationServicesEnabled(Boolean authorizationServicesEnabled) {
+        this.authorizationServicesEnabled = authorizationServicesEnabled;
+    }
+
+    @Deprecated
+    public Boolean isDirectGrantsOnly() {
+        return directGrantsOnly;
+    }
+
+    public void setDirectGrantsOnly(Boolean directGrantsOnly) {
+        this.directGrantsOnly = directGrantsOnly;
+    }
+
+    public Boolean isPublicClient() {
+        return publicClient;
+    }
+
+    public void setPublicClient(Boolean publicClient) {
+        this.publicClient = publicClient;
+    }
+
+    public Boolean isFullScopeAllowed() {
+        return fullScopeAllowed;
+    }
+
+    public void setFullScopeAllowed(Boolean fullScopeAllowed) {
+        this.fullScopeAllowed = fullScopeAllowed;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, String> getAuthenticationFlowBindingOverrides() {
+        return authenticationFlowBindingOverrides;
+    }
+
+    public void setAuthenticationFlowBindingOverrides(Map<String, String> authenticationFlowBindingOverrides) {
+        this.authenticationFlowBindingOverrides = authenticationFlowBindingOverrides;
+    }
+
+    public Integer getNodeReRegistrationTimeout() {
+        return nodeReRegistrationTimeout;
+    }
+
+    public void setNodeReRegistrationTimeout(Integer nodeReRegistrationTimeout) {
+        this.nodeReRegistrationTimeout = nodeReRegistrationTimeout;
+    }
+
+    public Map<String, Integer> getRegisteredNodes() {
+        return registeredNodes;
+    }
+
+    public void setRegisteredNodes(Map<String, Integer> registeredNodes) {
+        this.registeredNodes = registeredNodes;
+    }
+
+    public Boolean isFrontchannelLogout() {
+        return frontchannelLogout;
+    }
+
+    public void setFrontchannelLogout(Boolean frontchannelLogout) {
+        this.frontchannelLogout = frontchannelLogout;
+    }
+
+    public List<ProtocolMapperRepresentation> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void setProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+
+    @Deprecated
+    public String getClientTemplate() {
+        return clientTemplate;
+    }
+
+    @Deprecated
+    public Boolean isUseTemplateConfig() {
+        return useTemplateConfig;
+    }
+
+    @Deprecated
+    public Boolean isUseTemplateScope() {
+        return useTemplateScope;
+    }
+
+    @Deprecated
+    public Boolean isUseTemplateMappers() {
+        return useTemplateMappers;
+    }
+
+    public List<String> getDefaultClientScopes() {
+        return defaultClientScopes;
+    }
+
+    public void setDefaultClientScopes(List<String> defaultClientScopes) {
+        this.defaultClientScopes = defaultClientScopes;
+    }
+
+    public List<String> getOptionalClientScopes() {
+        return optionalClientScopes;
+    }
+
+    public void setOptionalClientScopes(List<String> optionalClientScopes) {
+        this.optionalClientScopes = optionalClientScopes;
+    }
+
+    public ResourceServerRepresentation getAuthorizationSettings() {
+        return authorizationSettings;
+    }
+
+    public void setAuthorizationSettings(ResourceServerRepresentation authorizationSettings) {
+        this.authorizationSettings = authorizationSettings;
+    }
+
+    public Map<String, Boolean> getAccess() {
+        return access;
+    }
+
+    public void setAccess(Map<String, Boolean> access) {
+        this.access = access;
+    }
+
+
+    /**
+     * Returns id of ClientStorageProvider that loaded this user
+     *
+     * @return NULL if user stored locally
+     */
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientScopeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientScopeRepresentation.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown=true) // Backwards compatibility of admin REST endpoints (ClientTemplateRepresentation was more rich)
+public class ClientScopeRepresentation {
+
+    protected String id;
+    protected String name;
+    protected String description;
+    protected String protocol;
+    protected Map<String, String> attributes;
+
+    protected List<ProtocolMapperRepresentation> protocolMappers;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+    public List<ProtocolMapperRepresentation> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void setProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof ClientScopeRepresentation)) return false;
+
+        ClientScopeRepresentation that = (ClientScopeRepresentation) o;
+        return that.getId().equals(getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientTemplateRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientTemplateRepresentation.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+@Deprecated // Use ClientScopeRepresentation instead
+public class ClientTemplateRepresentation {
+    /**
+     * Use this value in ClientRepresentation.setClientTemplate when you want to clear this value
+     */
+    public static final String NONE = "NONE";
+    protected String id;
+    protected String name;
+    protected String description;
+    protected String protocol;
+    protected Boolean fullScopeAllowed;
+    protected Boolean bearerOnly;
+    protected Boolean consentRequired;
+    protected Boolean standardFlowEnabled;
+    protected Boolean implicitFlowEnabled;
+    protected Boolean directAccessGrantsEnabled;
+    protected Boolean serviceAccountsEnabled;
+    protected Boolean publicClient;
+    protected Boolean frontchannelLogout;
+    protected Map<String, String> attributes;
+
+    protected List<ProtocolMapperRepresentation> protocolMappers;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+    public List<ProtocolMapperRepresentation> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void setProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public Boolean isFullScopeAllowed() {
+        return fullScopeAllowed;
+    }
+
+    public void setFullScopeAllowed(Boolean fullScopeAllowed) {
+        this.fullScopeAllowed = fullScopeAllowed;
+    }
+
+    public Boolean isBearerOnly() {
+        return bearerOnly;
+    }
+
+    public void setBearerOnly(Boolean bearerOnly) {
+        this.bearerOnly = bearerOnly;
+    }
+
+    public Boolean isConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(Boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    public Boolean isStandardFlowEnabled() {
+        return standardFlowEnabled;
+    }
+
+    public void setStandardFlowEnabled(Boolean standardFlowEnabled) {
+        this.standardFlowEnabled = standardFlowEnabled;
+    }
+
+    public Boolean isImplicitFlowEnabled() {
+        return implicitFlowEnabled;
+    }
+
+    public void setImplicitFlowEnabled(Boolean implicitFlowEnabled) {
+        this.implicitFlowEnabled = implicitFlowEnabled;
+    }
+
+    public Boolean isDirectAccessGrantsEnabled() {
+        return directAccessGrantsEnabled;
+    }
+
+    public void setDirectAccessGrantsEnabled(Boolean directAccessGrantsEnabled) {
+        this.directAccessGrantsEnabled = directAccessGrantsEnabled;
+    }
+
+    public Boolean isServiceAccountsEnabled() {
+        return serviceAccountsEnabled;
+    }
+
+    public void setServiceAccountsEnabled(Boolean serviceAccountsEnabled) {
+        this.serviceAccountsEnabled = serviceAccountsEnabled;
+    }
+
+    public Boolean isPublicClient() {
+        return publicClient;
+    }
+
+    public void setPublicClient(Boolean publicClient) {
+        this.publicClient = publicClient;
+    }
+
+    public Boolean isFrontchannelLogout() {
+        return frontchannelLogout;
+    }
+
+    public void setFrontchannelLogout(Boolean frontchannelLogout) {
+        this.frontchannelLogout = frontchannelLogout;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+}
+

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientTypeRepresentation.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ClientTypeRepresentation {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("provider")
+    private String provider;
+
+    @JsonProperty("parent")
+    private String parent;
+
+    @JsonProperty("config")
+    private Map<String, PropertyConfig> config;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public Map<String, PropertyConfig> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, PropertyConfig> config) {
+        this.config = config;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public static class PropertyConfig {
+
+        @JsonProperty("applicable")
+        private Boolean applicable;
+
+        @JsonProperty("value")
+        private Object value;
+
+        public Boolean getApplicable() {
+            return applicable;
+        }
+
+        public void setApplicable(Boolean applicable) {
+            this.applicable = applicable;
+        }
+
+
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ClientTypesRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ClientTypesRepresentation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ClientTypesRepresentation {
+
+    @JsonProperty("client-types")
+    private List<ClientTypeRepresentation> realmClientTypes;
+
+    @JsonProperty("global-client-types")
+    private List<ClientTypeRepresentation> globalClientTypes;
+
+    public ClientTypesRepresentation() {
+    }
+
+    public ClientTypesRepresentation(List<ClientTypeRepresentation> realmClientTypes, List<ClientTypeRepresentation> globalClientTypes) {
+        this.realmClientTypes = realmClientTypes;
+        this.globalClientTypes = globalClientTypes;
+    }
+
+    public List<ClientTypeRepresentation> getRealmClientTypes() {
+        return realmClientTypes;
+    }
+
+    public void setRealmClientTypes(List<ClientTypeRepresentation> realmClientTypes) {
+        this.realmClientTypes = realmClientTypes;
+    }
+
+    public List<ClientTypeRepresentation> getGlobalClientTypes() {
+        return globalClientTypes;
+    }
+
+    public void setGlobalClientTypes(List<ClientTypeRepresentation> globalClientTypes) {
+        this.globalClientTypes = globalClientTypes;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ComponentExportRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ComponentExportRepresentation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import org.keycloak.common.util.MultivaluedHashMap;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ComponentExportRepresentation {
+
+    private String id;
+    private String name;
+    private String providerId;
+    private String subType;
+    private MultivaluedHashMap<String, ComponentExportRepresentation> subComponents = new MultivaluedHashMap<>();
+    private MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public void setSubType(String subType) {
+        this.subType = subType;
+    }
+
+    public MultivaluedHashMap<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(MultivaluedHashMap<String, String> config) {
+        this.config = config;
+    }
+
+    public MultivaluedHashMap<String, ComponentExportRepresentation> getSubComponents() {
+        return subComponents;
+    }
+
+    public void setSubComponents(MultivaluedHashMap<String, ComponentExportRepresentation> subComponents) {
+        this.subComponents = subComponents;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ComponentRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ComponentRepresentation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import org.keycloak.common.util.MultivaluedHashMap;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ComponentRepresentation {
+
+    public static final String SECRET_VALUE = "**********";
+
+    private String id;
+    private String name;
+    private String providerId;
+    private String providerType;
+    private String parentId;
+    private String subType;
+    private MultivaluedHashMap<String, String> config;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getProviderType() {
+        return providerType;
+    }
+
+    public void setProviderType(String providerType) {
+        this.providerType = providerType;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public void setSubType(String subType) {
+        this.subType = subType;
+    }
+
+    public MultivaluedHashMap<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(MultivaluedHashMap<String, String> config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ComponentRepresentation that = (ComponentRepresentation) o;
+
+        if (!id.equals(that.id)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ComponentTypeRepresentation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class ComponentTypeRepresentation {
+    protected String id;
+    protected String helpText;
+    protected List<ConfigPropertyRepresentation> properties;
+
+    protected Map<String, Object> metadata = new HashMap<>();
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Extra information about the component that might come from annotations or interfaces that the component implements
+     * For example, if UserStorageProvider implements ImportSynchronization
+     *
+     * @return
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ConfigPropertyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ConfigPropertyRepresentation.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class ConfigPropertyRepresentation {
+    protected String name;
+    protected String label;
+    protected String helpText;
+    protected String type;
+    protected Object defaultValue;
+    protected List<String> options;
+    protected boolean secret;
+    protected boolean required;
+    private boolean readOnly;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(Object defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    public boolean isSecret() {
+        return secret;
+    }
+
+    public void setSecret(boolean secret) {
+        this.secret = secret;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import org.keycloak.common.util.MultivaluedHashMap;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class CredentialRepresentation {
+    public static final String SECRET = "secret";
+    public static final String PASSWORD = "password";
+    public static final String TOTP = "totp";
+    public static final String HOTP = "hotp";
+    public static final String KERBEROS = "kerberos";
+
+    private String id;
+    private String type;
+    private String userLabel;
+    private Long createdDate;
+    private String secretData;
+    private String credentialData;
+    private Integer priority;
+
+    private String value;
+
+    // only used when updating a credential.  Might set required action
+    protected Boolean temporary;
+
+    // All those fields are just for backwards compatibility
+    @Deprecated
+    protected String device;
+    @Deprecated
+    protected String hashedSaltedValue;
+    @Deprecated
+    protected String salt;
+    @Deprecated
+    protected Integer hashIterations;
+    @Deprecated
+    protected Integer counter;
+    @Deprecated
+    private String algorithm;
+    @Deprecated
+    private Integer digits;
+    @Deprecated
+    private Integer period;
+    @Deprecated
+    private MultivaluedHashMap<String, String> config;
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getUserLabel() {
+        return userLabel;
+    }
+    public void setUserLabel(String userLabel) {
+        this.userLabel = userLabel;
+    }
+
+    public String getSecretData() {
+        return secretData;
+    }
+    public void setSecretData(String secretData) {
+        this.secretData = secretData;
+    }
+
+    public String getCredentialData() {
+        return credentialData;
+    }
+    public void setCredentialData(String credentialData) {
+        this.credentialData = credentialData;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Boolean isTemporary() {
+        return temporary;
+    }
+    public void setTemporary(Boolean temporary) {
+        this.temporary = temporary;
+    }
+
+    @Deprecated
+    public String getDevice() {
+        return device;
+    }
+
+    @Deprecated
+    public String getHashedSaltedValue() {
+        return hashedSaltedValue;
+    }
+
+    @Deprecated
+    public String getSalt() {
+        return salt;
+    }
+
+    @Deprecated
+    public Integer getHashIterations() {
+        return hashIterations;
+    }
+
+    @Deprecated
+    public Integer getCounter() {
+        return counter;
+    }
+
+    @Deprecated
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    @Deprecated
+    public Integer getDigits() {
+        return digits;
+    }
+
+    @Deprecated
+    public Integer getPeriod() {
+        return period;
+    }
+
+    @Deprecated
+    public MultivaluedHashMap<String, String> getConfig() {
+        return config;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((createdDate == null) ? 0 : createdDate.hashCode());
+        result = prime * result + ((userLabel == null) ? 0 : userLabel.hashCode());
+        result = prime * result + ((secretData == null) ? 0 : secretData.hashCode());
+        result = prime * result + ((credentialData == null) ? 0 : credentialData.hashCode());
+        result = prime * result + ((temporary == null) ? 0 : temporary.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + ((priority == null) ? 0 : priority);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CredentialRepresentation other = (CredentialRepresentation) obj;
+        if (secretData == null) {
+            if (other.secretData != null)
+                return false;
+        } else if (!secretData.equals(other.secretData))
+            return false;
+        if (credentialData == null) {
+            if (other.credentialData != null)
+                return false;
+        } else if (!credentialData.equals(other.credentialData))
+            return false;
+        if (createdDate == null) {
+            if (other.createdDate != null)
+                return false;
+        } else if (!createdDate.equals(other.createdDate))
+            return false;
+        if (userLabel == null) {
+            if (other.userLabel != null)
+                return false;
+        } else if (!userLabel.equals(other.userLabel))
+            return false;
+        if (temporary == null) {
+            if (other.temporary != null)
+                return false;
+        } else if (!temporary.equals(other.temporary))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        if (priority == null) {
+            if (other.priority != null)
+                return false;
+        } else if (!priority.equals(other.priority))
+            return false;
+        return true;
+    }
+
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ErrorRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ErrorRepresentation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ErrorRepresentation {
+    private String field;
+    private String errorMessage;
+    private Object[] params;
+    private List<ErrorRepresentation> errors;
+
+    public ErrorRepresentation() {
+    }
+
+    public ErrorRepresentation(String field, String errorMessage, Object[] params) {
+        super();
+        this.field = field;
+        this.errorMessage = errorMessage;
+        this.params = params;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+    
+    public Object[] getParams() {
+        return this.params;
+    }
+    
+    public void setParams(Object[] params) {
+        this.params = params;
+    }
+
+    public void setErrors(List<ErrorRepresentation> errors) {
+        this.errors = errors;
+    }
+
+    public List<ErrorRepresentation> getErrors() {
+        return errors;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/EventRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/EventRepresentation.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class EventRepresentation {
+
+    private long time;
+    private String type;
+    private String realmId;
+    private String clientId;
+    private String userId;
+    private String sessionId;
+    private String ipAddress;
+    private String error;
+    private Map<String, String> details;
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EventRepresentation that = (EventRepresentation) o;
+
+        if (time != that.time) return false;
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        if (realmId != null ? !realmId.equals(that.realmId) : that.realmId != null) return false;
+        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
+        if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
+        if (sessionId != null ? !sessionId.equals(that.sessionId) : that.sessionId != null) return false;
+        if (ipAddress != null ? !ipAddress.equals(that.ipAddress) : that.ipAddress != null) return false;
+        if (error != null ? !error.equals(that.error) : that.error != null) return false;
+        return !(details != null ? !details.equals(that.details) : that.details != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (time ^ (time >>> 32));
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (realmId != null ? realmId.hashCode() : 0);
+        result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
+        result = 31 * result + (userId != null ? userId.hashCode() : 0);
+        result = 31 * result + (sessionId != null ? sessionId.hashCode() : 0);
+        result = 31 * result + (ipAddress != null ? ipAddress.hashCode() : 0);
+        result = 31 * result + (error != null ? error.hashCode() : 0);
+        result = 31 * result + (details != null ? details.hashCode() : 0);
+        return result;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/FederatedIdentityRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/FederatedIdentityRepresentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class FederatedIdentityRepresentation {
+
+    protected String identityProvider;
+    protected String userId;
+    protected String userName;
+
+    public String getIdentityProvider() {
+        return identityProvider;
+    }
+
+    public void setIdentityProvider(String identityProvider) {
+        this.identityProvider = identityProvider;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/GroupRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/GroupRepresentation.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class GroupRepresentation {
+    // For an individual group these are the sufficient minimum fields
+    // to identify a group and operate on it in a basic way
+    protected String id;
+    protected String name;
+    protected String path;
+    protected String parentId;
+    protected Long subGroupCount;
+    // For navigating a hierarchy of groups, we can also include a minimum representation of subGroups
+    // These aren't populated by default and are only included as-needed
+    protected List<GroupRepresentation> subGroups;
+    protected Map<String, List<String>>  attributes;
+    protected List<String> realmRoles;
+    protected Map<String, List<String>> clientRoles;
+
+    private Map<String, Boolean> access;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    public Long getSubGroupCount() {
+        return subGroupCount;
+    }
+
+    public void setSubGroupCount(Long subGroupCount) {
+        this.subGroupCount = subGroupCount;
+    }
+
+    public List<String> getRealmRoles() {
+        return realmRoles;
+    }
+
+    public void setRealmRoles(List<String> realmRoles) {
+        this.realmRoles = realmRoles;
+    }
+
+    public Map<String, List<String>> getClientRoles() {
+        return clientRoles;
+    }
+
+    public void setClientRoles(Map<String, List<String>> clientRoles) {
+        this.clientRoles = clientRoles;
+    }
+
+
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, List<String>>  attributes) {
+        this.attributes = attributes;
+    }
+
+    public GroupRepresentation singleAttribute(String name, String value) {
+        if (this.attributes == null) attributes = new HashMap<>();
+        attributes.put(name, Arrays.asList(value));
+        return this;
+    }
+
+    public List<GroupRepresentation> getSubGroups() {
+        if(subGroups == null) {
+            subGroups = new ArrayList<>();
+        }
+        return subGroups;
+    }
+
+    public void setSubGroups(List<GroupRepresentation> subGroups) {
+        this.subGroups = subGroups;
+    }
+
+    public Map<String, Boolean> getAccess() {
+        return access;
+    }
+
+    public void setAccess(Map<String, Boolean> access) {
+        this.access = access;
+    }
+
+    public void merge(GroupRepresentation g) {
+        merge(this, g);
+    }
+
+    private void merge(GroupRepresentation g1, GroupRepresentation g2) {
+        if(g1.equals(g2)) {
+            Map<String, GroupRepresentation> g1Children = g1.getSubGroups().stream().collect(Collectors.toMap(GroupRepresentation::getId, g -> g));
+            Map<String, GroupRepresentation> g2Children = g2.getSubGroups().stream().collect(Collectors.toMap(GroupRepresentation::getId, g -> g));
+
+            g2Children.forEach((key, value) -> {
+                if (g1Children.containsKey(key)) {
+                    merge(g1Children.get(key), value);
+                } else {
+                    g1Children.put(key, value);
+                }
+            });
+            g1.setSubGroups(new ArrayList<>(g1Children.values()));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GroupRepresentation that = (GroupRepresentation) o;
+        boolean isEqual = Objects.equals(id, that.id) && Objects.equals(parentId, that.parentId);
+        if(isEqual) {
+            return true;
+        } else {
+            return Objects.equals(name, that.name) && Objects.equals(path, that.path);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        if(id == null) {
+            return Objects.hash(name, path);
+        }
+        return Objects.hash(id, parentId);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperRepresentation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class IdentityProviderMapperRepresentation {
+    protected String id;
+    protected String name;
+    protected String identityProviderAlias;
+    protected String identityProviderMapper;
+    protected Map<String, String> config = new HashMap<>();
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIdentityProviderAlias() {
+        return identityProviderAlias;
+    }
+
+    public void setIdentityProviderAlias(String identityProviderAlias) {
+        this.identityProviderAlias = identityProviderAlias;
+    }
+
+    public String getIdentityProviderMapper() {
+        return identityProviderMapper;
+    }
+
+    public void setIdentityProviderMapper(String identityProviderMapper) {
+        this.identityProviderMapper = identityProviderMapper;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperTypeRepresentation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class IdentityProviderMapperTypeRepresentation {
+    protected String id;
+    protected String name;
+    protected String category;
+    protected String helpText;
+
+    protected List<ConfigPropertyRepresentation> properties = new LinkedList<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/IdentityProviderRepresentation.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Pedro Igor
+ */
+public class IdentityProviderRepresentation {
+
+    protected String alias;
+    protected String displayName;
+    protected String internalId;
+    protected String providerId;
+    protected boolean enabled = true;
+
+    public static final String UPFLM_ON = "on";
+    public static final String UPFLM_MISSING = "missing";
+    public static final String UPFLM_OFF = "off";
+
+    /**
+     * Mode of profile update after first login when user is created over this identity provider. Possible values:
+     * <ul>
+     * <li><code>on</code> - update profile page is presented for all users
+     * <li><code>missing</code> - update profile page is presented for users with missing some of mandatory user profile fields
+     * <li><code>off</code> - update profile page is newer shown after first login
+     * </ul>
+     * 
+     * @see #UPFLM_ON
+     * @see #UPFLM_MISSING
+     * @see #UPFLM_OFF
+     */
+    @Deprecated
+    protected String updateProfileFirstLoginMode = UPFLM_ON;
+
+    protected boolean trustEmail;
+    protected boolean storeToken;
+    protected boolean addReadTokenRoleOnCreate;
+    protected boolean authenticateByDefault;
+    protected boolean linkOnly;
+    protected String firstBrokerLoginFlowAlias;
+    protected String postBrokerLoginFlowAlias;
+    protected Map<String, String> config = new HashMap<>();
+
+    public String getInternalId() {
+        return this.internalId;
+    }
+
+    public void setInternalId(String internalId) {
+        this.internalId = internalId;
+    }
+
+    public String getAlias() {
+        return this.alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getProviderId() {
+        return this.providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public Map<String, String> getConfig() {
+        return this.config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isLinkOnly() {
+        return linkOnly;
+    }
+
+    public void setLinkOnly(boolean linkOnly) {
+        this.linkOnly = linkOnly;
+    }
+
+    /**
+     * 
+     * Deprecated because replaced by {@link #updateProfileFirstLoginMode}. Kept here to allow import of old realms.
+     * 
+     * @deprecated {@link #setUpdateProfileFirstLoginMode(String)}
+     */
+    @Deprecated
+    public void setUpdateProfileFirstLogin(boolean updateProfileFirstLogin) {
+        this.updateProfileFirstLoginMode = updateProfileFirstLogin ? UPFLM_ON : UPFLM_OFF;
+    }
+
+    /**
+     * @deprecated deprecated and replaced by configuration on IdpReviewProfileAuthenticator
+     */
+    @Deprecated
+    public String getUpdateProfileFirstLoginMode() {
+        return updateProfileFirstLoginMode;
+    }
+
+    /**
+     * @deprecated deprecated and replaced by configuration on IdpReviewProfileAuthenticator
+     */
+    @Deprecated
+    public void setUpdateProfileFirstLoginMode(String updateProfileFirstLoginMode) {
+        this.updateProfileFirstLoginMode = updateProfileFirstLoginMode;
+    }
+
+    /**
+     * @deprecated Replaced by configuration option in identity provider authenticator
+     */
+    @Deprecated
+    public boolean isAuthenticateByDefault() {
+        return authenticateByDefault;
+    }
+
+    @Deprecated
+    public void setAuthenticateByDefault(boolean authenticateByDefault) {
+        this.authenticateByDefault = authenticateByDefault;
+    }
+
+    public String getFirstBrokerLoginFlowAlias() {
+        return firstBrokerLoginFlowAlias;
+    }
+
+    public void setFirstBrokerLoginFlowAlias(String firstBrokerLoginFlowAlias) {
+        this.firstBrokerLoginFlowAlias = firstBrokerLoginFlowAlias;
+    }
+
+    public String getPostBrokerLoginFlowAlias() {
+        return postBrokerLoginFlowAlias;
+    }
+
+    public void setPostBrokerLoginFlowAlias(String postBrokerLoginFlowAlias) {
+        this.postBrokerLoginFlowAlias = postBrokerLoginFlowAlias;
+    }
+
+    public boolean isStoreToken() {
+        return this.storeToken;
+    }
+
+    public void setStoreToken(boolean storeToken) {
+        this.storeToken = storeToken;
+    }
+
+    public boolean isAddReadTokenRoleOnCreate() {
+        return addReadTokenRoleOnCreate;
+    }
+
+    public void setAddReadTokenRoleOnCreate(boolean addReadTokenRoleOnCreate) {
+        this.addReadTokenRoleOnCreate = addReadTokenRoleOnCreate;
+    }
+
+    public boolean isTrustEmail() {
+        return trustEmail;
+    }
+
+    public void setTrustEmail(boolean trustEmail) {
+        this.trustEmail = trustEmail;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.crypto.KeyUse;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class KeysMetadataRepresentation {
+
+    private Map<String, String> active;
+
+    private List<KeyMetadataRepresentation> keys;
+
+    public Map<String, String> getActive() {
+        return active;
+    }
+
+    public void setActive(Map<String, String> active) {
+        this.active = active;
+    }
+
+    public List<KeyMetadataRepresentation> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<KeyMetadataRepresentation> keys) {
+        this.keys = keys;
+    }
+
+    public static class KeyMetadataRepresentation {
+        private String providerId;
+        private long providerPriority;
+
+        private String kid;
+
+        private String status;
+
+        private String type;
+        private String algorithm;
+
+        private String publicKey;
+        private String certificate;
+        private KeyUse use;
+        private Long validTo;
+
+        public String getProviderId() {
+            return providerId;
+        }
+
+        public void setProviderId(String providerId) {
+            this.providerId = providerId;
+        }
+
+        public long getProviderPriority() {
+            return providerPriority;
+        }
+
+        public void setProviderPriority(long providerPriority) {
+            this.providerPriority = providerPriority;
+        }
+
+        public String getKid() {
+            return kid;
+        }
+
+        public void setKid(String kid) {
+            this.kid = kid;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getAlgorithm() {
+            return algorithm;
+        }
+
+        public void setAlgorithm(String algorithm) {
+            this.algorithm = algorithm;
+        }
+
+        public String getPublicKey() {
+            return publicKey;
+        }
+
+        public void setPublicKey(String publicKey) {
+            this.publicKey = publicKey;
+        }
+
+        public String getCertificate() {
+            return certificate;
+        }
+
+        public void setCertificate(String certificate) {
+            this.certificate = certificate;
+        }
+
+        public KeyUse getUse() {
+            return use;
+        }
+
+        public void setUse(KeyUse use) {
+            this.use = use;
+        }
+
+        public Long getValidTo() {
+            return validTo;
+        }
+
+        public void setValidTo(Long validTo) {
+            this.validTo = validTo;
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/LDAPCapabilityRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/LDAPCapabilityRepresentation.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Objects;
+
+import org.keycloak.common.util.ObjectUtil;
+
+/**
+ * Value object to represent an OID (object identifier) as used to describe LDAP schema, extension and features.
+ * See <a href="https://ldap.com/ldap-oid-reference-guide/">LDAP OID Reference Guide</a>.
+ *
+ * @author Lars Uffmann, 2020-05-13
+ * @since 11.0
+ */
+public class LDAPCapabilityRepresentation {
+
+    public enum CapabilityType {
+        CONTROL,
+        EXTENSION,
+        FEATURE,
+        UNKNOWN;
+
+        public static CapabilityType fromRootDseAttributeName(String attributeName) {
+            switch (attributeName) {
+                case "supportedExtension": return CapabilityType.EXTENSION;
+                case "supportedControl": return CapabilityType.CONTROL;
+                case "supportedFeatures": return CapabilityType.FEATURE;
+                default: return CapabilityType.UNKNOWN;
+            }
+        }
+    };
+
+    private Object oid;
+
+    private CapabilityType type;
+
+    public LDAPCapabilityRepresentation() {
+    }
+
+    public LDAPCapabilityRepresentation(Object oidValue, CapabilityType type) {
+        this.oid = Objects.requireNonNull(oidValue);
+        this.type = type;
+    }
+
+    public String getOid() {
+        return oid instanceof String ? (String) oid : String.valueOf(oid);
+    }
+
+    public CapabilityType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LDAPCapabilityRepresentation ldapOid = (LDAPCapabilityRepresentation) o;
+        return ObjectUtil.isEqualOrBothNull(oid, ldapOid.oid) && ObjectUtil.isEqualOrBothNull(type, ldapOid.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return oid.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(LDAPCapabilityRepresentation.class.getSimpleName() + "[ ")
+                .append("oid=" + oid + ", ")
+                .append("type=" + type + " ]")
+                .toString();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ManagementPermissionReference.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ManagementPermissionReference.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ManagementPermissionReference {
+    private boolean enabled;
+    private String resource;
+    private Map<String, String> scopePermissions;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public Map<String, String> getScopePermissions() {
+        return scopePermissions;
+    }
+
+    public void setScopePermissions(Map<String, String> scopePermissions) {
+        this.scopePermissions = scopePermissions;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ManagementPermissionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ManagementPermissionRepresentation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Bosch Software Innovations GmbH
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:leon.graser@bosch-si.com">Leon Graser</a>
+ */
+public class ManagementPermissionRepresentation {
+
+    private final boolean enabled;
+
+    public ManagementPermissionRepresentation(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/MappingsRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/MappingsRepresentation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class MappingsRepresentation {
+    protected List<RoleRepresentation> realmMappings;
+    protected Map<String, ClientMappingsRepresentation> clientMappings;
+
+    public List<RoleRepresentation> getRealmMappings() {
+        return realmMappings;
+    }
+
+    public void setRealmMappings(List<RoleRepresentation> realmMappings) {
+        this.realmMappings = realmMappings;
+    }
+
+    public Map<String, ClientMappingsRepresentation> getClientMappings() {
+        return clientMappings;
+    }
+
+    public void setClientMappings(Map<String, ClientMappingsRepresentation> clientMappings) {
+        this.clientMappings = clientMappings;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/OAuth2ErrorRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/OAuth2ErrorRepresentation.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.OAuth2Constants;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class OAuth2ErrorRepresentation {
+
+    private String error;
+    private String errorDescription;
+
+    public OAuth2ErrorRepresentation() {
+    }
+
+    public OAuth2ErrorRepresentation(String error, String errorDescription) {
+        this.error = error;
+        this.errorDescription = errorDescription;
+    }
+
+    @JsonProperty(OAuth2Constants.ERROR)
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    @JsonProperty(OAuth2Constants.ERROR_DESCRIPTION)
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
+    public void setErrorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/OAuthClientRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/OAuthClientRepresentation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+@Deprecated
+public class OAuthClientRepresentation extends ApplicationRepresentation {
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/OrganizationDomainRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/OrganizationDomainRepresentation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * Representation implementation of an organization internet domain.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class OrganizationDomainRepresentation {
+
+    private String name;
+    private boolean verified;
+
+    public OrganizationDomainRepresentation() {
+        // for reflection
+    }
+
+    public OrganizationDomainRepresentation(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isVerified() {
+        return this.verified;
+    }
+
+    public void setVerified(boolean verified) {
+        this.verified = verified;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof OrganizationDomainRepresentation)) return false;
+
+        OrganizationDomainRepresentation that = (OrganizationDomainRepresentation) o;
+        return name != null && name.equals(that.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        if (name == null) {
+            return super.hashCode();
+        }
+        return name.hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+
+public class OrganizationRepresentation {
+
+    private String id;
+    private String name;
+    private String alias;
+    private boolean enabled = true;
+    private String description;
+    private Map<String, List<String>> attributes;
+    private Set<OrganizationDomainRepresentation> domains;
+    private List<UserRepresentation> members;
+    private List<IdentityProviderRepresentation> identityProviders;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, List<String>>  attributes) {
+        this.attributes = attributes;
+    }
+
+    public OrganizationRepresentation singleAttribute(String name, String value) {
+        if (this.attributes == null) attributes = new HashMap<>();
+        attributes.put(name, Arrays.asList(value));
+        return this;
+    }
+
+    public Set<OrganizationDomainRepresentation> getDomains() {
+        return domains;
+    }
+
+    public OrganizationDomainRepresentation getDomain(String name) {
+        if (domains == null) {
+            return null;
+        }
+        return domains.stream()
+                .filter(organizationDomainRepresentation -> name.equals(organizationDomainRepresentation.getName()))
+                .findAny()
+                .orElse(null);
+    }
+
+    public void addDomain(OrganizationDomainRepresentation domain) {
+        if (domains == null) {
+            domains = new HashSet<>();
+        }
+        domains.add(domain);
+    }
+
+    public void removeDomain(OrganizationDomainRepresentation domain) {
+        if (domains == null) {
+            return;
+        }
+        getDomains().remove(domain);
+    }
+
+    public List<UserRepresentation> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<UserRepresentation> members) {
+        this.members = members;
+    }
+
+    public void addMember(UserRepresentation user) {
+        if (members == null) {
+            members = new ArrayList<>();
+        }
+        members.add(user);
+    }
+
+    public List<IdentityProviderRepresentation> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(List<IdentityProviderRepresentation> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public void addIdentityProvider(IdentityProviderRepresentation idp) {
+        if (identityProviders == null) {
+            identityProviders = new ArrayList<>();
+        }
+        identityProviders.add(idp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof OrganizationRepresentation)) return false;
+
+        OrganizationRepresentation that = (OrganizationRepresentation) o;
+
+        return id != null && id.equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return super.hashCode();
+        }
+        return id.hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/PartialImportRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/PartialImportRepresentation.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Used for partial import of users, groups, clients, roles, and identity providers.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class PartialImportRepresentation {
+    public enum Policy { SKIP, OVERWRITE, FAIL };
+
+    protected Policy policy = Policy.FAIL;
+    protected String ifResourceExists;
+    protected List<UserRepresentation> users;
+    protected List<GroupRepresentation> groups;
+    protected List<ClientRepresentation> clients;
+    protected List<IdentityProviderRepresentation> identityProviders;
+    protected List<IdentityProviderMapperRepresentation> identityProviderMappers;
+    protected RolesRepresentation roles;
+
+    public boolean hasUsers() {
+        return (users != null) && !users.isEmpty();
+    }
+
+    public boolean hasGroups() {
+        return (groups != null) && !groups.isEmpty();
+    }
+
+    public boolean hasClients() {
+        return (clients != null) && !clients.isEmpty();
+    }
+
+    public boolean hasIdps() {
+        return (identityProviders != null) && !identityProviders.isEmpty();
+    }
+
+    public boolean hasRealmRoles() {
+        return (roles != null) && (roles.getRealm() != null) && (!roles.getRealm().isEmpty());
+    }
+
+    public boolean hasClientRoles() {
+        return (roles != null) && (roles.getClient() != null) && (!roles.getClient().isEmpty());
+    }
+
+    public String getIfResourceExists() {
+        return ifResourceExists;
+    }
+
+    public void setIfResourceExists(String ifResourceExists) {
+        this.ifResourceExists = ifResourceExists;
+        this.policy = ifResourceExists != null ? Policy.valueOf(ifResourceExists) : null;
+    }
+
+    public Policy getPolicy() {
+        return this.policy;
+    }
+
+    public List<UserRepresentation> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserRepresentation> users) {
+        this.users = users;
+    }
+
+    public List<ClientRepresentation> getClients() {
+        return clients;
+    }
+
+    public List<GroupRepresentation> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<GroupRepresentation> groups) {
+        this.groups = groups;
+    }
+
+    public void setClients(List<ClientRepresentation> clients) {
+        this.clients = clients;
+    }
+
+    public List<IdentityProviderRepresentation> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(List<IdentityProviderRepresentation> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public List<IdentityProviderMapperRepresentation> getIdentityProviderMappers() {
+        return identityProviderMappers;
+    }
+
+    public void setIdentityProviderMappers(List<IdentityProviderMapperRepresentation> identityProviderMappers) {
+        this.identityProviderMappers = identityProviderMappers;
+    }
+
+    public RolesRepresentation getRoles() {
+        return roles;
+    }
+
+    public void setRoles(RolesRepresentation roles) {
+        this.roles = roles;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/PasswordPolicyTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/PasswordPolicyTypeRepresentation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class PasswordPolicyTypeRepresentation {
+
+    private String id;
+    private String displayName;
+    private String configType;
+    private String defaultValue;
+    private boolean multipleSupported;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getConfigType() {
+        return configType;
+    }
+
+    public void setConfigType(String configType) {
+        this.configType = configType;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public boolean isMultipleSupported() {
+        return multipleSupported;
+    }
+
+    public void setMultipleSupported(boolean multipleSupported) {
+        this.multipleSupported = multipleSupported;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ProtocolMapperRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ProtocolMapperRepresentation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ProtocolMapperRepresentation {
+    protected String id;
+    protected String name;
+    protected String protocol;
+    protected String protocolMapper;
+
+    @Deprecated // backwards compatibility only
+    protected boolean consentRequired;
+
+    @Deprecated // backwards compatibility only
+    protected String consentText;
+    protected Map<String, String> config = new HashMap<>();
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getProtocolMapper() {
+        return protocolMapper;
+    }
+
+    public void setProtocolMapper(String protocolMapper) {
+        this.protocolMapper = protocolMapper;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+
+    @Deprecated
+    public boolean isConsentRequired() {
+        return consentRequired;
+    }
+
+    @Deprecated
+    public String getConsentText() {
+        return consentText;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ProtocolMapperTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ProtocolMapperTypeRepresentation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ProtocolMapperTypeRepresentation {
+    protected String id;
+    protected String name;
+    protected String category;
+    protected String helpText;
+    protected int priority;
+
+    protected List<ConfigPropertyRepresentation> properties;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/PublishedRealmRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/PublishedRealmRepresentation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class PublishedRealmRepresentation {
+    protected String realm;
+
+    @JsonProperty("public_key")
+    protected String publicKeyPem;
+
+    @JsonProperty("token-service")
+    protected String tokenServiceUrl;
+
+    @JsonProperty("account-service")
+    protected String accountServiceUrl;
+
+    @JsonProperty("tokens-not-before")
+    protected int notBefore;
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public String getPublicKeyPem() {
+        return publicKeyPem;
+    }
+
+    public void setPublicKeyPem(String publicKeyPem) {
+        this.publicKeyPem = publicKeyPem;
+    }
+
+    public String getTokenServiceUrl() {
+        return tokenServiceUrl;
+    }
+
+    public void setTokenServiceUrl(String tokenServiceUrl) {
+        this.tokenServiceUrl = tokenServiceUrl;
+    }
+
+    public String getAccountServiceUrl() {
+        return accountServiceUrl;
+    }
+
+    public void setAccountServiceUrl(String accountServiceUrl) {
+        this.accountServiceUrl = accountServiceUrl;
+    }
+
+    public int getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(int notBefore) {
+        this.notBefore = notBefore;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RealmEventsConfigRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RealmEventsConfigRepresentation.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class RealmEventsConfigRepresentation {
+    protected boolean eventsEnabled;
+    protected Long eventsExpiration;
+    protected List<String> eventsListeners;
+    protected List<String> enabledEventTypes;
+    
+    protected Boolean adminEventsEnabled;
+    protected Boolean adminEventsDetailsEnabled;
+
+    public boolean isEventsEnabled() {
+        return eventsEnabled;
+    }
+
+    public void setEventsEnabled(boolean eventsEnabled) {
+        this.eventsEnabled = eventsEnabled;
+    }
+
+    public Long getEventsExpiration() {
+        return eventsExpiration;
+    }
+
+    public void setEventsExpiration(Long eventsExpiration) {
+        this.eventsExpiration = eventsExpiration;
+    }
+
+    public List<String> getEventsListeners() {
+        return eventsListeners;
+    }
+
+    public void setEventsListeners(List<String> eventsListeners) {
+        this.eventsListeners = eventsListeners;
+    }
+
+    public List<String> getEnabledEventTypes() {
+        return enabledEventTypes;
+    }
+
+    public void setEnabledEventTypes(List<String> enabledEventTypes) {
+        this.enabledEventTypes = enabledEventTypes;
+    }
+
+    public Boolean isAdminEventsEnabled() {
+        return adminEventsEnabled;
+    }
+
+    public void setAdminEventsEnabled(Boolean adminEventsEnabled) {
+        this.adminEventsEnabled = adminEventsEnabled;
+    }
+
+    public Boolean isAdminEventsDetailsEnabled() {
+        return adminEventsDetailsEnabled;
+    }
+
+    public void setAdminEventsDetailsEnabled(Boolean adminEventsDetailsEnabled) {
+        this.adminEventsDetailsEnabled = adminEventsDetailsEnabled;
+    }
+    
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -1,0 +1,1453 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.util.JsonSerialization;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class RealmRepresentation {
+
+    private static final Logger logger = Logger.getLogger(RealmRepresentation.class);
+
+    protected String id;
+    protected String realm;
+    protected String displayName;
+    protected String displayNameHtml;
+    protected Integer notBefore;
+    protected String defaultSignatureAlgorithm;
+    protected Boolean revokeRefreshToken;
+    protected Integer refreshTokenMaxReuse;
+    protected Integer accessTokenLifespan;
+    protected Integer accessTokenLifespanForImplicitFlow;
+    protected Integer ssoSessionIdleTimeout;
+    protected Integer ssoSessionMaxLifespan;
+    protected Integer ssoSessionIdleTimeoutRememberMe;
+    protected Integer ssoSessionMaxLifespanRememberMe;
+    protected Integer offlineSessionIdleTimeout;
+    // KEYCLOAK-7688 Offline Session Max for Offline Token
+    protected Boolean offlineSessionMaxLifespanEnabled;
+    protected Integer offlineSessionMaxLifespan;
+    protected Integer clientSessionIdleTimeout;
+    protected Integer clientSessionMaxLifespan;
+    protected Integer clientOfflineSessionIdleTimeout;
+    protected Integer clientOfflineSessionMaxLifespan;
+    protected Integer accessCodeLifespan;
+    protected Integer accessCodeLifespanUserAction;
+    protected Integer accessCodeLifespanLogin;
+    protected Integer actionTokenGeneratedByAdminLifespan;
+    protected Integer actionTokenGeneratedByUserLifespan;
+    protected Integer oauth2DeviceCodeLifespan;
+    protected Integer oauth2DevicePollingInterval;
+    protected Boolean enabled;
+    protected String sslRequired;
+    @Deprecated
+    protected Boolean passwordCredentialGrantAllowed;
+    protected Boolean registrationAllowed;
+    protected Boolean registrationEmailAsUsername;
+    protected Boolean rememberMe;
+    protected Boolean verifyEmail;
+    protected Boolean loginWithEmailAllowed;
+    protected Boolean duplicateEmailsAllowed;
+    protected Boolean resetPasswordAllowed;
+    protected Boolean editUsernameAllowed;
+
+    @Deprecated
+    protected Boolean userCacheEnabled;
+    @Deprecated
+    protected Boolean realmCacheEnabled;
+
+    //--- brute force settings
+    protected Boolean bruteForceProtected;
+    protected Boolean permanentLockout;
+    protected Integer maxTemporaryLockouts;
+    protected Integer maxFailureWaitSeconds;
+    protected Integer minimumQuickLoginWaitSeconds;
+    protected Integer waitIncrementSeconds;
+    protected Long quickLoginCheckMilliSeconds;
+    protected Integer maxDeltaTimeSeconds;
+    protected Integer failureFactor;
+    //--- end brute force settings
+
+    @Deprecated
+    protected String privateKey;
+    @Deprecated
+    protected String publicKey;
+    @Deprecated
+    protected String certificate;
+    @Deprecated
+    protected String codeSecret;
+    protected RolesRepresentation roles;
+    protected List<GroupRepresentation> groups;
+    @Deprecated
+    protected List<String> defaultRoles;
+    protected RoleRepresentation defaultRole;
+    protected List<String> defaultGroups;
+    @Deprecated
+    protected Set<String> requiredCredentials;
+    protected String passwordPolicy;
+    protected String otpPolicyType;
+    protected String otpPolicyAlgorithm;
+    protected Integer otpPolicyInitialCounter;
+    protected Integer otpPolicyDigits;
+    protected Integer otpPolicyLookAheadWindow;
+    protected Integer otpPolicyPeriod;
+    protected Boolean otpPolicyCodeReusable;
+    protected List<String> otpSupportedApplications;
+    protected Map<String, Map<String, String>> localizationTexts;
+
+    // WebAuthn 2-factor properties below
+
+    protected String webAuthnPolicyRpEntityName;
+    protected List<String> webAuthnPolicySignatureAlgorithms;
+    protected String webAuthnPolicyRpId;
+    protected String webAuthnPolicyAttestationConveyancePreference;
+    protected String webAuthnPolicyAuthenticatorAttachment;
+    protected String webAuthnPolicyRequireResidentKey;
+    protected String webAuthnPolicyUserVerificationRequirement;
+    protected Integer webAuthnPolicyCreateTimeout;
+    protected Boolean webAuthnPolicyAvoidSameAuthenticatorRegister;
+    protected List<String> webAuthnPolicyAcceptableAaguids;
+    protected List<String> webAuthnPolicyExtraOrigins;
+
+    // WebAuthn passwordless properties below
+
+    protected String webAuthnPolicyPasswordlessRpEntityName;
+    protected List<String> webAuthnPolicyPasswordlessSignatureAlgorithms;
+    protected String webAuthnPolicyPasswordlessRpId;
+    protected String webAuthnPolicyPasswordlessAttestationConveyancePreference;
+    protected String webAuthnPolicyPasswordlessAuthenticatorAttachment;
+    protected String webAuthnPolicyPasswordlessRequireResidentKey;
+    protected String webAuthnPolicyPasswordlessUserVerificationRequirement;
+    protected Integer webAuthnPolicyPasswordlessCreateTimeout;
+    protected Boolean webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister;
+    protected List<String> webAuthnPolicyPasswordlessAcceptableAaguids;
+    protected List<String> webAuthnPolicyPasswordlessExtraOrigins;
+
+    // Client Policies/Profiles
+
+    @JsonProperty("clientProfiles")
+    @Schema(implementation = ClientProfilesRepresentation.class)
+    protected JsonNode clientProfiles;
+
+    @JsonProperty("clientPolicies")
+    @Schema(implementation = ClientPoliciesRepresentation.class)
+    protected JsonNode clientPolicies;
+
+    protected List<UserRepresentation> users;
+    protected List<UserRepresentation> federatedUsers;
+    protected List<ScopeMappingRepresentation> scopeMappings;
+    protected Map<String, List<ScopeMappingRepresentation>> clientScopeMappings;
+    protected List<ClientRepresentation> clients;
+    protected List<ClientScopeRepresentation> clientScopes;
+    protected List<String> defaultDefaultClientScopes;
+    protected List<String> defaultOptionalClientScopes;
+    protected Map<String, String> browserSecurityHeaders;
+    protected Map<String, String> smtpServer;
+    protected List<UserFederationProviderRepresentation> userFederationProviders;
+    protected List<UserFederationMapperRepresentation> userFederationMappers;
+    protected String loginTheme;
+    protected String accountTheme;
+    protected String adminTheme;
+    protected String emailTheme;
+
+    protected Boolean eventsEnabled;
+    protected Long eventsExpiration;
+    protected List<String> eventsListeners;
+    protected List<String> enabledEventTypes;
+
+    protected Boolean adminEventsEnabled;
+    protected Boolean adminEventsDetailsEnabled;
+
+    private List<IdentityProviderRepresentation> identityProviders;
+    private List<IdentityProviderMapperRepresentation> identityProviderMappers;
+    private List<ProtocolMapperRepresentation> protocolMappers;
+    private MultivaluedHashMap<String, ComponentExportRepresentation> components;
+    protected Boolean internationalizationEnabled;
+    protected Set<String> supportedLocales;
+    protected String defaultLocale;
+    protected List<AuthenticationFlowRepresentation> authenticationFlows;
+    protected List<AuthenticatorConfigRepresentation> authenticatorConfig;
+    protected List<RequiredActionProviderRepresentation> requiredActions;
+    protected String browserFlow;
+    protected String registrationFlow;
+    protected String directGrantFlow;
+    protected String resetCredentialsFlow;
+    protected String clientAuthenticationFlow;
+    protected String dockerAuthenticationFlow;
+    protected String firstBrokerLoginFlow;
+
+    protected Map<String, String> attributes;
+
+    protected String keycloakVersion;
+
+    protected Boolean userManagedAccessAllowed;
+
+    protected Boolean organizationsEnabled;
+    private List<OrganizationRepresentation> organizations;
+
+    @Deprecated
+    protected Boolean social;
+    @Deprecated
+    protected Boolean updateProfileOnInitialSocialLogin;
+    @Deprecated
+    protected Map<String, String> socialProviders;
+    @Deprecated
+    protected Map<String, List<ScopeMappingRepresentation>> applicationScopeMappings;
+    @Deprecated
+    protected List<ApplicationRepresentation> applications;
+    @Deprecated
+    protected List<OAuthClientRepresentation> oauthClients;
+    @Deprecated
+    protected List<ClientTemplateRepresentation> clientTemplates;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayNameHtml() {
+        return displayNameHtml;
+    }
+
+    public void setDisplayNameHtml(String displayNameHtml) {
+        this.displayNameHtml = displayNameHtml;
+    }
+
+    public List<UserRepresentation> getUsers() {
+        return users;
+    }
+
+    public List<ApplicationRepresentation> getApplications() {
+        return applications;
+    }
+
+    public void setUsers(List<UserRepresentation> users) {
+        this.users = users;
+    }
+
+    public UserRepresentation user(String username) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        if (users == null) users = new ArrayList<>();
+        users.add(user);
+        return user;
+    }
+
+    public List<ClientRepresentation> getClients() {
+        return clients;
+    }
+
+    public void setClients(List<ClientRepresentation> clients) {
+        this.clients = clients;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getSslRequired() {
+        return sslRequired;
+    }
+
+    public void setSslRequired(String sslRequired) {
+        this.sslRequired = sslRequired;
+    }
+
+    public String getDefaultSignatureAlgorithm() {
+        return defaultSignatureAlgorithm;
+    }
+
+    public void setDefaultSignatureAlgorithm(String defaultSignatureAlgorithm) {
+        this.defaultSignatureAlgorithm = defaultSignatureAlgorithm;
+    }
+
+    public Boolean getRevokeRefreshToken() {
+        return revokeRefreshToken;
+    }
+
+    public void setRevokeRefreshToken(Boolean revokeRefreshToken) {
+        this.revokeRefreshToken = revokeRefreshToken;
+    }
+
+    public Integer getRefreshTokenMaxReuse() {
+        return refreshTokenMaxReuse;
+    }
+
+    public void setRefreshTokenMaxReuse(Integer refreshTokenMaxReuse) {
+        this.refreshTokenMaxReuse = refreshTokenMaxReuse;
+    }
+
+    public Integer getAccessTokenLifespan() {
+        return accessTokenLifespan;
+    }
+
+    public void setAccessTokenLifespan(Integer accessTokenLifespan) {
+        this.accessTokenLifespan = accessTokenLifespan;
+    }
+
+    public Integer getAccessTokenLifespanForImplicitFlow() {
+        return accessTokenLifespanForImplicitFlow;
+    }
+
+    public void setAccessTokenLifespanForImplicitFlow(Integer accessTokenLifespanForImplicitFlow) {
+        this.accessTokenLifespanForImplicitFlow = accessTokenLifespanForImplicitFlow;
+    }
+
+    public Integer getSsoSessionIdleTimeout() {
+        return ssoSessionIdleTimeout;
+    }
+
+    public void setSsoSessionIdleTimeout(Integer ssoSessionIdleTimeout) {
+        this.ssoSessionIdleTimeout = ssoSessionIdleTimeout;
+    }
+
+    public Integer getSsoSessionMaxLifespan() {
+        return ssoSessionMaxLifespan;
+    }
+
+    public void setSsoSessionMaxLifespan(Integer ssoSessionMaxLifespan) {
+        this.ssoSessionMaxLifespan = ssoSessionMaxLifespan;
+    }
+
+    public Integer getSsoSessionMaxLifespanRememberMe() {
+        return ssoSessionMaxLifespanRememberMe;
+    }
+
+    public void setSsoSessionMaxLifespanRememberMe(Integer ssoSessionMaxLifespanRememberMe) {
+        this.ssoSessionMaxLifespanRememberMe = ssoSessionMaxLifespanRememberMe;
+    }
+
+    public Integer getSsoSessionIdleTimeoutRememberMe() {
+        return ssoSessionIdleTimeoutRememberMe;
+    }
+
+    public void setSsoSessionIdleTimeoutRememberMe(Integer ssoSessionIdleTimeoutRememberMe) {
+        this.ssoSessionIdleTimeoutRememberMe = ssoSessionIdleTimeoutRememberMe;
+    }
+
+    public Integer getOfflineSessionIdleTimeout() {
+        return offlineSessionIdleTimeout;
+    }
+
+    public void setOfflineSessionIdleTimeout(Integer offlineSessionIdleTimeout) {
+        this.offlineSessionIdleTimeout = offlineSessionIdleTimeout;
+    }
+
+    // KEYCLOAK-7688 Offline Session Max for Offline Token
+    public Boolean getOfflineSessionMaxLifespanEnabled() {
+        return offlineSessionMaxLifespanEnabled;
+    }
+
+    public void setOfflineSessionMaxLifespanEnabled(Boolean offlineSessionMaxLifespanEnabled) {
+        this.offlineSessionMaxLifespanEnabled = offlineSessionMaxLifespanEnabled;
+    }
+
+    public Integer getOfflineSessionMaxLifespan() {
+        return offlineSessionMaxLifespan;
+    }
+
+    public void setOfflineSessionMaxLifespan(Integer offlineSessionMaxLifespan) {
+        this.offlineSessionMaxLifespan = offlineSessionMaxLifespan;
+    }
+
+    public Integer getClientSessionIdleTimeout() {
+        return clientSessionIdleTimeout;
+    }
+
+    public void setClientSessionIdleTimeout(Integer clientSessionIdleTimeout) {
+        this.clientSessionIdleTimeout = clientSessionIdleTimeout;
+    }
+
+    public Integer getClientSessionMaxLifespan() {
+        return clientSessionMaxLifespan;
+    }
+
+    public void setClientSessionMaxLifespan(Integer clientSessionMaxLifespan) {
+        this.clientSessionMaxLifespan = clientSessionMaxLifespan;
+    }
+
+    public Integer getClientOfflineSessionIdleTimeout() {
+        return clientOfflineSessionIdleTimeout;
+    }
+
+    public void setClientOfflineSessionIdleTimeout(Integer clientOfflineSessionIdleTimeout) {
+        this.clientOfflineSessionIdleTimeout = clientOfflineSessionIdleTimeout;
+    }
+
+    public Integer getClientOfflineSessionMaxLifespan() {
+        return clientOfflineSessionMaxLifespan;
+    }
+
+    public void setClientOfflineSessionMaxLifespan(Integer clientOfflineSessionMaxLifespan) {
+        this.clientOfflineSessionMaxLifespan = clientOfflineSessionMaxLifespan;
+    }
+
+    public List<ScopeMappingRepresentation> getScopeMappings() {
+        return scopeMappings;
+    }
+
+    public ScopeMappingRepresentation clientScopeMapping(String clientName) {
+        ScopeMappingRepresentation mapping = new ScopeMappingRepresentation();
+        mapping.setClient(clientName);
+        if (scopeMappings == null) scopeMappings = new ArrayList<>();
+        scopeMappings.add(mapping);
+        return mapping;
+    }
+
+    public ScopeMappingRepresentation clientScopeScopeMapping(String clientScopeName) {
+        ScopeMappingRepresentation mapping = new ScopeMappingRepresentation();
+        mapping.setClientScope(clientScopeName);
+        if (scopeMappings == null) scopeMappings = new ArrayList<>();
+        scopeMappings.add(mapping);
+        return mapping;
+    }
+
+    @Deprecated
+    public Set<String> getRequiredCredentials() {
+        return requiredCredentials;
+    }
+    @Deprecated
+    public void setRequiredCredentials(Set<String> requiredCredentials) {
+        this.requiredCredentials = requiredCredentials;
+    }
+
+    public String getPasswordPolicy() {
+        return passwordPolicy;
+    }
+
+    public void setPasswordPolicy(String passwordPolicy) {
+        this.passwordPolicy = passwordPolicy;
+    }
+
+    public Integer getAccessCodeLifespan() {
+        return accessCodeLifespan;
+    }
+
+    public void setAccessCodeLifespan(Integer accessCodeLifespan) {
+        this.accessCodeLifespan = accessCodeLifespan;
+    }
+
+    public Integer getAccessCodeLifespanUserAction() {
+        return accessCodeLifespanUserAction;
+    }
+
+    public void setAccessCodeLifespanUserAction(Integer accessCodeLifespanUserAction) {
+        this.accessCodeLifespanUserAction = accessCodeLifespanUserAction;
+    }
+
+    public Integer getAccessCodeLifespanLogin() {
+        return accessCodeLifespanLogin;
+    }
+
+    public void setAccessCodeLifespanLogin(Integer accessCodeLifespanLogin) {
+        this.accessCodeLifespanLogin = accessCodeLifespanLogin;
+    }
+
+    public Integer getActionTokenGeneratedByAdminLifespan() {
+        return actionTokenGeneratedByAdminLifespan;
+    }
+
+    public void setActionTokenGeneratedByAdminLifespan(Integer actionTokenGeneratedByAdminLifespan) {
+        this.actionTokenGeneratedByAdminLifespan = actionTokenGeneratedByAdminLifespan;
+    }
+
+    public void setOAuth2DeviceCodeLifespan(Integer oauth2DeviceCodeLifespan) {
+        this.oauth2DeviceCodeLifespan = oauth2DeviceCodeLifespan;
+    }
+
+    public Integer getOAuth2DeviceCodeLifespan() {
+        return oauth2DeviceCodeLifespan;
+    }
+
+    public void setOAuth2DevicePollingInterval(Integer oauth2DevicePollingInterval) {
+        this.oauth2DevicePollingInterval = oauth2DevicePollingInterval;
+    }
+
+    public Integer getOAuth2DevicePollingInterval() {
+        return oauth2DevicePollingInterval;
+    }
+
+    public Integer getActionTokenGeneratedByUserLifespan() {
+        return actionTokenGeneratedByUserLifespan;
+    }
+
+    public void setActionTokenGeneratedByUserLifespan(Integer actionTokenGeneratedByUserLifespan) {
+        this.actionTokenGeneratedByUserLifespan = actionTokenGeneratedByUserLifespan;
+    }
+
+    @Deprecated
+    public List<String> getDefaultRoles() {
+        return defaultRoles;
+    }
+
+    @Deprecated
+    public void setDefaultRoles(List<String> defaultRoles) {
+        this.defaultRoles = defaultRoles;
+    }
+
+    public RoleRepresentation getDefaultRole() {
+        return defaultRole;
+    }
+
+    public void setDefaultRole(RoleRepresentation defaultRole) {
+        this.defaultRole = defaultRole;
+    }
+
+    public List<String> getDefaultGroups() {
+        return defaultGroups;
+    }
+
+    public void setDefaultGroups(List<String> defaultGroups) {
+        this.defaultGroups = defaultGroups;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public String getCodeSecret() {
+        return codeSecret;
+    }
+
+    public void setCodeSecret(String codeSecret) {
+        this.codeSecret = codeSecret;
+    }
+
+    public Boolean isPasswordCredentialGrantAllowed() {
+        return passwordCredentialGrantAllowed;
+    }
+
+    public Boolean isRegistrationAllowed() {
+        return registrationAllowed;
+    }
+
+    public void setRegistrationAllowed(Boolean registrationAllowed) {
+        this.registrationAllowed = registrationAllowed;
+    }
+
+    public Boolean isRegistrationEmailAsUsername() {
+        return registrationEmailAsUsername;
+    }
+
+    public void setRegistrationEmailAsUsername(Boolean registrationEmailAsUsername) {
+        this.registrationEmailAsUsername = registrationEmailAsUsername;
+    }
+
+    public Boolean isRememberMe() {
+        return rememberMe;
+    }
+
+    public void setRememberMe(Boolean rememberMe) {
+        this.rememberMe = rememberMe;
+    }
+
+    public Boolean isVerifyEmail() {
+        return verifyEmail;
+    }
+
+    public void setVerifyEmail(Boolean verifyEmail) {
+        this.verifyEmail = verifyEmail;
+    }
+
+    public Boolean isLoginWithEmailAllowed() {
+        return loginWithEmailAllowed;
+    }
+
+    public void setLoginWithEmailAllowed(Boolean loginWithEmailAllowed) {
+        this.loginWithEmailAllowed = loginWithEmailAllowed;
+    }
+
+    public Boolean isDuplicateEmailsAllowed() {
+        return duplicateEmailsAllowed;
+    }
+
+    public void setDuplicateEmailsAllowed(Boolean duplicateEmailsAllowed) {
+        this.duplicateEmailsAllowed = duplicateEmailsAllowed;
+    }
+
+    public Boolean isResetPasswordAllowed() {
+        return resetPasswordAllowed;
+    }
+
+    public void setResetPasswordAllowed(Boolean resetPassword) {
+        this.resetPasswordAllowed = resetPassword;
+    }
+
+    public Boolean isEditUsernameAllowed() {
+        return editUsernameAllowed;
+    }
+
+    public void setEditUsernameAllowed(Boolean editUsernameAllowed) {
+        this.editUsernameAllowed = editUsernameAllowed;
+    }
+
+    @Deprecated
+    public Boolean isSocial() {
+        return social;
+    }
+
+    @Deprecated
+    public Boolean isUpdateProfileOnInitialSocialLogin() {
+        return updateProfileOnInitialSocialLogin;
+    }
+
+    public Map<String, String> getBrowserSecurityHeaders() {
+        return browserSecurityHeaders;
+    }
+
+    public void setBrowserSecurityHeaders(Map<String, String> browserSecurityHeaders) {
+        this.browserSecurityHeaders = browserSecurityHeaders;
+    }
+
+    @Deprecated
+    public Map<String, String> getSocialProviders() {
+        return socialProviders;
+    }
+
+    public Map<String, String> getSmtpServer() {
+        return smtpServer;
+    }
+
+    public void setSmtpServer(Map<String, String> smtpServer) {
+        this.smtpServer = smtpServer;
+    }
+
+    @Deprecated
+    public List<OAuthClientRepresentation> getOauthClients() {
+        return oauthClients;
+    }
+
+    public Map<String, List<ScopeMappingRepresentation>> getClientScopeMappings() {
+        return clientScopeMappings;
+    }
+
+    public void setClientScopeMappings(Map<String, List<ScopeMappingRepresentation>> clientScopeMappings) {
+        this.clientScopeMappings = clientScopeMappings;
+    }
+
+    @Deprecated
+    public Map<String, List<ScopeMappingRepresentation>> getApplicationScopeMappings() {
+        return applicationScopeMappings;
+    }
+
+    public RolesRepresentation getRoles() {
+        return roles;
+    }
+
+    public void setRoles(RolesRepresentation roles) {
+        this.roles = roles;
+    }
+
+    public String getLoginTheme() {
+        return loginTheme;
+    }
+
+    public void setLoginTheme(String loginTheme) {
+        this.loginTheme = loginTheme;
+    }
+
+    public String getAccountTheme() {
+        return accountTheme;
+    }
+
+    public void setAccountTheme(String accountTheme) {
+        this.accountTheme = accountTheme;
+    }
+
+    public String getAdminTheme() {
+        return adminTheme;
+    }
+
+    public void setAdminTheme(String adminTheme) {
+        this.adminTheme = adminTheme;
+    }
+
+    public String getEmailTheme() {
+        return emailTheme;
+    }
+
+    public void setEmailTheme(String emailTheme) {
+        this.emailTheme = emailTheme;
+    }
+
+    public Integer getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(Integer notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    public Boolean isBruteForceProtected() {
+        return bruteForceProtected;
+    }
+
+    public void setBruteForceProtected(Boolean bruteForceProtected) {
+        this.bruteForceProtected = bruteForceProtected;
+    }
+
+    public Boolean isPermanentLockout() {
+        return permanentLockout;
+    }
+
+    public void setPermanentLockout(Boolean permanentLockout) {
+        this.permanentLockout = permanentLockout;
+    }
+
+    public Integer getMaxTemporaryLockouts() {
+        return maxTemporaryLockouts;
+    }
+
+    public void setMaxTemporaryLockouts(Integer maxTemporaryLockouts) {
+        this.maxTemporaryLockouts = maxTemporaryLockouts;
+    }
+
+    public Integer getMaxFailureWaitSeconds() {
+        return maxFailureWaitSeconds;
+    }
+
+    public void setMaxFailureWaitSeconds(Integer maxFailureWaitSeconds) {
+        this.maxFailureWaitSeconds = maxFailureWaitSeconds;
+    }
+
+    public Integer getMinimumQuickLoginWaitSeconds() {
+        return minimumQuickLoginWaitSeconds;
+    }
+
+    public void setMinimumQuickLoginWaitSeconds(Integer minimumQuickLoginWaitSeconds) {
+        this.minimumQuickLoginWaitSeconds = minimumQuickLoginWaitSeconds;
+    }
+
+    public Integer getWaitIncrementSeconds() {
+        return waitIncrementSeconds;
+    }
+
+    public void setWaitIncrementSeconds(Integer waitIncrementSeconds) {
+        this.waitIncrementSeconds = waitIncrementSeconds;
+    }
+
+    public Long getQuickLoginCheckMilliSeconds() {
+        return quickLoginCheckMilliSeconds;
+    }
+
+    public void setQuickLoginCheckMilliSeconds(Long quickLoginCheckMilliSeconds) {
+        this.quickLoginCheckMilliSeconds = quickLoginCheckMilliSeconds;
+    }
+
+    public Integer getMaxDeltaTimeSeconds() {
+        return maxDeltaTimeSeconds;
+    }
+
+    public void setMaxDeltaTimeSeconds(Integer maxDeltaTimeSeconds) {
+        this.maxDeltaTimeSeconds = maxDeltaTimeSeconds;
+    }
+
+    public Integer getFailureFactor() {
+        return failureFactor;
+    }
+
+    public void setFailureFactor(Integer failureFactor) {
+        this.failureFactor = failureFactor;
+    }
+
+    public Boolean isEventsEnabled() {
+        return eventsEnabled;
+    }
+
+    public void setEventsEnabled(boolean eventsEnabled) {
+        this.eventsEnabled = eventsEnabled;
+    }
+
+    public Long getEventsExpiration() {
+        return eventsExpiration;
+    }
+
+    public void setEventsExpiration(long eventsExpiration) {
+        this.eventsExpiration = eventsExpiration;
+    }
+
+    public List<String> getEventsListeners() {
+        return eventsListeners;
+    }
+
+    public void setEventsListeners(List<String> eventsListeners) {
+        this.eventsListeners = eventsListeners;
+    }
+
+    public List<String> getEnabledEventTypes() {
+        return enabledEventTypes;
+    }
+
+    public void setEnabledEventTypes(List<String> enabledEventTypes) {
+        this.enabledEventTypes = enabledEventTypes;
+    }
+
+    public Boolean isAdminEventsEnabled() {
+        return adminEventsEnabled;
+    }
+
+    public void setAdminEventsEnabled(Boolean adminEventsEnabled) {
+        this.adminEventsEnabled = adminEventsEnabled;
+    }
+
+    public Boolean isAdminEventsDetailsEnabled() {
+        return adminEventsDetailsEnabled;
+    }
+
+    public void setAdminEventsDetailsEnabled(Boolean adminEventsDetailsEnabled) {
+        this.adminEventsDetailsEnabled = adminEventsDetailsEnabled;
+    }
+
+    public List<UserFederationProviderRepresentation> getUserFederationProviders() {
+        return userFederationProviders;
+    }
+
+    public void setUserFederationProviders(List<UserFederationProviderRepresentation> userFederationProviders) {
+        this.userFederationProviders = userFederationProviders;
+    }
+
+    public List<UserFederationMapperRepresentation> getUserFederationMappers() {
+        return userFederationMappers;
+    }
+
+    public void setUserFederationMappers(List<UserFederationMapperRepresentation> userFederationMappers) {
+        this.userFederationMappers = userFederationMappers;
+    }
+
+    public void addUserFederationMapper(UserFederationMapperRepresentation userFederationMapper) {
+        if (userFederationMappers == null) userFederationMappers = new LinkedList<>();
+        userFederationMappers.add(userFederationMapper);
+    }
+
+    public List<IdentityProviderRepresentation> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(List<IdentityProviderRepresentation> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public void addIdentityProvider(IdentityProviderRepresentation identityProviderRepresentation) {
+        if (identityProviders == null) identityProviders = new LinkedList<>();
+        identityProviders.add(identityProviderRepresentation);
+    }
+
+    public List<ProtocolMapperRepresentation> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void addProtocolMapper(ProtocolMapperRepresentation rep) {
+        if (protocolMappers == null) protocolMappers = new LinkedList<ProtocolMapperRepresentation>();
+        protocolMappers.add(rep);
+    }
+
+    public void setProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+
+    public Boolean isInternationalizationEnabled() {
+        return internationalizationEnabled;
+    }
+
+    public void setInternationalizationEnabled(Boolean internationalizationEnabled) {
+        this.internationalizationEnabled = internationalizationEnabled;
+    }
+
+    public Set<String> getSupportedLocales() {
+        return supportedLocales;
+    }
+
+    public void addSupportedLocales(String locale) {
+        if(supportedLocales == null){
+            supportedLocales = new HashSet<>();
+        }
+        supportedLocales.add(locale);
+    }
+
+    public void setSupportedLocales(Set<String> supportedLocales) {
+        this.supportedLocales = supportedLocales;
+    }
+
+    public String getDefaultLocale() {
+        return defaultLocale;
+    }
+
+    public void setDefaultLocale(String defaultLocale) {
+        this.defaultLocale = defaultLocale;
+    }
+
+    public List<IdentityProviderMapperRepresentation> getIdentityProviderMappers() {
+        return identityProviderMappers;
+    }
+
+    public void setIdentityProviderMappers(List<IdentityProviderMapperRepresentation> identityProviderMappers) {
+        this.identityProviderMappers = identityProviderMappers;
+    }
+
+    public void addIdentityProviderMapper(IdentityProviderMapperRepresentation rep) {
+        if (identityProviderMappers == null) identityProviderMappers = new LinkedList<>();
+        identityProviderMappers.add(rep);
+    }
+
+    public List<AuthenticationFlowRepresentation> getAuthenticationFlows() {
+        return authenticationFlows;
+    }
+
+    public void setAuthenticationFlows(List<AuthenticationFlowRepresentation> authenticationFlows) {
+        this.authenticationFlows = authenticationFlows;
+    }
+
+    public List<AuthenticatorConfigRepresentation> getAuthenticatorConfig() {
+        return authenticatorConfig;
+    }
+
+    public void setAuthenticatorConfig(List<AuthenticatorConfigRepresentation> authenticatorConfig) {
+        this.authenticatorConfig = authenticatorConfig;
+    }
+
+    public List<RequiredActionProviderRepresentation> getRequiredActions() {
+        return requiredActions;
+    }
+
+    public void setRequiredActions(List<RequiredActionProviderRepresentation> requiredActions) {
+        this.requiredActions = requiredActions;
+    }
+
+    public String getOtpPolicyType() {
+        return otpPolicyType;
+    }
+
+    public void setOtpPolicyType(String otpPolicyType) {
+        this.otpPolicyType = otpPolicyType;
+    }
+
+    public String getOtpPolicyAlgorithm() {
+        return otpPolicyAlgorithm;
+    }
+
+    public void setOtpPolicyAlgorithm(String otpPolicyAlgorithm) {
+        this.otpPolicyAlgorithm = otpPolicyAlgorithm;
+    }
+
+    public Integer getOtpPolicyInitialCounter() {
+        return otpPolicyInitialCounter;
+    }
+
+    public void setOtpPolicyInitialCounter(Integer otpPolicyInitialCounter) {
+        this.otpPolicyInitialCounter = otpPolicyInitialCounter;
+    }
+
+    public Integer getOtpPolicyDigits() {
+        return otpPolicyDigits;
+    }
+
+    public void setOtpPolicyDigits(Integer otpPolicyDigits) {
+        this.otpPolicyDigits = otpPolicyDigits;
+    }
+
+    public Integer getOtpPolicyLookAheadWindow() {
+        return otpPolicyLookAheadWindow;
+    }
+
+    public void setOtpPolicyLookAheadWindow(Integer otpPolicyLookAheadWindow) {
+        this.otpPolicyLookAheadWindow = otpPolicyLookAheadWindow;
+    }
+
+    public Integer getOtpPolicyPeriod() {
+        return otpPolicyPeriod;
+    }
+
+    public void setOtpPolicyPeriod(Integer otpPolicyPeriod) {
+        this.otpPolicyPeriod = otpPolicyPeriod;
+    }
+
+    public List<String> getOtpSupportedApplications() {
+        return otpSupportedApplications;
+    }
+
+    public void setOtpSupportedApplications(List<String> otpSupportedApplications) {
+        this.otpSupportedApplications = otpSupportedApplications;
+    }
+
+    public Map<String, Map<String, String>> getLocalizationTexts() {
+        return localizationTexts;
+    }
+
+    public void setLocalizationTexts(Map<String, Map<String, String>> localizationTexts) {
+        this.localizationTexts = localizationTexts;
+    }
+
+    public Boolean isOtpPolicyCodeReusable() {
+        return otpPolicyCodeReusable;
+    }
+
+    public void setOtpPolicyCodeReusable(Boolean isCodeReusable) {
+        this.otpPolicyCodeReusable = isCodeReusable;
+    }
+
+    // WebAuthn 2-factor properties below
+
+    public String getWebAuthnPolicyRpEntityName() {
+        return webAuthnPolicyRpEntityName;
+    }
+
+    public void setWebAuthnPolicyRpEntityName(String webAuthnPolicyRpEntityName) {
+        this.webAuthnPolicyRpEntityName = webAuthnPolicyRpEntityName;
+    }
+
+    public List<String> getWebAuthnPolicySignatureAlgorithms() {
+        return webAuthnPolicySignatureAlgorithms;
+    }
+
+    public void setWebAuthnPolicySignatureAlgorithms(List<String> webAuthnPolicySignatureAlgorithms) {
+        this.webAuthnPolicySignatureAlgorithms = webAuthnPolicySignatureAlgorithms;
+    }
+
+    public String getWebAuthnPolicyRpId() {
+        return webAuthnPolicyRpId;
+    }
+
+    public void setWebAuthnPolicyRpId(String webAuthnPolicyRpId) {
+        this.webAuthnPolicyRpId = webAuthnPolicyRpId;
+    }
+
+    public String getWebAuthnPolicyAttestationConveyancePreference() {
+        return webAuthnPolicyAttestationConveyancePreference;
+    }
+
+    public void setWebAuthnPolicyAttestationConveyancePreference(String webAuthnPolicyAttestationConveyancePreference) {
+        this.webAuthnPolicyAttestationConveyancePreference = webAuthnPolicyAttestationConveyancePreference;
+    }
+
+    public String getWebAuthnPolicyAuthenticatorAttachment() {
+        return webAuthnPolicyAuthenticatorAttachment;
+    }
+
+    public void setWebAuthnPolicyAuthenticatorAttachment(String webAuthnPolicyAuthenticatorAttachment) {
+        this.webAuthnPolicyAuthenticatorAttachment = webAuthnPolicyAuthenticatorAttachment;
+    }
+
+    public String getWebAuthnPolicyRequireResidentKey() {
+        return webAuthnPolicyRequireResidentKey;
+    }
+
+    public void setWebAuthnPolicyRequireResidentKey(String webAuthnPolicyRequireResidentKey) {
+        this.webAuthnPolicyRequireResidentKey = webAuthnPolicyRequireResidentKey;
+    }
+
+    public String getWebAuthnPolicyUserVerificationRequirement() {
+        return webAuthnPolicyUserVerificationRequirement;
+    }
+
+    public void setWebAuthnPolicyUserVerificationRequirement(String webAuthnPolicyUserVerificationRequirement) {
+        this.webAuthnPolicyUserVerificationRequirement = webAuthnPolicyUserVerificationRequirement;
+    }
+
+    public Integer getWebAuthnPolicyCreateTimeout() {
+        return webAuthnPolicyCreateTimeout;
+    }
+
+    public void setWebAuthnPolicyCreateTimeout(Integer webAuthnPolicyCreateTimeout) {
+        this.webAuthnPolicyCreateTimeout = webAuthnPolicyCreateTimeout;
+    }
+
+    public Boolean isWebAuthnPolicyAvoidSameAuthenticatorRegister() {
+        return webAuthnPolicyAvoidSameAuthenticatorRegister;
+    }
+
+    public void setWebAuthnPolicyAvoidSameAuthenticatorRegister(Boolean webAuthnPolicyAvoidSameAuthenticatorRegister) {
+        this.webAuthnPolicyAvoidSameAuthenticatorRegister = webAuthnPolicyAvoidSameAuthenticatorRegister;
+    }
+
+    public List<String> getWebAuthnPolicyAcceptableAaguids() {
+        return webAuthnPolicyAcceptableAaguids;
+    }
+
+    public void setWebAuthnPolicyAcceptableAaguids(List<String> webAuthnPolicyAcceptableAaguids) {
+        this.webAuthnPolicyAcceptableAaguids = webAuthnPolicyAcceptableAaguids;
+    }
+
+    public List<String> getWebAuthnPolicyExtraOrigins(){
+        return webAuthnPolicyExtraOrigins;
+    }
+
+    public void setWebAuthnPolicyExtraOrigins(List<String> extraOrigins) {
+        this.webAuthnPolicyExtraOrigins = extraOrigins;
+    }
+
+    // WebAuthn passwordless properties below
+
+
+    public String getWebAuthnPolicyPasswordlessRpEntityName() {
+        return webAuthnPolicyPasswordlessRpEntityName;
+    }
+
+    public void setWebAuthnPolicyPasswordlessRpEntityName(String webAuthnPolicyPasswordlessRpEntityName) {
+        this.webAuthnPolicyPasswordlessRpEntityName = webAuthnPolicyPasswordlessRpEntityName;
+    }
+
+    public List<String> getWebAuthnPolicyPasswordlessSignatureAlgorithms() {
+        return webAuthnPolicyPasswordlessSignatureAlgorithms;
+    }
+
+    public void setWebAuthnPolicyPasswordlessSignatureAlgorithms(List<String> webAuthnPolicyPasswordlessSignatureAlgorithms) {
+        this.webAuthnPolicyPasswordlessSignatureAlgorithms = webAuthnPolicyPasswordlessSignatureAlgorithms;
+    }
+
+    public String getWebAuthnPolicyPasswordlessRpId() {
+        return webAuthnPolicyPasswordlessRpId;
+    }
+
+    public void setWebAuthnPolicyPasswordlessRpId(String webAuthnPolicyPasswordlessRpId) {
+        this.webAuthnPolicyPasswordlessRpId = webAuthnPolicyPasswordlessRpId;
+    }
+
+    public String getWebAuthnPolicyPasswordlessAttestationConveyancePreference() {
+        return webAuthnPolicyPasswordlessAttestationConveyancePreference;
+    }
+
+    public void setWebAuthnPolicyPasswordlessAttestationConveyancePreference(String webAuthnPolicyPasswordlessAttestationConveyancePreference) {
+        this.webAuthnPolicyPasswordlessAttestationConveyancePreference = webAuthnPolicyPasswordlessAttestationConveyancePreference;
+    }
+
+    public String getWebAuthnPolicyPasswordlessAuthenticatorAttachment() {
+        return webAuthnPolicyPasswordlessAuthenticatorAttachment;
+    }
+
+    public void setWebAuthnPolicyPasswordlessAuthenticatorAttachment(String webAuthnPolicyPasswordlessAuthenticatorAttachment) {
+        this.webAuthnPolicyPasswordlessAuthenticatorAttachment = webAuthnPolicyPasswordlessAuthenticatorAttachment;
+    }
+
+    public String getWebAuthnPolicyPasswordlessRequireResidentKey() {
+        return webAuthnPolicyPasswordlessRequireResidentKey;
+    }
+
+    public void setWebAuthnPolicyPasswordlessRequireResidentKey(String webAuthnPolicyPasswordlessRequireResidentKey) {
+        this.webAuthnPolicyPasswordlessRequireResidentKey = webAuthnPolicyPasswordlessRequireResidentKey;
+    }
+
+    public String getWebAuthnPolicyPasswordlessUserVerificationRequirement() {
+        return webAuthnPolicyPasswordlessUserVerificationRequirement;
+    }
+
+    public void setWebAuthnPolicyPasswordlessUserVerificationRequirement(String webAuthnPolicyPasswordlessUserVerificationRequirement) {
+        this.webAuthnPolicyPasswordlessUserVerificationRequirement = webAuthnPolicyPasswordlessUserVerificationRequirement;
+    }
+
+    public Integer getWebAuthnPolicyPasswordlessCreateTimeout() {
+        return webAuthnPolicyPasswordlessCreateTimeout;
+    }
+
+    public void setWebAuthnPolicyPasswordlessCreateTimeout(Integer webAuthnPolicyPasswordlessCreateTimeout) {
+        this.webAuthnPolicyPasswordlessCreateTimeout = webAuthnPolicyPasswordlessCreateTimeout;
+    }
+
+    public Boolean isWebAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister() {
+        return webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister;
+    }
+
+    public void setWebAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister(Boolean webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister) {
+        this.webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister = webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister;
+    }
+
+    public List<String> getWebAuthnPolicyPasswordlessAcceptableAaguids() {
+        return webAuthnPolicyPasswordlessAcceptableAaguids;
+    }
+
+    public void setWebAuthnPolicyPasswordlessAcceptableAaguids(List<String> webAuthnPolicyPasswordlessAcceptableAaguids) {
+        this.webAuthnPolicyPasswordlessAcceptableAaguids = webAuthnPolicyPasswordlessAcceptableAaguids;
+    }
+
+    public List<String> getWebAuthnPolicyPasswordlessExtraOrigins(){
+        return webAuthnPolicyPasswordlessExtraOrigins;
+    }
+
+    public void setWebAuthnPolicyPasswordlessExtraOrigins(List<String> extraOrigins) {
+        this.webAuthnPolicyPasswordlessExtraOrigins = extraOrigins;
+    }
+
+    // Client Policies/Profiles
+
+    @JsonIgnore
+    public ClientProfilesRepresentation getParsedClientProfiles() {
+        try {
+            if (clientProfiles == null) return null;
+            return JsonSerialization.mapper.convertValue(clientProfiles, ClientProfilesRepresentation.class);
+        } catch (IllegalArgumentException ioe) {
+            logger.warnf("Failed to deserialize client profiles in the realm %s. Fallback to return empty profiles. Details: %s", realm, ioe.getMessage());
+            return null;
+        }
+    }
+
+    @JsonIgnore
+    public void setParsedClientProfiles(ClientProfilesRepresentation clientProfiles) {
+        if (clientProfiles == null) {
+            this.clientProfiles = null;
+            return;
+        }
+        this.clientProfiles = JsonSerialization.mapper.convertValue(clientProfiles, JsonNode.class);
+    }
+
+    @JsonIgnore
+    public ClientPoliciesRepresentation getParsedClientPolicies() {
+        try {
+            if (clientPolicies == null) return null;
+            return JsonSerialization.mapper.convertValue(clientPolicies, ClientPoliciesRepresentation.class);
+        } catch (IllegalArgumentException ioe) {
+            logger.warnf("Failed to deserialize client policies in the realm %s. Fallback to return empty profiles. Details: %s", realm, ioe.getMessage());
+            return null;
+        }
+    }
+
+    @JsonIgnore
+    public void setParsedClientPolicies(ClientPoliciesRepresentation clientPolicies) {
+        if (clientPolicies == null) {
+            this.clientPolicies = null;
+            return;
+        }
+        this.clientPolicies = JsonSerialization.mapper.convertValue(clientPolicies, JsonNode.class);
+    }
+
+    public String getBrowserFlow() {
+        return browserFlow;
+    }
+
+    public void setBrowserFlow(String browserFlow) {
+        this.browserFlow = browserFlow;
+    }
+
+    public String getRegistrationFlow() {
+        return registrationFlow;
+    }
+
+    public void setRegistrationFlow(String registrationFlow) {
+        this.registrationFlow = registrationFlow;
+    }
+
+    public String getDirectGrantFlow() {
+        return directGrantFlow;
+    }
+
+    public void setDirectGrantFlow(String directGrantFlow) {
+        this.directGrantFlow = directGrantFlow;
+    }
+
+    public String getResetCredentialsFlow() {
+        return resetCredentialsFlow;
+    }
+
+    public void setResetCredentialsFlow(String resetCredentialsFlow) {
+        this.resetCredentialsFlow = resetCredentialsFlow;
+    }
+
+    public String getClientAuthenticationFlow() {
+        return clientAuthenticationFlow;
+    }
+
+    public void setClientAuthenticationFlow(String clientAuthenticationFlow) {
+        this.clientAuthenticationFlow = clientAuthenticationFlow;
+    }
+
+    public String getDockerAuthenticationFlow() {
+        return dockerAuthenticationFlow;
+    }
+
+    public RealmRepresentation setDockerAuthenticationFlow(final String dockerAuthenticationFlow) {
+        this.dockerAuthenticationFlow = dockerAuthenticationFlow;
+        return this;
+    }
+
+    public String getFirstBrokerLoginFlow() {
+        return firstBrokerLoginFlow;
+    }
+
+    public RealmRepresentation setFirstBrokerLoginFlow(String firstBrokerLoginFlow) {
+        this.firstBrokerLoginFlow = firstBrokerLoginFlow;
+        return this;
+    }
+
+    public String getKeycloakVersion() {
+        return keycloakVersion;
+    }
+
+    public void setKeycloakVersion(String keycloakVersion) {
+        this.keycloakVersion = keycloakVersion;
+    }
+
+    public List<GroupRepresentation> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<GroupRepresentation> groups) {
+        this.groups = groups;
+    }
+
+    @Deprecated // use getClientScopes() instead
+    public List<ClientTemplateRepresentation> getClientTemplates() {
+        return clientTemplates;
+    }
+
+    public List<ClientScopeRepresentation> getClientScopes() {
+        return clientScopes;
+    }
+
+    public void setClientScopes(List<ClientScopeRepresentation> clientScopes) {
+        this.clientScopes = clientScopes;
+    }
+
+    public List<String> getDefaultDefaultClientScopes() {
+        return defaultDefaultClientScopes;
+    }
+
+    public void setDefaultDefaultClientScopes(List<String> defaultDefaultClientScopes) {
+        this.defaultDefaultClientScopes = defaultDefaultClientScopes;
+    }
+
+    public List<String> getDefaultOptionalClientScopes() {
+        return defaultOptionalClientScopes;
+    }
+
+    public void setDefaultOptionalClientScopes(List<String> defaultOptionalClientScopes) {
+        this.defaultOptionalClientScopes = defaultOptionalClientScopes;
+    }
+
+    public MultivaluedHashMap<String, ComponentExportRepresentation> getComponents() {
+        return components;
+    }
+
+    public void setComponents(MultivaluedHashMap<String, ComponentExportRepresentation> components) {
+        this.components = components;
+    }
+
+    @JsonIgnore
+    public boolean isIdentityFederationEnabled() {
+        return identityProviders != null && !identityProviders.isEmpty();
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public List<UserRepresentation> getFederatedUsers() {
+        return federatedUsers;
+    }
+
+    public void setFederatedUsers(List<UserRepresentation> federatedUsers) {
+        this.federatedUsers = federatedUsers;
+    }
+
+    public void setUserManagedAccessAllowed(Boolean userManagedAccessAllowed) {
+        this.userManagedAccessAllowed = userManagedAccessAllowed;
+    }
+
+    public Boolean isUserManagedAccessAllowed() {
+        return userManagedAccessAllowed;
+    }
+
+    public Boolean isOrganizationsEnabled() {
+        return organizationsEnabled;
+    }
+
+    public void setOrganizationsEnabled(Boolean organizationsEnabled) {
+        this.organizationsEnabled = organizationsEnabled;
+    }
+
+    @JsonIgnore
+    public Map<String, String> getAttributesOrEmpty() {
+        return (Map<String, String>) (attributes == null ? Collections.emptyMap() : attributes);
+    }
+
+    public List<OrganizationRepresentation> getOrganizations() {
+        return organizations;
+    }
+
+    public void setOrganizations(List<OrganizationRepresentation> organizations) {
+        this.organizations = organizations;
+    }
+
+    public void addOrganization(OrganizationRepresentation org) {
+        if (organizations == null) {
+            organizations = new ArrayList<>();
+        }
+        organizations.add(org);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionConfigInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionConfigInfoRepresentation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+/**
+ * Represents the configurable properties of a RequiredAction.
+ */
+public class RequiredActionConfigInfoRepresentation {
+
+    private List<ConfigPropertyRepresentation> properties;
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+}
+

--- a/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionConfigRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionConfigRepresentation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents the configuration of a RequiredAction.
+ */
+public class RequiredActionConfigRepresentation implements Serializable {
+
+    private Map<String, String> config = new HashMap<>();
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderRepresentation.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+* @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+* @version $Revision: 1 $
+*/
+public class RequiredActionProviderRepresentation {
+
+    private String alias;
+    private String name;
+    private String providerId;
+    private boolean enabled;
+    private boolean defaultAction;
+    private int priority;
+    private Map<String, String> config;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+     * Used for display purposes.  Probably should clean this code up and make alias and name the same, but
+     * the old code references an Enum and the admin console creates a "friendly" name for each enum.
+     *
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isDefaultAction() {
+        return defaultAction;
+    }
+
+    public void setDefaultAction(boolean defaultAction) {
+        this.defaultAction = defaultAction;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderSimpleRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderSimpleRepresentation.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * Some endpoints (like register new required action) doesn't support all the fields (like setEnabled etc).
+ * So this is just simplified version of full RequiredActionProviderRepresentation
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class RequiredActionProviderSimpleRepresentation {
+
+    private String id;
+    private String name;
+    private String providerId;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RoleRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RoleRepresentation.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class RoleRepresentation {
+    protected String id;
+    protected String name;
+    protected String description;
+    @Deprecated
+    protected Boolean scopeParamRequired;
+    protected boolean composite;
+    protected Composites composites;
+    private Boolean clientRole;
+    private String containerId;
+    protected Map<String, List<String>> attributes;
+
+    public static class Composites {
+        protected Set<String> realm;
+        protected Map<String, List<String>> client;
+        @Deprecated
+        protected Map<String, List<String>> application;
+
+        public Set<String> getRealm() {
+            return realm;
+        }
+
+        public void setRealm(Set<String> realm) {
+            this.realm = realm;
+        }
+
+        public Map<String, List<String>> getClient() {
+            return client;
+        }
+
+        public void setClient(Map<String, List<String>> client) {
+            this.client = client;
+        }
+
+        @Deprecated
+        public Map<String, List<String>> getApplication() {
+            return application;
+        }
+    }
+
+    public RoleRepresentation() {
+    }
+
+    public RoleRepresentation(String name, String description, boolean scopeParamRequired) {
+        this.name = name;
+        this.description = description;
+        this.scopeParamRequired = scopeParamRequired;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Deprecated
+    public Boolean isScopeParamRequired() {
+        return scopeParamRequired;
+    }
+
+    public Composites getComposites() {
+        return composites;
+    }
+
+    public void setComposites(Composites composites) {
+        this.composites = composites;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public boolean isComposite() {
+        return composite;
+    }
+
+    public void setComposite(boolean composite) {
+        this.composite = composite;
+    }
+
+    public Boolean getClientRole() {
+        return clientRole;
+    }
+
+    public void setClientRole(Boolean clientRole) {
+        this.clientRole = clientRole;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    public RoleRepresentation singleAttribute(String name, String value) {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+
+        attributes.put(name, Arrays.asList(value));
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 29 * hash + Objects.hashCode(this.id);
+        hash = 29 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || (!(obj instanceof RoleRepresentation))) {
+            return false;
+        }
+        final RoleRepresentation other = (RoleRepresentation) obj;
+        return Objects.equals(this.id, other.id) && Objects.equals(this.name, other.name);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/RolesRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/RolesRepresentation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class RolesRepresentation {
+    protected List<RoleRepresentation> realm;
+    protected Map<String, List<RoleRepresentation>> client;
+    @Deprecated
+    protected Map<String, List<RoleRepresentation>> application;
+
+    public List<RoleRepresentation> getRealm() {
+        return realm;
+    }
+
+    public void setRealm(List<RoleRepresentation> realm) {
+        this.realm = realm;
+    }
+
+    public Map<String, List<RoleRepresentation>> getClient() {
+        return client;
+    }
+
+    public void setClient(Map<String, List<RoleRepresentation>> client) {
+        this.client = client;
+    }
+
+    @Deprecated
+    public Map<String, List<RoleRepresentation>> getApplication() {
+        return application;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/ScopeMappingRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/ScopeMappingRepresentation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ScopeMappingRepresentation {
+    protected String self; // link
+    protected String client;
+
+    @Deprecated // Replaced by clientScope
+    protected String clientTemplate;
+    protected String clientScope;
+    protected Set<String> roles;
+
+    public String getSelf() {
+        return self;
+    }
+
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    @Deprecated
+    public String getClientTemplate() {
+        return clientTemplate;
+    }
+
+    public String getClientScope() {
+        return clientScope;
+    }
+
+    public void setClientScope(String clientScope) {
+        this.clientScope = clientScope;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public ScopeMappingRepresentation role(String role) {
+        if (this.roles == null) this.roles = new HashSet<>();
+        this.roles.add(role);
+        return this;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/SecurityProfileConfiguration.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/SecurityProfileConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Default configuration for security profile. For the moment just a name and pointers
+ * to default global client profiles and policies.
+ *
+ * @author rmartinc
+ */
+public class SecurityProfileConfiguration {
+
+    private String name;
+    @JsonProperty("client-profiles")
+    private String clientProfiles;
+    @JsonProperty("client-policies")
+    private String clientPolicies;
+    @JsonIgnore
+    private List<ClientProfileRepresentation> defaultClientProfiles;
+    @JsonIgnore
+    private List<ClientPolicyRepresentation> defaultClientPolicies;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getClientProfiles() {
+        return clientProfiles;
+    }
+
+    public void setClientProfiles(String clientProfiles) {
+        this.clientProfiles = clientProfiles;
+    }
+
+    public String getClientPolicies() {
+        return clientPolicies;
+    }
+
+    public void setClientPolicies(String clientPolicies) {
+        this.clientPolicies = clientPolicies;
+    }
+
+    public List<ClientProfileRepresentation> getDefaultClientProfiles() {
+        return defaultClientProfiles;
+    }
+
+    public void setDefaultClientProfiles(List<ClientProfileRepresentation> defaultClientProfiles) {
+        this.defaultClientProfiles = defaultClientProfiles;
+    }
+
+    public List<ClientPolicyRepresentation> getDefaultClientPolicies() {
+        return defaultClientPolicies;
+    }
+
+    public void setDefaultClientPolicies(List<ClientPolicyRepresentation> defaultClientPolicies) {
+        this.defaultClientPolicies = defaultClientPolicies;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/SocialLinkRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/SocialLinkRepresentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SocialLinkRepresentation {
+
+    protected String socialProvider;
+    protected String socialUserId;
+    protected String socialUsername;
+
+    public String getSocialProvider() {
+        return socialProvider;
+    }
+
+    public void setSocialProvider(String socialProvider) {
+        this.socialProvider = socialProvider;
+    }
+
+    public String getSocialUserId() {
+        return socialUserId;
+    }
+
+    public void setSocialUserId(String socialUserId) {
+        this.socialUserId = socialUserId;
+    }
+
+    public String getSocialUsername() {
+        return socialUsername;
+    }
+
+    public void setSocialUsername(String socialUsername) {
+        this.socialUsername = socialUsername;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/SynchronizationResultRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/SynchronizationResultRepresentation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SynchronizationResultRepresentation {
+
+    private boolean ignored;
+
+    private int added;
+    private int updated;
+    private int removed;
+    private int failed;
+
+    private String status;
+
+    public SynchronizationResultRepresentation() {
+    }
+
+    public boolean isIgnored() {
+        return ignored;
+    }
+
+    public void setIgnored(boolean ignored) {
+        this.ignored = ignored;
+    }
+
+    public int getAdded() {
+        return added;
+    }
+
+    public void setAdded(int added) {
+        this.added = added;
+    }
+
+    public int getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(int updated) {
+        this.updated = updated;
+    }
+
+    public int getRemoved() {
+        return removed;
+    }
+
+    public void setRemoved(int removed) {
+        this.removed = removed;
+    }
+
+    public int getFailed() {
+        return failed;
+    }
+
+    public void setFailed(int failed) {
+        this.failed = failed;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/TestLdapConnectionRepresentation.java
@@ -1,0 +1,111 @@
+package org.keycloak.representations.idm;
+
+public class TestLdapConnectionRepresentation {
+
+    private String action;
+    private String connectionUrl;
+    private String bindDn;
+    private String bindCredential;
+    private String useTruststoreSpi;
+    private String connectionTimeout;
+    private String componentId;
+    private String startTls;
+    private String authType;
+
+    public TestLdapConnectionRepresentation() {
+    }
+
+    public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout) {
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, null, null, null);
+    }
+
+    public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential, String useTruststoreSpi, String connectionTimeout, String startTls, String authType) {
+        this(action, connectionUrl, bindDn, bindCredential, useTruststoreSpi, connectionTimeout, startTls, authType, null);
+    }
+
+    public TestLdapConnectionRepresentation(String action, String connectionUrl, String bindDn, String bindCredential,
+            String useTruststoreSpi, String connectionTimeout, String startTls, String authType, String componentId) {
+        this.action = action;
+        this.connectionUrl = connectionUrl;
+        this.bindDn = bindDn;
+        this.bindCredential = bindCredential;
+        this.useTruststoreSpi = useTruststoreSpi;
+        this.connectionTimeout = connectionTimeout;
+        this.startTls = startTls;
+        this.authType = authType;
+        this.componentId = componentId;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getConnectionUrl() {
+        return connectionUrl;
+    }
+
+    public void setConnectionUrl(String connectionUrl) {
+        this.connectionUrl = connectionUrl;
+    }
+
+    public String getAuthType() {
+        return authType;
+    }
+
+    public void setAuthType(String authType) {
+        this.authType = authType;
+    }
+
+    public String getBindDn() {
+        return bindDn;
+    }
+
+    public void setBindDn(String bindDn) {
+        this.bindDn = bindDn;
+    }
+
+    public String getBindCredential() {
+        return bindCredential;
+    }
+
+    public void setBindCredential(String bindCredential) {
+        this.bindCredential = bindCredential;
+    }
+
+    public String getUseTruststoreSpi() {
+        return useTruststoreSpi;
+    }
+
+    public void setUseTruststoreSpi(String useTruststoreSpi) {
+        this.useTruststoreSpi = useTruststoreSpi;
+    }
+
+    public String getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(String connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public String getComponentId() {
+        return componentId;
+    }
+
+    public void setComponentId(String componentId) {
+        this.componentId = componentId;
+    }
+
+    public String getStartTls() {
+        return startTls;
+    }
+
+    public void setStartTls(String startTls) {
+        this.startTls = startTls;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserConsentRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserConsentRepresentation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class UserConsentRepresentation {
+
+    protected String clientId;
+
+    protected List<String> grantedClientScopes;
+
+    private Long createdDate;
+
+    private Long lastUpdatedDate;
+
+    @Deprecated
+    protected List<String> grantedRealmRoles;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public List<String> getGrantedClientScopes() {
+        return grantedClientScopes;
+    }
+
+    public void setGrantedClientScopes(List<String> grantedClientScopes) {
+        this.grantedClientScopes = grantedClientScopes;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setLastUpdatedDate(Long lastUpdatedDate) {
+        this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    public Long getLastUpdatedDate() {
+        return lastUpdatedDate;
+    }
+
+    @Deprecated
+    public List<String> getGrantedRealmRoles() {
+        return grantedRealmRoles;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperRepresentation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class UserFederationMapperRepresentation {
+
+    protected String id;
+    protected String name;
+    protected String federationProviderDisplayName;
+    protected String federationMapperType;
+    protected Map<String, String> config;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getFederationProviderDisplayName() {
+        return federationProviderDisplayName;
+    }
+
+    public void setFederationProviderDisplayName(String federationProviderDisplayName) {
+        this.federationProviderDisplayName = federationProviderDisplayName;
+    }
+
+    public String getFederationMapperType() {
+        return federationMapperType;
+    }
+
+    public void setFederationMapperType(String federationMapperType) {
+        this.federationMapperType = federationMapperType;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}
+

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperSyncConfigRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperSyncConfigRepresentation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class UserFederationMapperSyncConfigRepresentation {
+
+    private Boolean fedToKeycloakSyncSupported;
+    private String fedToKeycloakSyncMessage; // applicable just if fedToKeycloakSyncSupported is true
+
+    private Boolean keycloakToFedSyncSupported;
+    private String keycloakToFedSyncMessage; // applicable just if keycloakToFedSyncSupported is true
+
+    public UserFederationMapperSyncConfigRepresentation() {
+    }
+
+    public UserFederationMapperSyncConfigRepresentation(boolean fedToKeycloakSyncSupported, String fedToKeycloakSyncMessage,
+                                                        boolean keycloakToFedSyncSupported, String keycloakToFedSyncMessage) {
+        this.fedToKeycloakSyncSupported = fedToKeycloakSyncSupported;
+        this.fedToKeycloakSyncMessage = fedToKeycloakSyncMessage;
+        this.keycloakToFedSyncSupported = keycloakToFedSyncSupported;
+        this.keycloakToFedSyncMessage = keycloakToFedSyncMessage;
+    }
+
+    public Boolean isFedToKeycloakSyncSupported() {
+        return fedToKeycloakSyncSupported;
+    }
+
+    public void setFedToKeycloakSyncSupported(Boolean fedToKeycloakSyncSupported) {
+        this.fedToKeycloakSyncSupported = fedToKeycloakSyncSupported;
+    }
+
+    public String getFedToKeycloakSyncMessage() {
+        return fedToKeycloakSyncMessage;
+    }
+
+    public void setFedToKeycloakSyncMessage(String fedToKeycloakSyncMessage) {
+        this.fedToKeycloakSyncMessage = fedToKeycloakSyncMessage;
+    }
+
+    public Boolean isKeycloakToFedSyncSupported() {
+        return keycloakToFedSyncSupported;
+    }
+
+    public void setKeycloakToFedSyncSupported(Boolean keycloakToFedSyncSupported) {
+        this.keycloakToFedSyncSupported = keycloakToFedSyncSupported;
+    }
+
+    public String getKeycloakToFedSyncMessage() {
+        return keycloakToFedSyncMessage;
+    }
+
+    public void setKeycloakToFedSyncMessage(String keycloakToFedSyncMessage) {
+        this.keycloakToFedSyncMessage = keycloakToFedSyncMessage;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperTypeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserFederationMapperTypeRepresentation.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class UserFederationMapperTypeRepresentation {
+    protected String id;
+    protected String name;
+    protected String category;
+    protected String helpText;
+
+    protected UserFederationMapperSyncConfigRepresentation syncConfig;
+    protected List<ConfigPropertyRepresentation> properties  = new LinkedList<>();
+    protected Map<String, String> defaultConfig = new HashMap<>();
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public UserFederationMapperSyncConfigRepresentation getSyncConfig() {
+        return syncConfig;
+    }
+
+    public void setSyncConfig(UserFederationMapperSyncConfigRepresentation syncConfig) {
+        this.syncConfig = syncConfig;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, String> getDefaultConfig() {
+        return defaultConfig;
+    }
+
+    public void setDefaultConfig(Map<String, String> defaultConfig) {
+        this.defaultConfig = defaultConfig;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserFederationProviderFactoryRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserFederationProviderFactoryRepresentation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bburke@redhat.com">Bill Burke</a>
+ */
+public class UserFederationProviderFactoryRepresentation {
+
+    private String id;
+    private Set<String> options; // TODO:Remove as configurable providers are more flexible?
+    private String helpText; // Used for configurable providers
+    private List<ConfigPropertyRepresentation> properties; // Used for configurable providers
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Set<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Set<String> options) {
+        this.options = options;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public List<ConfigPropertyRepresentation> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigPropertyRepresentation> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UserFederationProviderFactoryRepresentation that = (UserFederationProviderFactoryRepresentation) o;
+
+        if (!id.equals(that.id)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserFederationProviderRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserFederationProviderRepresentation.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class UserFederationProviderRepresentation {
+
+    private String id;
+    private String displayName;
+    private String providerName;
+    private Map<String, String> config;
+    private int priority;
+    private int fullSyncPeriod;
+    private int changedSyncPeriod;
+    private int lastSync;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public int getFullSyncPeriod() {
+        return fullSyncPeriod;
+    }
+
+    public void setFullSyncPeriod(int fullSyncPeriod) {
+        this.fullSyncPeriod = fullSyncPeriod;
+    }
+
+    public int getChangedSyncPeriod() {
+        return changedSyncPeriod;
+    }
+
+    public void setChangedSyncPeriod(int changedSyncPeriod) {
+        this.changedSyncPeriod = changedSyncPeriod;
+    }
+
+    public int getLastSync() {
+        return lastSync;
+    }
+
+    public void setLastSync(int lastSync) {
+        this.lastSync = lastSync;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UserFederationProviderRepresentation that = (UserFederationProviderRepresentation) o;
+
+        if (!id.equals(that.id)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserProfileAttributeGroupMetadata.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserProfileAttributeGroupMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+public class UserProfileAttributeGroupMetadata {
+
+    private String name;
+    private String displayHeader;
+    private String displayDescription;
+    private Map<String, Object> annotations;
+
+    public UserProfileAttributeGroupMetadata() {
+    }
+
+    public UserProfileAttributeGroupMetadata(String name, String displayHeader, String displayDescription, Map<String, Object> annotations) {
+        this.name = name;
+        this.displayHeader = displayHeader;
+        this.displayDescription = displayDescription;
+        this.annotations = annotations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisplayHeader() {
+        return displayHeader;
+    }
+
+
+    public String getDisplayDescription() {
+        return displayDescription;
+    }
+
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserProfileAttributeMetadata.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserProfileAttributeMetadata.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import java.util.Map;
+
+/**
+ * @author Vlastimil Elias <velias@redhat.com>
+ */
+public class UserProfileAttributeMetadata {
+
+    private String name;
+    private String displayName;
+    private boolean required;
+    private boolean readOnly;
+    private Map<String, Object> annotations;
+    private Map<String, Map<String, Object>> validators;
+    private String group;
+    private boolean multivalued;
+
+    public UserProfileAttributeMetadata() {
+
+    }
+
+    public UserProfileAttributeMetadata(String name, String displayName, boolean required, boolean readOnly, String group, Map<String, Object> annotations,
+            Map<String, Map<String, Object>> validators, boolean multivalued) {
+        this.name = name;
+        this.displayName = displayName;
+        this.required = required;
+        this.readOnly = readOnly;
+        this.annotations = annotations;
+        this.validators = validators;
+        this.group = group;
+        this.multivalued = multivalued;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return display name, either direct string to display, or construct for i18n like <code>${i18nkey}</code>
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    /**
+     * Get info about attribute annotations loaded from UserProfile configuration.
+     */
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    /**
+     * Get info about validators applied to attribute.
+     * 
+     * @return map where key is validatorId and value is map with configuration for given validator (loaded from UserProfile configuration)
+     */
+    public Map<String, Map<String, Object>> getValidators() {
+        return validators;
+    }
+
+    public void setMultivalued(boolean multivalued) {
+        this.multivalued = multivalued;
+    }
+
+    public boolean isMultivalued() {
+        return multivalued;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserProfileMetadata.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserProfileMetadata.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Vlastimil Elias <velias@redhat.com>
+ */
+public class UserProfileMetadata {
+
+    private List<UserProfileAttributeMetadata> attributes;
+    private List<UserProfileAttributeGroupMetadata> groups;
+
+    public UserProfileMetadata() {
+
+    }
+
+    public UserProfileMetadata(List<UserProfileAttributeMetadata> attributes, List<UserProfileAttributeGroupMetadata> groups) {
+        super();
+        this.attributes = attributes;
+        this.groups = groups;
+    }
+
+    public List<UserProfileAttributeMetadata> getAttributes() {
+        return attributes;
+    }
+
+    public List<UserProfileAttributeGroupMetadata> getGroups() {
+        return groups;
+    }
+
+    public void setAttributes(List<UserProfileAttributeMetadata> attributes) {
+        this.attributes = attributes;
+    }
+
+    public UserProfileAttributeMetadata getAttributeMetadata(String name) {
+        for (UserProfileAttributeMetadata m : Optional.ofNullable(getAttributes()).orElse(emptyList())) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+
+        return null;
+    }
+
+    public UserProfileAttributeGroupMetadata getAttributeGroupMetadata(String name) {
+        for (UserProfileAttributeGroupMetadata m : Optional.ofNullable(getGroups()).orElse(emptyList())) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+
+        return null;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class UserRepresentation extends AbstractUserRepresentation{
+
+    protected String self; // link
+    protected String origin;
+    protected Long createdTimestamp;
+    protected Boolean enabled;
+    protected Boolean totp;
+    protected String federationLink;
+    protected String serviceAccountClientId; // For rep, it points to clientId (not DB ID)
+
+    protected List<CredentialRepresentation> credentials;
+    protected Set<String> disableableCredentialTypes;
+    protected List<String> requiredActions;
+    protected List<FederatedIdentityRepresentation> federatedIdentities;
+    protected List<String> realmRoles;
+    protected Map<String, List<String>> clientRoles;
+    protected List<UserConsentRepresentation> clientConsents;
+    protected Integer notBefore;
+
+    @Deprecated
+    protected Map<String, List<String>> applicationRoles;
+    @Deprecated
+    protected List<SocialLinkRepresentation> socialLinks;
+
+    protected List<String> groups;
+    private Map<String, Boolean> access;
+
+    public String getSelf() {
+        return self;
+    }
+
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+    public Long getCreatedTimestamp() {
+        return createdTimestamp;
+    }
+
+    public void setCreatedTimestamp(Long createdTimestamp) {
+        this.createdTimestamp = createdTimestamp;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Deprecated
+    public Boolean isTotp() {
+        return totp;
+    }
+
+    @Deprecated
+    public void setTotp(Boolean totp) {
+        this.totp = totp;
+    }
+
+    public List<CredentialRepresentation> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<CredentialRepresentation> credentials) {
+        this.credentials = credentials;
+    }
+
+    public List<String> getRequiredActions() {
+        return requiredActions;
+    }
+
+    public void setRequiredActions(List<String> requiredActions) {
+        this.requiredActions = requiredActions;
+    }
+
+    public List<FederatedIdentityRepresentation> getFederatedIdentities() {
+        return federatedIdentities;
+    }
+
+    public void setFederatedIdentities(List<FederatedIdentityRepresentation> federatedIdentities) {
+        this.federatedIdentities = federatedIdentities;
+    }
+
+    public List<SocialLinkRepresentation> getSocialLinks() {
+        return socialLinks;
+    }
+
+    public void setSocialLinks(List<SocialLinkRepresentation> socialLinks) {
+        this.socialLinks = socialLinks;
+    }
+
+    public List<String> getRealmRoles() {
+        return realmRoles;
+    }
+
+    public void setRealmRoles(List<String> realmRoles) {
+        this.realmRoles = realmRoles;
+    }
+
+    public Map<String, List<String>> getClientRoles() {
+        return clientRoles;
+    }
+
+    public void setClientRoles(Map<String, List<String>> clientRoles) {
+        this.clientRoles = clientRoles;
+    }
+
+    public List<UserConsentRepresentation> getClientConsents() {
+        return clientConsents;
+    }
+
+    public void setClientConsents(List<UserConsentRepresentation> clientConsents) {
+        this.clientConsents = clientConsents;
+    }
+
+    public Integer getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(Integer notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    @Deprecated
+    public Map<String, List<String>> getApplicationRoles() {
+        return applicationRoles;
+    }
+
+    public String getFederationLink() {
+        return federationLink;
+    }
+
+    public void setFederationLink(String federationLink) {
+        this.federationLink = federationLink;
+    }
+
+    public String getServiceAccountClientId() {
+        return serviceAccountClientId;
+    }
+
+    public void setServiceAccountClientId(String serviceAccountClientId) {
+        this.serviceAccountClientId = serviceAccountClientId;
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
+    }
+
+    /**
+     * Returns id of UserStorageProvider that loaded this user
+     *
+     * @return NULL if user stored locally
+     */
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public Set<String> getDisableableCredentialTypes() {
+        return disableableCredentialTypes;
+    }
+
+    public void setDisableableCredentialTypes(Set<String> disableableCredentialTypes) {
+        this.disableableCredentialTypes = disableableCredentialTypes;
+    }
+
+    public Map<String, Boolean> getAccess() {
+        return access;
+    }
+
+    public void setAccess(Map<String, Boolean> access) {
+        this.access = access;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class UserSessionRepresentation {
+    private String id;
+    private String username;
+    private String userId;
+    private String ipAddress;
+    private long start;
+    private long lastAccess;
+    private boolean rememberMe;
+    private Map<String, String> clients = new HashMap<>();
+    private boolean transientUser;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public void setStart(long start) {
+        this.start = start;
+    }
+
+    public long getLastAccess() {
+        return lastAccess;
+    }
+
+    public void setLastAccess(long lastAccess) {
+        this.lastAccess = lastAccess;
+    }
+
+    public boolean isRememberMe() {
+        return rememberMe;
+    }
+
+    public void setRememberMe(boolean rememberMe) {
+        this.rememberMe = rememberMe;
+    }
+
+    public Map<String, String> getClients() {
+        return clients;
+    }
+
+    public void setClients(Map<String, String> clients) {
+        this.clients = clients;
+    }
+
+    public boolean isTransientUser() {
+        return transientUser;
+    }
+
+    public void setTransientUser(boolean transientUser) {
+        this.transientUser = transientUser;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/AbstractPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/AbstractPolicyRepresentation.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class AbstractPolicyRepresentation {
+
+    private String id;
+    private String name;
+    private String description;
+    private String type;
+    private Set<String> policies;
+    private Set<String> resources;
+    private Set<String> scopes;
+    private Logic logic = Logic.POSITIVE;
+    private DecisionStrategy decisionStrategy = DecisionStrategy.UNANIMOUS;
+    private String owner;
+    
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Set<ResourceRepresentation> resourcesData;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Set<ScopeRepresentation> scopesData;
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public DecisionStrategy getDecisionStrategy() {
+        return this.decisionStrategy;
+    }
+
+    public void setDecisionStrategy(DecisionStrategy decisionStrategy) {
+        this.decisionStrategy = decisionStrategy;
+    }
+
+    public Logic getLogic() {
+        return logic;
+    }
+
+    public void setLogic(Logic logic) {
+        this.logic = logic;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Set<String> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(Set<String> policies) {
+        this.policies = policies;
+    }
+
+    public void addPolicy(String... id) {
+        if (this.policies == null) {
+            this.policies = new HashSet<>();
+        }
+        this.policies.addAll(Arrays.asList(id));
+    }
+
+    public void removePolicy(String policy) {
+        if (policies != null) {
+            policies.remove(policy);
+        }
+    }
+
+    public Set<String> getResources() {
+        return resources;
+    }
+
+    public void setResources(Set<String> resources) {
+        this.resources = resources;
+    }
+
+    public void addResource(String id) {
+        if (this.resources == null) {
+            this.resources = new HashSet<>();
+        }
+        this.resources.add(id);
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public void addScope(String... id) {
+        if (this.scopes == null) {
+            this.scopes = new HashSet<>();
+        }
+        this.scopes.addAll(Arrays.asList(id));
+    }
+
+    public void removeScope(String scope) {
+        if (scopes != null) {
+            scopes.remove(scope);
+        }
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final AbstractPolicyRepresentation policy = (AbstractPolicyRepresentation) o;
+        return Objects.equals(getId(), policy.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+
+    public <R> void setResourcesData(Set<ResourceRepresentation> resources) {
+        this.resourcesData = resources;
+    }
+
+    public Set<ResourceRepresentation> getResourcesData() {
+        return resourcesData;
+    }
+
+    public void setScopesData(Set<ScopeRepresentation> scopesData) {
+        this.scopesData = scopesData;
+    }
+
+    public Set<ScopeRepresentation> getScopesData() {
+        return scopesData;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/AggregatePolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/AggregatePolicyRepresentation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class AggregatePolicyRepresentation extends AbstractPolicyRepresentation {
+
+    @Override
+    public String getType() {
+        return "aggregate";
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationRequest.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationRequest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.representations.AccessToken;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class AuthorizationRequest {
+
+    private String ticket;
+    private String claimToken;
+    private String claimTokenFormat;
+    private String pct;
+    private String scope;
+    private PermissionTicketToken permissions = new PermissionTicketToken();
+    private Metadata metadata;
+    private String audience;
+    private String subjectToken;
+    private boolean submitRequest;
+    private Map<String, List<String>> claims;
+    private AccessToken rpt;
+    private String rptToken;
+
+    public AuthorizationRequest(String ticket) {
+        this.ticket = ticket;
+    }
+
+    public AuthorizationRequest() {
+        this(null);
+    }
+
+    public String getTicket() {
+        return this.ticket;
+    }
+
+    public void setTicket(String ticket) {
+        this.ticket = ticket;
+    }
+
+    public AccessToken getRpt() {
+        return this.rpt;
+    }
+
+    public void setRpt(AccessToken rpt) {
+        this.rpt = rpt;
+    }
+
+    public void setRpt(String rpt) {
+        this.rptToken = rpt;
+    }
+
+    public String getRptToken() {
+        return rptToken;
+    }
+
+    public void setClaimToken(String claimToken) {
+        this.claimToken = claimToken;
+    }
+
+    public String getClaimToken() {
+        return claimToken;
+    }
+
+    public void setClaimTokenFormat(String claimTokenFormat) {
+        this.claimTokenFormat = claimTokenFormat;
+    }
+
+    public String getClaimTokenFormat() {
+        return claimTokenFormat;
+    }
+
+    public void setPct(String pct) {
+        this.pct = pct;
+    }
+
+    public String getPct() {
+        return pct;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setPermissions(PermissionTicketToken permissions) {
+        this.permissions = permissions;
+    }
+
+    public PermissionTicketToken getPermissions() {
+        return permissions;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public void setAudience(String audience) {
+        this.audience = audience;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public void setSubjectToken(String subjectToken) {
+        this.subjectToken = subjectToken;
+    }
+
+    public String getSubjectToken() {
+        return subjectToken;
+    }
+
+    public Map<String, List<String>> getClaims() {
+        return claims;
+    }
+
+    public void setClaims(Map<String, List<String>> claims) {
+        this.claims = claims;
+    }
+
+    public void addPermission(String resourceId, List<String> scopes) {
+        addPermission(resourceId, scopes.toArray(new String[scopes.size()]));
+    }
+
+    public void addPermission(String resourceId, String... scopes) {
+        if (permissions == null) {
+            permissions = new PermissionTicketToken(new ArrayList<Permission>());
+        }
+
+        Permission permission = null;
+
+        for (Permission resourcePermission : permissions.getPermissions()) {
+            if (resourcePermission.getResourceId() != null && resourcePermission.getResourceId().equals(resourceId)) {
+                permission = resourcePermission;
+                break;
+            }
+        }
+
+        if (permission == null) {
+            permission = new Permission(resourceId, new HashSet<String>());
+            permissions.getPermissions().add(permission);
+        }
+
+        permission.getScopes().addAll(Arrays.asList(scopes));
+    }
+
+    public void setSubmitRequest(boolean submitRequest) {
+        this.submitRequest = submitRequest;
+    }
+
+    public boolean isSubmitRequest() {
+        return submitRequest && ticket != null;
+    }
+
+    public static class Metadata {
+
+        private Boolean includeResourceName;
+        private Integer limit;
+        private String responseMode;
+        private String permissionResourceFormat;
+        private Boolean permissionResourceMatchingUri;
+
+        public Boolean getIncludeResourceName() {
+            if (includeResourceName == null) {
+                includeResourceName = Boolean.TRUE;
+            }
+            return includeResourceName;
+        }
+
+        public void setIncludeResourceName(Boolean includeResourceName) {
+            this.includeResourceName = includeResourceName;
+        }
+
+        public Integer getLimit() {
+            return limit;
+        }
+
+        public void setLimit(Integer limit) {
+            this.limit = limit;
+        }
+
+        public void setResponseMode(String responseMode) {
+            this.responseMode = responseMode;
+        }
+
+        public String getResponseMode() {
+            return responseMode;
+        }
+
+        public String getPermissionResourceFormat() {
+            return permissionResourceFormat;
+        }
+
+        public void setPermissionResourceFormat(String permissionResourceFormat) {
+            this.permissionResourceFormat = permissionResourceFormat;
+        }
+
+        public Boolean getPermissionResourceMatchingUri() {
+            return permissionResourceMatchingUri;
+        }
+
+        public void setPermissionResourceMatchingUri(Boolean permissionResourceMatchingUri) {
+            this.permissionResourceMatchingUri = permissionResourceMatchingUri;
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationResponse.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/AuthorizationResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+import org.keycloak.representations.AccessTokenResponse;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class AuthorizationResponse extends AccessTokenResponse {
+
+    private boolean upgraded;
+
+    public AuthorizationResponse() {
+    }
+
+    public AuthorizationResponse(AccessTokenResponse response, boolean upgraded) {
+        setToken(response.getToken());
+        setTokenType("Bearer");
+        setRefreshToken(response.getRefreshToken());
+        setRefreshExpiresIn(response.getRefreshExpiresIn());
+        setExpiresIn(response.getExpiresIn());
+        setNotBeforePolicy(response.getNotBeforePolicy());
+        this.upgraded = upgraded;
+    }
+
+    public boolean isUpgraded() {
+        return upgraded;
+    }
+
+    public void setUpgraded(boolean upgraded) {
+        this.upgraded = upgraded;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ClientPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ClientPolicyRepresentation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ClientPolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private Set<String> clients;
+
+    @Override
+    public String getType() {
+        return "client";
+    }
+
+    public Set<String> getClients() {
+        return clients;
+    }
+
+    public void setClients(Set<String> clients) {
+        this.clients = clients;
+    }
+
+    public void addClient(String... id) {
+        if (this.clients == null) {
+            this.clients = new HashSet<>();
+        }
+        this.clients.addAll(Arrays.asList(id));
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ClientScopePolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ClientScopePolicyRepresentation.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
+ */
+public class ClientScopePolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private Set<ClientScopeDefinition> clientScopes;
+
+    @Override
+    public String getType() {
+        return "client-scope";
+    }
+
+    public Set<ClientScopeDefinition> getClientScopes() {
+        return clientScopes;
+    }
+
+    public void setClientScopes(Set<ClientScopeDefinition> clientScopes) {
+        this.clientScopes = clientScopes;
+    }
+
+    public void addClientScope(String name, boolean required) {
+        if (clientScopes == null) {
+            clientScopes = new HashSet<>();
+        }
+        clientScopes.add(new ClientScopeDefinition(name, required));
+    }
+
+    public void addClientScope(String name) {
+        addClientScope(name, false);
+    }
+
+    public static class ClientScopeDefinition {
+        private String id;
+        private boolean required;
+
+        public ClientScopeDefinition() {
+            this(null, false);
+        }
+
+        public ClientScopeDefinition(String id, boolean required) {
+            this.id = id;
+            this.required = required;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/DecisionEffect.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/DecisionEffect.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public enum DecisionEffect {
+    PERMIT,
+    DENY
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/DecisionStrategy.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/DecisionStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Map;
+import java.util.Objects;
+import org.keycloak.util.EnumWithStableIndex;
+
+/**
+ * The decision strategy dictates how the policies associated with a given policy are evaluated and how a final decision
+ * is obtained.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public enum DecisionStrategy implements EnumWithStableIndex {
+
+    /**
+     * Defines that at least one policy must evaluate to a positive decision in order to the overall decision be also positive.
+     */
+    AFFIRMATIVE(0),
+
+    /**
+     * Defines that all policies must evaluate to a positive decision in order to the overall decision be also positive.
+     */
+    UNANIMOUS(1),
+
+    /**
+     * Defines that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same,
+     * the final decision will be negative.
+     */
+    CONSENSUS(2);
+
+    private final int stableIndex;
+    private static final Map<Integer, DecisionStrategy> BY_ID = EnumWithStableIndex.getReverseIndex(values());
+
+    private DecisionStrategy(int stableIndex) {
+        Objects.requireNonNull(stableIndex);
+        this.stableIndex = stableIndex;
+    }
+
+    @Override
+    public int getStableIndex() {
+        return stableIndex;
+    }
+
+    public static DecisionStrategy valueOfInteger(Integer id) {
+        return id == null ? null : BY_ID.get(id);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/GroupPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/GroupPolicyRepresentation.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class GroupPolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private String groupsClaim;
+    private Set<GroupDefinition> groups;
+
+    @Override
+    public String getType() {
+        return "group";
+    }
+
+    public String getGroupsClaim() {
+        return groupsClaim;
+    }
+
+    public void setGroupsClaim(String groupsClaim) {
+        this.groupsClaim = groupsClaim;
+    }
+
+    public Set<GroupDefinition> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<GroupDefinition> groups) {
+        this.groups = groups;
+    }
+
+    public void addGroup(String... ids) {
+        for (String id : ids) {
+            addGroup(id, false);
+        }
+    }
+
+    public void addGroup(String id, boolean extendChildren) {
+        if (groups == null) {
+            groups = new HashSet<>();
+        }
+        groups.add(new GroupDefinition(id, extendChildren));
+    }
+
+    public void addGroupPath(String... paths) {
+        for (String path : paths) {
+            addGroupPath(path, false);
+        }
+    }
+
+    public void addGroupPath(String path, boolean extendChildren) {
+        if (groups == null) {
+            groups = new HashSet<>();
+        }
+        groups.add(new GroupDefinition(null, path, extendChildren));
+    }
+
+    public void removeGroup(String... ids) {
+        if (groups != null) {
+            for (String id : ids) {
+                Iterator<GroupDefinition> iterator = groups.iterator();
+                while (iterator.hasNext()) {
+                    GroupDefinition group = iterator.next();
+                    if (id.equals(group.getId()) || (group.getPath() != null && group.getPath().equals(id))) {
+                        iterator.remove();
+                    }
+                }
+            }
+        }
+    }
+
+    public static class GroupDefinition implements Comparable<GroupDefinition> {
+
+        private String id;
+        private String path;
+        private boolean extendChildren;
+
+        public GroupDefinition() {
+            this(null);
+        }
+
+        public GroupDefinition(String id) {
+            this(id, false);
+        }
+
+        public GroupDefinition(String id, boolean extendChildren) {
+            this(id, null, extendChildren);
+        }
+
+        public GroupDefinition(String id, String path, boolean extendChildren) {
+            this.id = id;
+            this.path = path;
+            this.extendChildren = extendChildren;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public boolean isExtendChildren() {
+            return extendChildren;
+        }
+
+        public void setExtendChildren(boolean extendChildren) {
+            this.extendChildren = extendChildren;
+        }
+
+        @Override
+        public int compareTo(GroupDefinition o) {
+            if (o.id == null || id == null) {
+                return 1;
+            }
+            return id.compareTo(o.id);
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/JSPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/JSPolicyRepresentation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class JSPolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private String code;
+
+    @Override
+    public String getType() {
+        if (super.getType() == null) {
+            return "js";
+        }
+        return super.getType();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/Logic.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/Logic.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Map;
+import java.util.Objects;
+import org.keycloak.util.EnumWithStableIndex;
+
+/**
+ * The decision strategy dictates how the policies associated with a given policy are evaluated and how a final decision
+ * is obtained.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public enum Logic implements EnumWithStableIndex {
+
+    /**
+     * Defines that this policy follows a positive logic. In other words, the final decision is the policy outcome.
+     */
+    POSITIVE(0),
+
+    /**
+     * Defines that this policy uses a logical negation. In other words, the final decision would be a negative of the policy outcome.
+     */
+    NEGATIVE(1);
+
+    private final int stableIndex;
+    private static final Map<Integer, Logic> BY_ID = EnumWithStableIndex.getReverseIndex(values());
+
+    private Logic(int stableIndex) {
+        Objects.requireNonNull(stableIndex);
+        this.stableIndex = stableIndex;
+    }
+
+    @Override
+    public int getStableIndex() {
+        return stableIndex;
+    }
+
+    public static Logic valueOfInteger(Integer id) {
+        return id == null ? null : BY_ID.get(id);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Permission {
+
+    @JsonProperty("rsid")
+    private String resourceId;
+
+    @JsonProperty("rsname")
+    private String resourceName;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Set<String> scopes;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, Set<String>> claims;
+
+    public Permission() {
+        this(null, null, null, null);
+    }
+
+    public Permission(final String resourceId, final Set<String> scopes) {
+        this(resourceId, null, scopes, null);
+    }
+
+    public Permission(final String resourceId, String resourceName, final Set<String> scopes, Map<String, Set<String>> claims) {
+        this.resourceId = resourceId;
+        this.resourceName = resourceName;
+        this.scopes = scopes;
+        this.claims = claims;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getResourceId() {
+        if (resourceId == null || "".equals(resourceId.trim())) {
+            return null;
+        }
+        return this.resourceId;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public String getResourceName() {
+        return this.resourceName;
+    }
+
+    public Set<String> getScopes() {
+        if (this.scopes == null) {
+            this.scopes = new HashSet<>();
+        }
+
+        return this.scopes;
+    }
+
+    public Map<String, Set<String>> getClaims() {
+        return claims;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !getClass().isAssignableFrom(o.getClass())) return false;
+
+        Permission that = (Permission) o;
+
+        if (getResourceId() != null || getResourceName() != null) {
+            if (!getResourceId().equals(that.resourceId)) {
+                return false;
+            }
+
+            if (getScopes().isEmpty() && that.getScopes().isEmpty()) {
+                return true;
+            }
+        } else if (that.resourceId != null) {
+            return false;
+        }
+
+        for (String scope : that.getScopes()) {
+            if (getScopes().contains(scope)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceId);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("Permission {").append("id=").append(resourceId).append(", name=").append(resourceName)
+                .append(", scopes=").append(scopes).append("}");
+
+        return builder.toString();
+    }
+
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionRequest.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionRequest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.keycloak.json.StringListMapDeserializer;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionRequest {
+
+    private String resourceId;
+    private Set<String> scopes;
+    private String resourceServerId;
+
+    @JsonDeserialize(using = StringListMapDeserializer.class)
+    private Map<String, List<String>> claims;
+
+    public PermissionRequest(String resourceId, String... scopes) {
+        this.resourceId = resourceId;
+        if (scopes != null) {
+            this.scopes = new HashSet<>(Arrays.asList(scopes));
+        }
+    }
+
+    public PermissionRequest() {
+        this(null, null);
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    @JsonProperty("resource_id")
+    public void setResourceId(String resourceSetId) {
+        this.resourceId = resourceSetId;
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    @JsonProperty("resource_scopes")
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    @JsonProperty("resource_server_id")
+    public void setResourceServerId(String resourceServerId) {
+        this.resourceServerId = resourceServerId;
+    }
+
+    public String getResourceServerId() {
+        return resourceServerId;
+    }
+
+    public Map<String, List<String>> getClaims() {
+        return claims;
+    }
+
+    public void setClaims(Map<String, List<String>> claims) {
+        this.claims = claims;
+    }
+
+    public void setClaim(String name, String... value) {
+        if (claims == null) {
+            claims = new HashMap<>();
+        }
+
+        claims.put(name, Arrays.asList(value));
+    }
+
+    public void addScope(String... name) {
+        if (scopes == null) {
+            scopes = new HashSet<>();
+        }
+
+        scopes.addAll(Arrays.asList(name));
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionResponse.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionResponse {
+
+    private final String ticket;
+
+    public PermissionResponse(String ticket) {
+        this.ticket = ticket;
+    }
+
+    public PermissionResponse() {
+        this(null);
+    }
+
+    public String getTicket() {
+        return this.ticket;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketRepresentation.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionTicketRepresentation {
+
+    private String id;
+    private String owner;
+    private String resource;
+    private String scope;
+    private boolean granted;
+    private String scopeName;
+    private String resourceName;
+    private String requester; 
+    private String ownerName;
+    private String requesterName;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public boolean isGranted() {
+        return granted;
+    }
+
+    public void setGranted(boolean granted) {
+        this.granted = granted;
+    }
+
+    public void setScopeName(String scopeName) {
+        this.scopeName = scopeName;
+    }
+
+    public String getScopeName() {
+        return scopeName;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+    
+    public void setRequesterName(String requesterName) {
+        this.requesterName = requesterName;
+    }
+
+    public String getRequesterName() {
+        return requesterName;
+    }
+    
+    public void setRequester(String requester) {
+        this.requester = requester;
+    }
+
+    public String getRequester() {
+        return requester;
+    }
+    
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketToken.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketToken.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.keycloak.TokenIdGenerator;
+import org.keycloak.json.StringListMapDeserializer;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionTicketToken extends JsonWebToken {
+
+    private final List<Permission> permissions;
+
+    @JsonDeserialize(using = StringListMapDeserializer.class)
+    private Map<String, List<String>> claims;
+
+    public PermissionTicketToken() {
+        this(new ArrayList<Permission>());
+    }
+
+    public PermissionTicketToken(List<Permission> permissions, String audience, AccessToken accessToken) {
+        if (accessToken != null) {
+            id(TokenIdGenerator.generateId());
+            subject(accessToken.getSubject());
+            this.exp(accessToken.getExp());
+            this.nbf(accessToken.getNbf());
+            iat(accessToken.getIat());
+            issuedFor(accessToken.getIssuedFor());
+        }
+        if (audience != null) {
+            audience(audience);
+        }
+        this.permissions = permissions;
+    }
+
+    public PermissionTicketToken(List<Permission> resources) {
+        this(resources, null, null);
+    }
+
+    public List<Permission> getPermissions() {
+        return this.permissions;
+    }
+
+    public Map<String, List<String>> getClaims() {
+        return claims;
+    }
+
+    public void setClaims(Map<String, List<String>> claims) {
+        this.claims = claims;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEnforcementMode.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEnforcementMode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Map;
+import java.util.Objects;
+import org.keycloak.util.EnumWithStableIndex;
+
+/**
+ * The policy enforcement mode dictates how authorization requests are handled by the server.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public enum PolicyEnforcementMode implements EnumWithStableIndex {
+
+    /**
+     * Requests are denied by default even when there is no policy associated with a given resource.
+     */
+    ENFORCING(0),
+
+    /**
+     * Requests are allowed even when there is no policy associated with a given resource.
+     */
+    PERMISSIVE(1),
+
+    /**
+     * Completely disables the evaluation of policies and allow access to any resource.
+     */
+    DISABLED(2);
+
+    private final int stableIndex;
+    private static final Map<Integer, PolicyEnforcementMode> BY_ID = EnumWithStableIndex.getReverseIndex(values());
+
+    private PolicyEnforcementMode(int stableIndex) {
+        Objects.requireNonNull(stableIndex);
+        this.stableIndex = stableIndex;
+    }
+
+    @Override
+    public int getStableIndex() {
+        return stableIndex;
+    }
+
+    public static PolicyEnforcementMode valueOfInteger(Integer id) {
+        return id == null ? null : BY_ID.get(id);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationRequest.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationRequest.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PolicyEvaluationRequest {
+
+    private Map<String, Map<String, String>> context = new HashMap<>();
+    private List<ResourceRepresentation> resources = new LinkedList<>();
+    private String clientId;
+    private String userId;
+    private List<String> roleIds = new LinkedList<>();
+    private boolean entitlements;
+
+    public Map<String, Map<String, String>> getContext() {
+        return this.context;
+    }
+
+    public void setContext(Map<String, Map<String, String>> context) {
+        this.context = context;
+    }
+
+    public List<ResourceRepresentation> getResources() {
+        return this.resources;
+    }
+
+    public void setResources(List<ResourceRepresentation> resources) {
+        this.resources = resources;
+    }
+
+    public String getClientId() {
+        return this.clientId;
+    }
+
+    public void setClientId(final String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getUserId() {
+        return this.userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public List<String> getRoleIds() {
+        return this.roleIds;
+    }
+
+    public void setRoleIds(List<String> roleIds) {
+        this.roleIds = roleIds;
+    }
+
+    public boolean isEntitlements() {
+        return entitlements;
+    }
+
+    public void setEntitlements(boolean entitlements) {
+        this.entitlements = entitlements;
+    }
+
+    public PolicyEvaluationRequest addResource(String name, String... scopes) {
+        if (resources == null) {
+            resources = new LinkedList<>();
+        }
+        resources.add(new ResourceRepresentation(name, scopes));
+        return this;
+    }
+
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationResponse.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationResponse.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm.authorization;
+
+import org.keycloak.representations.AccessToken;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PolicyEvaluationResponse {
+
+    private List<EvaluationResultRepresentation> results;
+    private boolean entitlements;
+    private DecisionEffect status;
+    private AccessToken rpt;
+
+    public List<EvaluationResultRepresentation> getResults() {
+        return results;
+    }
+
+    public DecisionEffect getStatus() {
+        return status;
+    }
+
+    public boolean isEntitlements() {
+        return entitlements;
+    }
+
+    public AccessToken getRpt() {
+        return rpt;
+    }
+
+    public void setResults(List<EvaluationResultRepresentation> results) {
+        this.results = results;
+    }
+
+    public void setEntitlements(boolean entitlements) {
+        this.entitlements = entitlements;
+    }
+
+    public void setStatus(DecisionEffect status) {
+        this.status = status;
+    }
+
+    public void setRpt(AccessToken rpt) {
+        this.rpt = rpt;
+    }
+
+    public static class EvaluationResultRepresentation {
+
+        private ResourceRepresentation resource;
+        private List<ScopeRepresentation> scopes;
+        private List<PolicyResultRepresentation> policies;
+        private DecisionEffect status;
+        private List<ScopeRepresentation> allowedScopes = new ArrayList<>();
+
+        public void setResource(final ResourceRepresentation resource) {
+            this.resource = resource;
+        }
+
+        public ResourceRepresentation getResource() {
+            return resource;
+        }
+
+        public void setScopes(List<ScopeRepresentation> scopes) {
+            this.scopes = scopes;
+        }
+
+        public List<ScopeRepresentation> getScopes() {
+            return scopes;
+        }
+
+        public void setPolicies(final List<PolicyResultRepresentation> policies) {
+            this.policies = policies;
+        }
+
+        public List<PolicyResultRepresentation> getPolicies() {
+            return policies;
+        }
+
+        public void setStatus(final DecisionEffect status) {
+            this.status = status;
+        }
+
+        public DecisionEffect getStatus() {
+            return status;
+        }
+
+        public void setAllowedScopes(List<ScopeRepresentation> allowedScopes) {
+            this.allowedScopes = allowedScopes;
+        }
+
+        public List<ScopeRepresentation> getAllowedScopes() {
+            return allowedScopes;
+        }
+    }
+
+    public static class PolicyResultRepresentation {
+
+        private PolicyRepresentation policy;
+        private DecisionEffect status;
+        private List<PolicyResultRepresentation> associatedPolicies;
+        private Set<String> scopes = new HashSet<>();
+
+        public PolicyRepresentation getPolicy() {
+            return policy;
+        }
+
+        public void setPolicy(final PolicyRepresentation policy) {
+            this.policy = policy;
+        }
+
+        public DecisionEffect getStatus() {
+            return status;
+        }
+
+        public void setStatus(final DecisionEffect status) {
+            this.status = status;
+        }
+
+        public List<PolicyResultRepresentation> getAssociatedPolicies() {
+            return associatedPolicies;
+        }
+
+        public void setAssociatedPolicies(final List<PolicyResultRepresentation> associatedPolicies) {
+            this.associatedPolicies = associatedPolicies;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.policy.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final PolicyResultRepresentation policy = (PolicyResultRepresentation) o;
+            return this.policy.equals(policy.getPolicy());
+        }
+
+        public void setScopes(Set<String> scopes) {
+            this.scopes = scopes;
+        }
+
+        public Set<String> getScopes() {
+            return scopes;
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyProviderRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyProviderRepresentation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PolicyProviderRepresentation {
+
+    private String type;
+    private String name;
+    private String group;
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType( String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName( String name) {
+        this.name = name;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public void setGroup( String group) {
+        this.group = group;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/PolicyRepresentation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private Map<String, String> config = new HashMap();
+
+    public Map<String, String> getConfig() {
+        return this.config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/RegexPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/RegexPolicyRepresentation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
+ */
+public class RegexPolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private String targetClaim;
+    private String pattern;
+    private boolean targetContextAttributes;
+
+    @Override
+    public String getType() {
+        return "regex";
+    }
+
+    public String getTargetClaim() {
+        return targetClaim;
+    }
+
+    public void setTargetClaim(String targetClaim) {
+        this.targetClaim = targetClaim;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public boolean isTargetContextAttributes() {
+        return targetContextAttributes;
+    }
+
+    public void setTargetContextAttributes(boolean targetContextAttributes) {
+        this.targetContextAttributes = targetContextAttributes;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceOwnerRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceOwnerRepresentation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ResourceOwnerRepresentation {
+
+    private String id;
+    private String name;
+
+    public ResourceOwnerRepresentation() {
+
+    }
+
+    public ResourceOwnerRepresentation(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourcePermissionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourcePermissionRepresentation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ResourcePermissionRepresentation extends AbstractPolicyRepresentation {
+
+    private String resourceType;
+
+    @Override
+    public String getType() {
+        return "resource";
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceRepresentation.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.keycloak.json.StringListMapDeserializer;
+
+/**
+ * <p>One or more resources that the resource server manages as a set of protected resources.
+ *
+ * <p>For more details, <a href="https://docs.kantarainitiative.org/uma/draft-oauth-resource-reg.html#rfc.section.2.2">OAuth-resource-reg</a>.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ResourceRepresentation {
+
+    @JsonProperty("_id")
+    private String id;
+
+    private String name;
+
+    @JsonProperty("uris")
+    private Set<String> uris;
+    private String type;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("scopes")
+    private Set<ScopeRepresentation> scopes;
+
+    @JsonProperty("icon_uri")
+    private String iconUri;
+    private ResourceOwnerRepresentation owner;
+    private Boolean ownerManagedAccess;
+
+    private String displayName;
+
+    @JsonDeserialize(using = StringListMapDeserializer.class)
+    private Map<String, List<String>> attributes;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name a human-readable string describing a set of one or more resources
+     * @param uris a {@link List} of {@link URI} that provides network locations for the resource set being registered
+     * @param type a string uniquely identifying the semantics of the resource set
+     * @param scopes the available scopes for this resource set
+     * @param iconUri a {@link URI} for a graphic icon representing the resource set
+     */
+    public ResourceRepresentation(String name, Set<ScopeRepresentation> scopes, Set<String> uris, String type, String iconUri) {
+        this.name = name;
+        this.scopes = scopes;
+        this.uris = uris;
+        this.type = type;
+        this.iconUri = iconUri;
+    }
+
+    public ResourceRepresentation(String name, Set<ScopeRepresentation> scopes, String uri, String type, String iconUri) {
+        this(name, scopes, Collections.singleton(uri), type, iconUri);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name a human-readable string describing a set of one or more resources
+     * @param uris a {@link List} of {@link URI} that provides the network location for the resource set being registered
+     * @param type a string uniquely identifying the semantics of the resource set
+     * @param scopes the available scopes for this resource set
+     */
+    public ResourceRepresentation(String name, Set<ScopeRepresentation> scopes, Set<String> uris, String type) {
+        this(name, scopes, uris, type, null);
+    }
+
+    public ResourceRepresentation(String name, Set<ScopeRepresentation> scopes, String uri, String type) {
+        this(name, scopes, Collections.singleton(uri), type, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name a human-readable string describing a set of one or more resources
+     * @param serverUri a {@link URI} that identifies this resource server
+     * @param scopes the available scopes for this resource set
+     */
+    public ResourceRepresentation(String name, Set<ScopeRepresentation> scopes) {
+        this(name, scopes, (Set<String>) null, null, null);
+    }
+
+    public ResourceRepresentation(String name, String... scopes) {
+        this.name = name;
+        this.scopes = new HashSet<>();
+        for (String s : scopes) {
+            ScopeRepresentation rep = new ScopeRepresentation(s);
+            this.scopes.add(rep);
+        }
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     */
+    public ResourceRepresentation() {
+        this(null, null, (Set<String>) null, null, null);
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public String getUri() {
+        if (this.uris == null || this.uris.isEmpty()) {
+            return null;
+        }
+
+        return this.uris.iterator().next();
+    }
+
+    public Set<String> getUris() {
+        return this.uris;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public Set<ScopeRepresentation> getScopes() {
+        if (this.scopes == null) {
+            return Collections.emptySet();
+        }
+
+        return Collections.unmodifiableSet(this.scopes);
+    }
+
+    public String getIconUri() {
+        return this.iconUri;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Deprecated
+    @JsonSetter("uri")
+    public void setUri(String uri) {
+        if (uri != null && !"".equalsIgnoreCase(uri.trim())) {
+            this.uris = Collections.singleton(uri);
+        }
+    }
+
+    public void setUris(Set<String> uris) {
+        if (uris != null) {
+            Set<String> resultSet = new HashSet<>();
+            for (String uri : uris) {
+                if (uri != null && !"".equalsIgnoreCase(uri.trim())) {
+                    resultSet.add(uri);
+                }
+            }
+
+            this.uris = resultSet;
+        }
+    }
+
+    public void setType(String type) {
+        if (type != null && !"".equalsIgnoreCase(type.trim())) {
+            this.type = type;
+        }
+    }
+
+    public void setScopes(Set<ScopeRepresentation> scopes) {
+        this.scopes = scopes;
+    }
+
+    /**
+     * TODO: This is a workaround to allow deserialization of UMA resource representation. Jackson 2.19+ support aliases, once we upgrade, change this.
+     *
+     * @param scopes
+     */
+    @JsonSetter("resource_scopes")
+    private void setScopesUma(Set<ScopeRepresentation> scopes) {
+        this.scopes = scopes;
+    }
+
+    public void setIconUri(String iconUri) {
+        this.iconUri = iconUri;
+    }
+
+    public ResourceOwnerRepresentation getOwner() {
+        return this.owner;
+    }
+
+    @JsonProperty
+    public void setOwner(ResourceOwnerRepresentation owner) {
+        this.owner = owner;
+    }
+
+    @JsonIgnore
+    public void setOwner(String ownerId) {
+        if (ownerId == null) {
+            owner = null;
+            return;
+        }
+
+        if (owner == null) {
+            owner = new ResourceOwnerRepresentation();
+        }
+
+        owner.setId(ownerId);
+    }
+
+    public Boolean getOwnerManagedAccess() {
+        return ownerManagedAccess;
+    }
+
+    public void setOwnerManagedAccess(Boolean ownerManagedAccess) {
+        this.ownerManagedAccess = ownerManagedAccess;
+    }
+
+    public void addScope(String... scopeNames) {
+        if (scopes == null) {
+            scopes = new HashSet<>();
+        }
+        for (String scopeName : scopeNames) {
+            scopes.add(new ScopeRepresentation(scopeName));
+        }
+    }
+
+    public void addScope(ScopeRepresentation scope) {
+        if (scopes == null) {
+            scopes = new HashSet<>();
+        }
+        scopes.add(scope);
+    }
+
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResourceRepresentation scope = (ResourceRepresentation) o;
+        return Objects.equals(getName(), scope.getName());
+    }
+
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceServerRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ResourceServerRepresentation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ResourceServerRepresentation {
+
+    private String id;
+
+    private String clientId;
+    private String name;
+    private boolean allowRemoteResourceManagement = true;
+    private PolicyEnforcementMode policyEnforcementMode = PolicyEnforcementMode.ENFORCING;
+    private List<ResourceRepresentation> resources = emptyList();
+    private List<PolicyRepresentation> policies = emptyList();
+    private List<ScopeRepresentation> scopes = emptyList();
+    private DecisionStrategy decisionStrategy;
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isAllowRemoteResourceManagement() {
+        return this.allowRemoteResourceManagement;
+    }
+
+    public void setAllowRemoteResourceManagement(boolean allowRemoteResourceManagement) {
+        this.allowRemoteResourceManagement = allowRemoteResourceManagement;
+    }
+
+    public PolicyEnforcementMode getPolicyEnforcementMode() {
+        return this.policyEnforcementMode;
+    }
+
+    public void setPolicyEnforcementMode(PolicyEnforcementMode policyEnforcementMode) {
+        this.policyEnforcementMode = policyEnforcementMode;
+    }
+
+    public void setResources(List<ResourceRepresentation> resources) {
+        this.resources = resources;
+    }
+
+    public List<ResourceRepresentation> getResources() {
+        return resources;
+    }
+
+    public void setPolicies(List<PolicyRepresentation> policies) {
+        this.policies = policies;
+    }
+
+    public List<PolicyRepresentation> getPolicies() {
+        return policies;
+    }
+
+    public void setScopes(List<ScopeRepresentation> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<ScopeRepresentation> getScopes() {
+        return scopes;
+    }
+
+    public void setDecisionStrategy(DecisionStrategy decisionStrategy) {
+        this.decisionStrategy = decisionStrategy;
+    }
+
+    public DecisionStrategy getDecisionStrategy() {
+        return decisionStrategy;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private Set<RoleDefinition> roles;
+    private boolean fetchRoles;
+
+    @Override
+    public String getType() {
+        return "role";
+    }
+
+    public Set<RoleDefinition> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<RoleDefinition> roles) {
+        this.roles = roles;
+    }
+
+    public void addRole(String name, boolean required) {
+        if (roles == null) {
+            roles = new HashSet<>();
+        }
+        roles.add(new RoleDefinition(name, required));
+    }
+
+    public void addRole(String name) {
+        addRole(name, false);
+    }
+
+    public void addClientRole(String clientId, String name) {
+        addRole(clientId + "/" +name, false);
+    }
+
+    public void addClientRole(String clientId, String name, boolean required) {
+        addRole(clientId + "/" + name, required);
+    }
+
+    public boolean isFetchRoles() {
+        return fetchRoles;
+    }
+
+    public void setFetchRoles(boolean fetchRoles) {
+        this.fetchRoles = fetchRoles;
+    }
+
+    public static class RoleDefinition implements Comparable<RoleDefinition> {
+
+        private String id;
+        private boolean required;
+
+        public RoleDefinition() {
+            this(null, false);
+        }
+
+        public RoleDefinition(String id, boolean required) {
+            this.id = id;
+            this.required = required;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+
+        @Override
+        public int compareTo(RoleDefinition o) {
+            if (id == null || o.id == null) {
+                return 1;
+            }
+            return id.compareTo(o.id);
+        }
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ScopePermissionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ScopePermissionRepresentation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ScopePermissionRepresentation extends AbstractPolicyRepresentation {
+
+    private String resourceType;
+
+    @Override
+    public String getType() {
+        return "scope";
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/ScopeRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/ScopeRepresentation.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * <p>A bounded extent of access that is possible to perform on a resource set. In authorization policy terminology,
+ * a scope is one of the potentially many "verbs" that can logically apply to a resource set ("object").
+ *
+ * <p>For more details, <a href="https://docs.kantarainitiative.org/uma/draft-oauth-resource-reg.html#rfc.section.2.1">OAuth-resource-reg</a>.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ScopeRepresentation {
+
+    private String id;
+    private String name;
+    private String iconUri;
+    private List<PolicyRepresentation> policies;
+    private List<ResourceRepresentation> resources;
+    private String displayName;
+
+    /**
+     * Creates an instance.
+     *
+     * @param name the a human-readable string describing some scope (extent) of access
+     * @param iconUri a {@link URI} for a graphic icon representing the scope
+     */
+    public ScopeRepresentation(String name, String iconUri) {
+        this.name = name;
+        this.iconUri = iconUri;
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param name the a human-readable string describing some scope (extent) of access
+     */
+    public ScopeRepresentation(String name) {
+        this(name, null);
+    }
+
+    /**
+     * Creates an instance.
+     */
+    public ScopeRepresentation() {
+        this(null, null);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getIconUri() {
+        return this.iconUri;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setIconUri(String iconUri) {
+        this.iconUri = iconUri;
+    }
+
+    public List<PolicyRepresentation> getPolicies() {
+        return this.policies;
+    }
+
+    public void setPolicies(List<PolicyRepresentation> policies) {
+        this.policies = policies;
+    }
+
+    public List<ResourceRepresentation> getResources() {
+        return this.resources;
+    }
+
+    public void setResources(List<ResourceRepresentation> resources) {
+        this.resources = resources;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ScopeRepresentation scope = (ScopeRepresentation) o;
+        return Objects.equals(getName(), scope.getName());
+    }
+
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/TimePolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/TimePolicyRepresentation.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class TimePolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private String notBefore;
+    private String notOnOrAfter;
+    private String dayMonth;
+    private String dayMonthEnd;
+    private String month;
+    private String monthEnd;
+    private String year;
+    private String yearEnd;
+    private String hour;
+    private String hourEnd;
+    private String minute;
+    private String minuteEnd;
+
+    @Override
+    public String getType() {
+        return "time";
+    }
+
+    public String getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(String notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    public String getNotOnOrAfter() {
+        return notOnOrAfter;
+    }
+
+    public void setNotOnOrAfter(String notOnOrAfter) {
+        this.notOnOrAfter = notOnOrAfter;
+    }
+
+    public String getDayMonth() {
+        return dayMonth;
+    }
+
+    public void setDayMonth(String dayMonth) {
+        this.dayMonth = dayMonth;
+    }
+
+    public String getDayMonthEnd() {
+        return dayMonthEnd;
+    }
+
+    public void setDayMonthEnd(String dayMonthEnd) {
+        this.dayMonthEnd = dayMonthEnd;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public void setMonth(String month) {
+        this.month = month;
+    }
+
+    public String getMonthEnd() {
+        return monthEnd;
+    }
+
+    public void setMonthEnd(String monthEnd) {
+        this.monthEnd = monthEnd;
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public void setYear(String year) {
+        this.year = year;
+    }
+
+    public String getYearEnd() {
+        return yearEnd;
+    }
+
+    public void setYearEnd(String yearEnd) {
+        this.yearEnd = yearEnd;
+    }
+
+    public String getHour() {
+        return hour;
+    }
+
+    public void setHour(String hour) {
+        this.hour = hour;
+    }
+
+    public String getHourEnd() {
+        return hourEnd;
+    }
+
+    public void setHourEnd(String hourEnd) {
+        this.hourEnd = hourEnd;
+    }
+
+    public String getMinute() {
+        return minute;
+    }
+
+    public void setMinute(String minute) {
+        this.minute = minute;
+    }
+
+    public String getMinuteEnd() {
+        return minuteEnd;
+    }
+
+    public void setMinuteEnd(String minuteEnd) {
+        this.minuteEnd = minuteEnd;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/UmaPermissionRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/UmaPermissionRepresentation.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:federico@martel-innovate.com">Federico M. Facca</a>
+ */
+public class UmaPermissionRepresentation extends AbstractPolicyRepresentation {
+    
+    private Set<String> roles;
+    private Set<String> groups;
+    private Set<String> clients;
+    private Set<String> users;
+    private String condition;
+
+    @Override
+    public String getType() {
+        return "uma";
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public void addRole(String... role) {
+        if (roles == null) {
+            roles = new HashSet<>();
+        }
+
+        roles.addAll(Arrays.asList(role));
+    }
+
+    public void addClientRole(String clientId, String roleName) {
+        addRole(clientId + "/" + roleName);
+    }
+
+    public void removeRole(String role) {
+        if (roles != null) {
+            roles.remove(role);
+        }
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    public void addGroup(String... group) {
+        if (groups == null) {
+            groups = new HashSet<>();
+        }
+
+        groups.addAll(Arrays.asList(group));
+    }
+
+    public void removeGroup(String group) {
+        if (groups != null) {
+            groups.remove(group);
+        }
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setClients(Set<String> clients) {
+        this.clients = clients;
+    }
+
+    public void addClient(String... client) {
+        if (clients == null) {
+            clients = new HashSet<>();
+        }
+
+        clients.addAll(Arrays.asList(client));
+    }
+
+    public void removeClient(String client) {
+        if (clients != null) {
+            clients.remove(client);
+        }
+    }
+
+    public Set<String> getClients() {
+        return clients;
+    }
+
+    public void setUsers(Set<String> users) {
+        this.users = users;
+    }
+
+    public void addUser(String... user) {
+        if (this.users == null) {
+            this.users = new HashSet<>();
+        }
+        this.users.addAll(Arrays.asList(user));
+    }
+
+    public void removeUser(String user) {
+        if (this.users != null) {
+            this.users.remove(user);
+        }
+    }
+
+    public Set<String> getUsers() {
+        return this.users;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/idm/authorization/UserPolicyRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/idm/authorization/UserPolicyRepresentation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm.authorization;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class UserPolicyRepresentation extends AbstractPolicyRepresentation {
+
+    private Set<String> users;
+
+    @Override
+    public String getType() {
+        return "user";
+    }
+
+    public Set<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<String> users) {
+        this.users= users;
+    }
+
+    public void addUser(String name) {
+        if (users == null) {
+            users = new HashSet<>();
+        }
+        users.add(name);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/ClientInstallationRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/ClientInstallationRepresentation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ClientInstallationRepresentation {
+    protected String id;
+    protected String protocol;
+    protected boolean downloadOnly;
+    protected String displayType;
+    protected String helpText;
+    protected String filename;
+    protected String mediaType;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public boolean isDownloadOnly() {
+        return downloadOnly;
+    }
+
+    public void setDownloadOnly(boolean downloadOnly) {
+        this.downloadOnly = downloadOnly;
+    }
+
+    public String getDisplayType() {
+        return displayType;
+    }
+
+    public void setDisplayType(String displayType) {
+        this.displayType = displayType;
+    }
+
+    public String getHelpText() {
+        return helpText;
+    }
+
+    public void setHelpText(String helpText) {
+        this.helpText = helpText;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/CryptoInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/CryptoInfoRepresentation.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.info;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class CryptoInfoRepresentation {
+
+    private String cryptoProvider;
+    private List<String> supportedKeystoreTypes;
+
+    private List<String> clientSignatureSymmetricAlgorithms;
+
+    private List<String> clientSignatureAsymmetricAlgorithms;
+
+    public String getCryptoProvider() {
+        return cryptoProvider;
+    }
+
+    public void setCryptoProvider(String cryptoProvider) {
+        this.cryptoProvider = cryptoProvider;
+    }
+
+    public List<String> getSupportedKeystoreTypes() {
+        return supportedKeystoreTypes;
+    }
+
+    public void setSupportedKeystoreTypes(List<String> supportedKeystoreTypes) {
+        this.supportedKeystoreTypes = supportedKeystoreTypes;
+    }
+
+    public List<String> getClientSignatureSymmetricAlgorithms() {
+        return clientSignatureSymmetricAlgorithms;
+    }
+
+    public void setClientSignatureSymmetricAlgorithms(List<String> clientSignatureSymmetricAlgorithms) {
+        this.clientSignatureSymmetricAlgorithms = clientSignatureSymmetricAlgorithms;
+    }
+
+    public List<String> getClientSignatureAsymmetricAlgorithms() {
+        return clientSignatureAsymmetricAlgorithms;
+    }
+
+    public void setClientSignatureAsymmetricAlgorithms(List<String> clientSignatureAsymmetricAlgorithms) {
+        this.clientSignatureAsymmetricAlgorithms = clientSignatureAsymmetricAlgorithms;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
@@ -1,0 +1,54 @@
+package org.keycloak.representations.info;
+
+import java.util.Set;
+
+public class FeatureRepresentation {
+    private String name;
+    private String label;
+    private FeatureType type;
+    private boolean isEnabled;
+    private Set<String> dependencies;
+
+    public FeatureRepresentation() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public FeatureType getType() {
+        return type;
+    }
+
+    public void setType(FeatureType type) {
+        this.type = type;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    public Set<String> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(Set<String> dependencies) {
+        this.dependencies = dependencies;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/FeatureType.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/FeatureType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.info;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public enum FeatureType {
+    DEFAULT,
+    DISABLED_BY_DEFAULT,
+    PREVIEW,
+    PREVIEW_DISABLED_BY_DEFAULT,
+    EXPERIMENTAL,
+    DEPRECATED;
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/MemoryInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/MemoryInfoRepresentation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+public class MemoryInfoRepresentation {
+
+    protected long total;
+    protected String totalFormated;
+    protected long used;
+    protected String usedFormated;
+    protected long free;
+    protected long freePercentage;
+    protected String freeFormated;
+
+    public static MemoryInfoRepresentation create() {
+        MemoryInfoRepresentation rep = new MemoryInfoRepresentation();
+        Runtime runtime = Runtime.getRuntime();
+        rep.total = runtime.maxMemory();
+        rep.totalFormated = formatMemory(rep.total);
+        rep.used = runtime.totalMemory() - runtime.freeMemory();
+        rep.usedFormated = formatMemory(rep.used);
+        rep.free = rep.total - rep.used;
+        rep.freeFormated = formatMemory(rep.free);
+        rep.freePercentage = rep.free * 100 / rep.total;
+        return rep;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public String getTotalFormated() {
+        return totalFormated;
+    }
+
+    public long getFree() {
+        return free;
+    }
+
+    public String getFreeFormated() {
+        return freeFormated;
+    }
+
+    public long getUsed() {
+        return used;
+    }
+
+    public String getUsedFormated() {
+        return usedFormated;
+    }
+
+    public long getFreePercentage() {
+        return freePercentage;
+    }
+
+    private static String formatMemory(long bytes) {
+        if (bytes > 1024L * 1024L) {
+            return bytes / (1024L * 1024L) + " MB";
+        } else if (bytes > 1024L) {
+            return bytes / (1024L) + " kB";
+        } else {
+            return bytes + " B";
+        }
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/ProfileInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/ProfileInfoRepresentation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ProfileInfoRepresentation {
+
+    private String name;
+    private List<String> disabledFeatures;
+    private List<String> previewFeatures;
+    private List<String> experimentalFeatures;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getDisabledFeatures() {
+        return disabledFeatures;
+    }
+
+    public void setDisabledFeatures(List<String> disabledFeatures) {
+        this.disabledFeatures = disabledFeatures;
+    }
+
+    public List<String> getPreviewFeatures() {
+        return previewFeatures;
+    }
+
+    public void setPreviewFeatures(List<String> previewFeatures) {
+        this.previewFeatures = previewFeatures;
+    }
+
+    public List<String> getExperimentalFeatures() {
+        return experimentalFeatures;
+    }
+
+    public void setExperimentalFeatures(List<String> experimentalFeatures) {
+        this.experimentalFeatures = experimentalFeatures;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/ProviderRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/ProviderRepresentation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+import java.util.Map;
+
+public class ProviderRepresentation {
+
+    private int order;
+
+    private Map<String, String> operationalInfo;
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int priorityUI) {
+        this.order = priorityUI;
+    }
+
+    public Map<String, String> getOperationalInfo() {
+        return operationalInfo;
+    }
+
+    public void setOperationalInfo(Map<String, String> operationalInfo) {
+        this.operationalInfo = operationalInfo;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/ServerInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/ServerInfoRepresentation.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
+import org.keycloak.representations.idm.PasswordPolicyTypeRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperTypeRepresentation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ServerInfoRepresentation {
+
+    private SystemInfoRepresentation systemInfo;
+    private MemoryInfoRepresentation memoryInfo;
+    private ProfileInfoRepresentation profileInfo;
+
+    private List<FeatureRepresentation> features;
+
+    private CryptoInfoRepresentation cryptoInfo;
+
+    private Map<String, List<ThemeInfoRepresentation>> themes;
+
+    private List<Map<String, String>> socialProviders;
+    private List<Map<String, String>> identityProviders;
+    private List<Map<String, String>> clientImporters;
+
+    private Map<String, SpiInfoRepresentation> providers;
+
+    private Map<String, List<ProtocolMapperTypeRepresentation>> protocolMapperTypes;
+    private Map<String, List<ProtocolMapperRepresentation>> builtinProtocolMappers;
+    private Map<String, List<ClientInstallationRepresentation>> clientInstallations;
+    private Map<String, List<ComponentTypeRepresentation>> componentTypes;
+
+    private List<PasswordPolicyTypeRepresentation> passwordPolicies;
+
+    private Map<String, List<String>> enums;
+
+    public SystemInfoRepresentation getSystemInfo() {
+        return systemInfo;
+    }
+
+    public void setSystemInfo(SystemInfoRepresentation systemInfo) {
+        this.systemInfo = systemInfo;
+    }
+
+    public MemoryInfoRepresentation getMemoryInfo() {
+        return memoryInfo;
+    }
+
+    public void setMemoryInfo(MemoryInfoRepresentation memoryInfo) {
+        this.memoryInfo = memoryInfo;
+    }
+
+    public ProfileInfoRepresentation getProfileInfo() {
+        return profileInfo;
+    }
+
+    public void setProfileInfo(ProfileInfoRepresentation profileInfo) {
+        this.profileInfo = profileInfo;
+    }
+
+    public List<FeatureRepresentation> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(List<FeatureRepresentation> features) {
+        this.features = features;
+    }
+
+    public CryptoInfoRepresentation getCryptoInfo() {
+        return cryptoInfo;
+    }
+
+    public void setCryptoInfo(CryptoInfoRepresentation cryptoInfo) {
+        this.cryptoInfo = cryptoInfo;
+    }
+
+    public Map<String, List<ThemeInfoRepresentation>> getThemes() {
+        return themes;
+    }
+
+    public void setThemes(Map<String, List<ThemeInfoRepresentation>> themes) {
+        this.themes = themes;
+    }
+
+    public List<Map<String, String>> getSocialProviders() {
+        return socialProviders;
+    }
+
+    public void setSocialProviders(List<Map<String, String>> socialProviders) {
+        this.socialProviders = socialProviders;
+    }
+
+    public List<Map<String, String>> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(List<Map<String, String>> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public List<Map<String, String>> getClientImporters() {
+        return clientImporters;
+    }
+
+    public void setClientImporters(List<Map<String, String>> clientImporters) {
+        this.clientImporters = clientImporters;
+    }
+
+    public Map<String, SpiInfoRepresentation> getProviders() {
+        return providers;
+    }
+
+    public void setProviders(Map<String, SpiInfoRepresentation> providers) {
+        this.providers = providers;
+    }
+
+    public Map<String, List<ProtocolMapperTypeRepresentation>> getProtocolMapperTypes() {
+        return protocolMapperTypes;
+    }
+
+    public void setProtocolMapperTypes(Map<String, List<ProtocolMapperTypeRepresentation>> protocolMapperTypes) {
+        this.protocolMapperTypes = protocolMapperTypes;
+    }
+
+    public Map<String, List<ProtocolMapperRepresentation>> getBuiltinProtocolMappers() {
+        return builtinProtocolMappers;
+    }
+
+    public void setBuiltinProtocolMappers(Map<String, List<ProtocolMapperRepresentation>> builtinProtocolMappers) {
+        this.builtinProtocolMappers = builtinProtocolMappers;
+    }
+
+    public Map<String, List<String>> getEnums() {
+        return enums;
+    }
+
+    public void setEnums(Map<String, List<String>> enums) {
+        this.enums = enums;
+    }
+
+    public Map<String, List<ClientInstallationRepresentation>> getClientInstallations() {
+        return clientInstallations;
+    }
+
+    public void setClientInstallations(Map<String, List<ClientInstallationRepresentation>> clientInstallations) {
+        this.clientInstallations = clientInstallations;
+    }
+
+    public List<PasswordPolicyTypeRepresentation> getPasswordPolicies() {
+        return passwordPolicies;
+    }
+
+    public void setPasswordPolicies(List<PasswordPolicyTypeRepresentation> passwordPolicies) {
+        this.passwordPolicies = passwordPolicies;
+    }
+
+    public Map<String, List<ComponentTypeRepresentation>> getComponentTypes() {
+        return componentTypes;
+    }
+
+    public void setComponentTypes(Map<String, List<ComponentTypeRepresentation>> componentTypes) {
+        this.componentTypes = componentTypes;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/SpiInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/SpiInfoRepresentation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class SpiInfoRepresentation {
+
+    private boolean internal;
+
+    private Map<String, ProviderRepresentation> providers;
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public void setInternal(boolean internal) {
+        this.internal = internal;
+    }
+
+    public Map<String, ProviderRepresentation> getProviders() {
+        return providers;
+    }
+
+    public void setProviders(Map<String, ProviderRepresentation> providers) {
+        this.providers = providers;
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/SystemInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/SystemInfoRepresentation.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.info;
+
+
+import java.util.Date;
+import java.util.Locale;
+
+public class SystemInfoRepresentation {
+
+    private String version;
+    private String serverTime;
+    private String uptime;
+    private long uptimeMillis;
+    private String javaVersion;
+    private String javaVendor;
+    private String javaVm;
+    private String javaVmVersion;
+    private String javaRuntime;
+    private String javaHome;
+    private String osName;
+    private String osArchitecture;
+    private String osVersion;
+    private String fileEncoding;
+    private String userName;
+    private String userDir;
+    private String userTimezone;
+    private String userLocale;
+
+    public static SystemInfoRepresentation create(long serverStartupTime, String serverVersion) {
+        SystemInfoRepresentation rep = new SystemInfoRepresentation();
+        rep.version = serverVersion;
+        rep.serverTime = new Date().toString();
+        rep.uptimeMillis = System.currentTimeMillis() - serverStartupTime;
+        rep.uptime = formatUptime(rep.uptimeMillis);
+        rep.javaVersion = System.getProperty("java.version");
+        rep.javaVendor = System.getProperty("java.vendor");
+        rep.javaVm = System.getProperty("java.vm.name");
+        rep.javaVmVersion = System.getProperty("java.vm.version");
+        rep.javaRuntime = System.getProperty("java.runtime.name");
+        rep.javaHome = System.getProperty("java.home");
+        rep.osName = System.getProperty("os.name");
+        rep.osArchitecture = System.getProperty("os.arch");
+        rep.osVersion = System.getProperty("os.version");
+        rep.fileEncoding = System.getProperty("file.encoding");
+        rep.userName = System.getProperty("user.name");
+        rep.userDir = System.getProperty("user.dir");
+        rep.userTimezone = System.getProperty("user.timezone");
+        if (System.getProperty("user.country") != null && System.getProperty("user.language") != null) {
+            rep.userLocale = (new Locale(System.getProperty("user.language"), System.getProperty("user.country")).toString());
+        }
+        return rep;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getServerTime() {
+        return serverTime;
+    }
+
+    public void setServerTime(String serverTime) {
+        this.serverTime = serverTime;
+    }
+
+    public String getUptime() {
+        return uptime;
+    }
+
+    public void setUptime(String uptime) {
+        this.uptime = uptime;
+    }
+
+    public long getUptimeMillis() {
+        return uptimeMillis;
+    }
+
+    public void setUptimeMillis(long uptimeMillis) {
+        this.uptimeMillis = uptimeMillis;
+    }
+
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+    public void setJavaVersion(String javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+
+    public String getJavaVendor() {
+        return javaVendor;
+    }
+
+    public void setJavaVendor(String javaVendor) {
+        this.javaVendor = javaVendor;
+    }
+
+    public String getJavaVm() {
+        return javaVm;
+    }
+
+    public void setJavaVm(String javaVm) {
+        this.javaVm = javaVm;
+    }
+
+    public String getJavaVmVersion() {
+        return javaVmVersion;
+    }
+
+    public void setJavaVmVersion(String javaVmVersion) {
+        this.javaVmVersion = javaVmVersion;
+    }
+
+    public String getJavaRuntime() {
+        return javaRuntime;
+    }
+
+    public void setJavaRuntime(String javaRuntime) {
+        this.javaRuntime = javaRuntime;
+    }
+
+    public String getJavaHome() {
+        return javaHome;
+    }
+
+    public void setJavaHome(String javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    public String getOsName() {
+        return osName;
+    }
+
+    public void setOsName(String osName) {
+        this.osName = osName;
+    }
+
+    public String getOsArchitecture() {
+        return osArchitecture;
+    }
+
+    public void setOsArchitecture(String osArchitecture) {
+        this.osArchitecture = osArchitecture;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public void setOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    public String getFileEncoding() {
+        return fileEncoding;
+    }
+
+    public void setFileEncoding(String fileEncoding) {
+        this.fileEncoding = fileEncoding;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getUserDir() {
+        return userDir;
+    }
+
+    public void setUserDir(String userDir) {
+        this.userDir = userDir;
+    }
+
+    public String getUserTimezone() {
+        return userTimezone;
+    }
+
+    public void setUserTimezone(String userTimezone) {
+        this.userTimezone = userTimezone;
+    }
+
+    public String getUserLocale() {
+        return userLocale;
+    }
+
+    public void setUserLocale(String userLocale) {
+        this.userLocale = userLocale;
+    }
+
+    private static String formatUptime(long uptime) {
+        long diffInSeconds = uptime / 1000;
+        long diff[] = new long[]{0, 0, 0, 0}; // sec
+        diff[3] = (diffInSeconds >= 60 ? diffInSeconds % 60 : diffInSeconds); // min
+        diff[2] = (diffInSeconds = (diffInSeconds / 60)) >= 60 ? diffInSeconds % 60 : diffInSeconds; // hours
+        diff[1] = (diffInSeconds = (diffInSeconds / 60)) >= 24 ? diffInSeconds % 24 : diffInSeconds; // days
+        diff[0] = (diffInSeconds = (diffInSeconds / 24));
+
+        return String.format(
+                "%d day%s, %d hour%s, %d minute%s, %d second%s",
+                diff[0],
+                diff[0] != 1 ? "s" : "",
+                diff[1],
+                diff[1] != 1 ? "s" : "",
+                diff[2],
+                diff[2] != 1 ? "s" : "",
+                diff[3],
+                diff[3] != 1 ? "s" : "");
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/representations/info/ThemeInfoRepresentation.java
+++ b/client-core/src/main/java/org/keycloak/representations/info/ThemeInfoRepresentation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ */
+
+package org.keycloak.representations.info;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ThemeInfoRepresentation {
+
+    private String name;
+    private String[] locales;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String[] getLocales() {
+        return locales;
+    }
+
+    public void setLocales(String[] locales) {
+        this.locales = locales;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttribute.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.representations.userprofile.config;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Configuration of the Attribute.
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPAttribute implements Cloneable {
+
+    private String name;
+    private String displayName;
+    /** key in the Map is name of the validator, value is its configuration */
+    private Map<String, Map<String, Object>> validations;
+    private Map<String, Object> annotations;
+    /** null means it is not required */
+    private UPAttributeRequired required;
+    /** null means everyone can view and edit the attribute */
+    private UPAttributePermissions permissions;
+    /** null means it is always selected */
+    private UPAttributeSelector selector;
+    private String group;
+    private boolean multivalued;
+
+    public UPAttribute() {
+    }
+
+    public UPAttribute(String name) {
+        this.name = name != null ? name.trim() : null;
+    }
+
+    public UPAttribute(String name, UPGroup group) {
+        this(name);
+        this.group = group.getName();
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions, UPAttributeRequired required, UPAttributeSelector selector) {
+        this(name);
+        this.permissions = permissions;
+        this.required = required;
+        this.selector = selector;
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions, UPAttributeRequired required) {
+        this(name, permissions, required, null);
+    }
+
+    public UPAttribute(String name, UPAttributePermissions permissions) {
+        this(name, permissions, null);
+    }
+
+    public UPAttribute(String name, boolean multivalued, UPAttributePermissions permissions) {
+        this(name, permissions, null);
+        setMultivalued(multivalued);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name != null ? name.trim() : null;
+    }
+
+    public Map<String, Map<String, Object>> getValidations() {
+        return validations;
+    }
+
+    public void setValidations(Map<String, Map<String, Object>> validations) {
+        this.validations = validations;
+    }
+
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(Map<String, Object> annotations) {
+        this.annotations = annotations;
+    }
+
+    public UPAttributeRequired getRequired() {
+        return required;
+    }
+
+    public void setRequired(UPAttributeRequired required) {
+        this.required = required;
+    }
+
+    public UPAttributePermissions getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(UPAttributePermissions permissions) {
+        this.permissions = permissions;
+    }
+
+    public void addValidation(String validator, Map<String, Object> config) {
+        if (validations == null) {
+            validations = new HashMap<>();
+        }
+        validations.put(validator, config);
+    }
+
+    public UPAttributeSelector getSelector() {
+        return selector;
+    }
+
+    public void setSelector(UPAttributeSelector selector) {
+        this.selector = selector;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group != null ? group.trim() : null;
+    }
+
+    public void setMultivalued(boolean multivalued) {
+        this.multivalued = multivalued;
+    }
+
+    public boolean isMultivalued() {
+        return multivalued;
+    }
+
+    @Override
+    public String toString() {
+        return "UPAttribute [name=" + name + ", displayName=" + displayName + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + ", group=" + group + ", multivalued=" + multivalued + "]";
+    }
+
+    @Override
+    protected UPAttribute clone() {
+        UPAttribute attr = new UPAttribute(this.name);
+        attr.setDisplayName(this.displayName);
+
+        Map<String, Map<String, Object>> validations;
+        if (this.validations == null) {
+            validations = null;
+        } else {
+            validations = new LinkedHashMap<>();
+            for (Map.Entry<String, Map<String, Object>> entry : this.validations.entrySet()) {
+                Map<String, Object> newVal = entry.getValue() == null ? null : new LinkedHashMap<>(entry.getValue());
+                validations.put(entry.getKey(), newVal);
+            }
+        }
+        attr.setValidations(validations);
+
+        attr.setAnnotations(this.annotations == null ? null : new HashMap<>(this.annotations));
+        attr.setRequired(this.required == null ? null : this.required.clone());
+        attr.setPermissions(this.permissions == null ? null : this.permissions.clone());
+        attr.setSelector(this.selector == null ? null : this.selector.clone());
+        attr.setGroup(this.group);
+        attr.setMultivalued(this.multivalued);
+        return attr;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttribute other = (UPAttribute) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.displayName, other.displayName)
+                && Objects.equals(this.group, other.group)
+                && Objects.equals(this.validations, other.validations)
+                && Objects.equals(this.annotations, other.annotations)
+                && Objects.equals(this.required, other.required)
+                && Objects.equals(this.permissions, other.permissions)
+                && Objects.equals(this.selector, other.selector)
+                && Objects.equals(this.multivalued, other.multivalued);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributePermissions.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.representations.userprofile.config;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Configuration of permissions for the attribute
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPAttributePermissions implements Cloneable {
+
+    private Set<String> view = Collections.emptySet();
+    private Set<String> edit = Collections.emptySet();
+
+    public UPAttributePermissions() {
+        // for reflection
+    }
+
+    public UPAttributePermissions(Set<String> view, Set<String> edit) {
+        this.view = view;
+        this.edit = edit;
+    }
+
+    public Set<String> getView() {
+        return view;
+    }
+
+    public void setView(Set<String> view) {
+        this.view = view;
+    }
+
+    public Set<String> getEdit() {
+        return edit;
+    }
+
+    public void setEdit(Set<String> edit) {
+        this.edit = edit;
+    }
+
+    @Override
+    public String toString() {
+        return "UPAttributePermissions [view=" + view + ", edit=" + edit + "]";
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return getEdit().isEmpty() && getView().isEmpty();
+    }
+
+    @Override
+    protected UPAttributePermissions clone() {
+        Set<String> view = this.view == null ? null : new HashSet<>(this.view);
+        Set<String> edit = this.edit == null ? null : new HashSet<>(this.edit);
+        return new UPAttributePermissions(view, edit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(view, edit);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributePermissions other = (UPAttributePermissions) obj;
+        return Objects.equals(this.view, other.view)
+                && Objects.equals(this.edit, other.edit);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeRequired.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.representations.userprofile.config;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Config of the rules when attribute is required.
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPAttributeRequired implements Cloneable {
+
+    private Set<String> roles;
+    private Set<String> scopes;
+
+    public UPAttributeRequired() {
+        // for reflection
+    }
+
+    public UPAttributeRequired(Set<String> roles, Set<String> scopes) {
+        this.roles = roles;
+        this.scopes = scopes;
+    }
+
+    /**
+     * Check if this config means that the attribute is ALWAYS required.
+     * 
+     * @return true if the attribute is always required
+     */
+    @JsonIgnore
+    public boolean isAlways() {
+        return (roles == null || roles.isEmpty()) && (scopes == null || scopes.isEmpty());
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+
+    @Override
+    public String toString() {
+        return "UPAttributeRequired [isAlways=" + isAlways() + ", roles=" + roles + ", scopes=" + scopes + "]";
+    }
+
+    @Override
+    protected UPAttributeRequired clone() {
+        Set<String> scopes = this.scopes == null ? null : new HashSet<>(this.scopes);
+        Set<String> roles = this.roles == null ? null : new HashSet<>(this.roles);
+        return new UPAttributeRequired(roles, scopes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(roles, scopes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributeRequired other = (UPAttributeRequired) obj;
+        return Objects.equals(this.roles, other.roles)
+                && Objects.equals(this.scopes, other.scopes);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPAttributeSelector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.representations.userprofile.config;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Config of the rules when attribute is selected.
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPAttributeSelector implements Cloneable {
+
+    private Set<String> scopes;
+
+    public UPAttributeSelector() {
+        // for reflection
+    }
+
+    public UPAttributeSelector(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    @Override
+    public String toString() {
+        return "UPAttributeSelector [scopes=" + scopes + "]";
+    }
+
+    @Override
+    protected UPAttributeSelector clone() {
+        return new UPAttributeSelector(scopes == null ? null : new HashSet<>(scopes));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPAttributeSelector other = (UPAttributeSelector) obj;
+        return Objects.equals(this.scopes, other.scopes);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPConfig.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.representations.userprofile.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Configuration of the User Profile for one realm.
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPConfig implements Cloneable {
+
+    public enum UnmanagedAttributePolicy {
+
+        /**
+         * Unmanaged attributes are enabled and available from any context.
+         */
+        ENABLED,
+
+        /**
+         * Unmanaged attributes are only available as read-only and only through the management interfaces.
+         */
+        ADMIN_VIEW,
+
+        /**
+         * Unmanaged attributes are only available as read-write and only through the management interfaces.
+         */
+        ADMIN_EDIT
+    }
+
+    private List<UPAttribute> attributes;
+    private List<UPGroup> groups;
+
+    private UnmanagedAttributePolicy unmanagedAttributePolicy;
+
+    public List<UPAttribute> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<UPAttribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public UPConfig addOrReplaceAttribute(UPAttribute attribute) {
+        if (attributes == null) {
+            attributes = new ArrayList<>();
+        }
+
+        removeAttribute(attribute.getName());
+        attributes.add(attribute);
+
+        return this;
+    }
+
+    public boolean removeAttribute(String name) {
+        return attributes != null && attributes.removeIf(attribute -> attribute.getName().equals(name));
+    }
+
+    public List<UPGroup> getGroups() {
+        if (groups == null) {
+            return Collections.emptyList();
+        }
+        return groups;
+    }
+
+    public void setGroups(List<UPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public UPConfig addGroup(UPGroup group) {
+        if (groups == null) {
+            groups = new ArrayList<>();
+        }
+
+        groups.add(group);
+
+        return this;
+    }
+
+    @JsonIgnore
+    public UPAttribute getAttribute(String name) {
+        for (UPAttribute attribute : getAttributes()) {
+            if (attribute.getName().equals(name)) {
+                return attribute;
+            }
+        }
+        return null;
+    }
+
+    public UnmanagedAttributePolicy getUnmanagedAttributePolicy() {
+        return unmanagedAttributePolicy;
+    }
+
+    public void setUnmanagedAttributePolicy(UnmanagedAttributePolicy unmanagedAttributePolicy) {
+        this.unmanagedAttributePolicy = unmanagedAttributePolicy;
+    }
+
+    @Override
+    public String toString() {
+        return "UPConfig [attributes=" + attributes + ", groups=" + groups + "]";
+    }
+
+    @Override
+    public UPConfig clone() {
+        UPConfig cfg = new UPConfig();
+
+        cfg.setUnmanagedAttributePolicy(this.unmanagedAttributePolicy);
+        if (attributes != null) {
+            cfg.setAttributes(attributes.stream().map(UPAttribute::clone).collect(Collectors.toList()));
+        }
+        if (groups != null) {
+            cfg.setGroups(groups.stream().map(UPGroup::clone).collect(Collectors.toList()));
+        }
+
+        return cfg;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributes, groups, unmanagedAttributePolicy);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPConfig other = (UPConfig) obj;
+        return Objects.equals(this.attributes, other.attributes)
+                && Objects.equals(this.groups, other.groups)
+                && this.unmanagedAttributePolicy == other.unmanagedAttributePolicy;
+    }
+}

--- a/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
+++ b/client-core/src/main/java/org/keycloak/representations/userprofile/config/UPGroup.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.representations.userprofile.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Configuration of the attribute group.
+ *
+ * @author <a href="joerg.matysiak@bosch.io">Jörg Matysiak</a>
+ */
+public class UPGroup implements Cloneable {
+
+    private String name;
+    private String displayHeader;
+    private String displayDescription;
+    private Map<String, Object> annotations;
+
+    public UPGroup() {
+        // for reflection
+    }
+
+    public UPGroup(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name != null ? name.trim() : null;
+    }
+
+    public String getDisplayHeader() {
+        return displayHeader;
+    }
+
+    public void setDisplayHeader(String displayHeader) {
+        this.displayHeader = displayHeader;
+    }
+
+    public String getDisplayDescription() {
+        return displayDescription;
+    }
+
+    public void setDisplayDescription(String displayDescription) {
+        this.displayDescription = displayDescription;
+    }
+
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(Map<String, Object> annotations) {
+        this.annotations = annotations;
+    }
+
+    @Override
+    protected UPGroup clone() {
+        UPGroup group = new UPGroup(this.name);
+        group.setDisplayHeader(displayHeader);
+        group.setDisplayDescription(displayDescription);
+        group.setAnnotations(this.annotations == null ? null : new HashMap<>(this.annotations));
+        return group;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UPGroup other = (UPGroup) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.displayHeader, other.displayHeader)
+                && Objects.equals(this.displayDescription, other.displayDescription)
+                && Objects.equals(this.annotations, other.annotations);
+    }
+}

--- a/client-core/src/main/java/org/keycloak/util/EnumWithStableIndex.java
+++ b/client-core/src/main/java/org/keycloak/util/EnumWithStableIndex.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.util;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Classes implementing this interface guarantee that for each instance of this class,
+ * there exists an mutually unique integer which is stable in time, and identifies
+ * always the same instance of this class.
+ * The index might be used for persistence, hence the index of a particular item
+ * cannot be changed.
+ * This is mostly usable for @{code enum}s.
+ */
+public interface EnumWithStableIndex {
+    /**
+     * @return Unique numeric index which is stable in time and identifies an instance.
+     *   Reusing the same index for two distinct entries of the same class is forbidden even
+     *   if they cannot exist at the same time (e.g. one is deleted before other is introduced).
+     */
+    public int getStableIndex();   
+
+    public static <E extends EnumWithStableIndex> Map<Integer, E> getReverseIndex(E[] values) {
+        return Stream.of(values).collect(Collectors.toMap(EnumWithStableIndex::getStableIndex, Function.identity()));
+    }
+}

--- a/client-core/src/main/java/org/keycloak/util/JsonSerialization.java
+++ b/client-core/src/main/java/org/keycloak/util/JsonSerialization.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Utility class to handle simple JSON serializable for Keycloak.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class JsonSerialization {
+    public static final ObjectMapper mapper = new ObjectMapper();
+    public static final ObjectMapper prettyMapper = new ObjectMapper();
+    public static final ObjectMapper sysPropertiesAwareMapper = new ObjectMapper(new SystemPropertiesJsonParserFactory());
+
+    static {
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        prettyMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        prettyMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        prettyMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+
+    public static void writeValueToStream(OutputStream os, Object obj) throws IOException {
+        mapper.writeValue(os, obj);
+    }
+
+    public static void writeValuePrettyToStream(OutputStream os, Object obj) throws IOException {
+        prettyMapper.writeValue(os, obj);
+    }
+
+    public static String writeValueAsPrettyString(Object obj) throws IOException {
+        return prettyMapper.writeValueAsString(obj);
+    }
+    public static String writeValueAsString(Object obj) throws IOException {
+        return mapper.writeValueAsString(obj);
+    }
+
+    public static byte[] writeValueAsBytes(Object obj) throws IOException {
+        return mapper.writeValueAsBytes(obj);
+    }
+
+    public static <T> T readValue(byte[] bytes, Class<T> type) throws IOException {
+        return mapper.readValue(bytes, type);
+    }
+
+    public static <T> T readValue(String bytes, Class<T> type) throws IOException {
+        return mapper.readValue(bytes, type);
+    }
+
+    public static <T> T readValue(InputStream bytes, Class<T> type) throws IOException {
+        return readValue(bytes, type, false);
+    }
+
+    public static <T> T readValue(String string, TypeReference<T> type) throws IOException {
+        return mapper.readValue(string, type);
+    }
+
+    public static <T> T readValue(InputStream bytes, TypeReference<T> type) throws IOException {
+        return mapper.readValue(bytes, type);
+    }
+
+    public static <T> T readValue(InputStream bytes, Class<T> type, boolean replaceSystemProperties) throws IOException {
+        if (replaceSystemProperties) {
+            return sysPropertiesAwareMapper.readValue(bytes, type);
+        } else {
+            return mapper.readValue(bytes, type);
+        }
+    }
+
+    /**
+     * Creates an {@link ObjectNode} based on the given {@code pojo}, copying all its properties to the resulting {@link ObjectNode}.
+     *
+     * @param pojo a pojo which properties will be populates into the resulting a {@link ObjectNode}
+     * @return a {@link ObjectNode} with all the properties from the given pojo
+     * @throws IOException if the resulting a {@link ObjectNode} can not be created
+     */
+    public static ObjectNode createObjectNode(Object pojo) throws IOException {
+        if (pojo == null) {
+            throw new IllegalArgumentException("Pojo can not be null.");
+        }
+
+        ObjectNode objectNode = createObjectNode();
+        JsonParser jsonParser = mapper.getFactory().createParser(writeValueAsBytes(pojo));
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+
+        if (!jsonNode.isObject()) {
+            throw new RuntimeException("JsonNode [" + jsonNode + "] is not a object.");
+        }
+
+        objectNode.setAll((ObjectNode) jsonNode);
+
+        return objectNode;
+    }
+
+    public static ObjectNode createObjectNode() {
+        return mapper.createObjectNode();
+    }
+
+}

--- a/client-core/src/main/java/org/keycloak/util/SystemPropertiesJsonParserFactory.java
+++ b/client-core/src/main/java/org/keycloak/util/SystemPropertiesJsonParserFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.JsonParserDelegate;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import org.keycloak.common.util.StringPropertyReplacer;
+import org.keycloak.common.util.SystemEnvProperties;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Properties;
+
+/**
+ * Provides replacing of system properties for parsed values
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SystemPropertiesJsonParserFactory extends MappingJsonFactory {
+
+    private static final Properties properties = new SystemEnvProperties();
+
+    @Override
+    protected JsonParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+        JsonParser delegate =  super._createParser(in, ctxt);
+        return new SystemPropertiesAwareJsonParser(delegate);
+    }
+
+    @Override
+    protected JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {
+        JsonParser delegate =  super._createParser(r, ctxt);
+        return new SystemPropertiesAwareJsonParser(delegate);
+    }
+
+    @Override
+    protected JsonParser _createParser(char[] data, int offset, int len, IOContext ctxt, boolean recyclable) throws IOException {
+        JsonParser delegate =  super._createParser(data, offset, len, ctxt, recyclable);
+        return new SystemPropertiesAwareJsonParser(delegate);
+    }
+
+    @Override
+    protected JsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
+        JsonParser delegate =  super._createParser(data, offset, len, ctxt);
+        return new SystemPropertiesAwareJsonParser(delegate);
+    }
+
+    public static class SystemPropertiesAwareJsonParser extends JsonParserDelegate {
+
+        public SystemPropertiesAwareJsonParser(JsonParser d) {
+            super(d);
+        }
+
+        @Override
+        public String getText() throws IOException {
+            String orig = super.getText();
+            return StringPropertyReplacer.replaceProperties(orig, properties);
+        }
+    }
+}

--- a/integration/admin-client-jee/pom.xml
+++ b/integration/admin-client-jee/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>keycloak-client-integration-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-admin-client-jee</artifactId>
+    <name>Keycloak Admin REST Client JavaEE</name>
+    <description/>
+
+    <properties>
+        <resteasy.version>${resteasy-legacy.version}</resteasy.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client-api</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
@@ -1,0 +1,35 @@
+package org.keycloak.admin.client;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.ClientBuilder;
+
+public class ClientBuilderWrapper {
+
+    static Class clazz;
+    static {
+        try {
+            clazz = Class.forName("org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl");
+        } catch (ClassNotFoundException e) {
+            try {
+                clazz = Class.forName("org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder");
+            } catch (ClassNotFoundException ex) {
+                throw new RuntimeException("RestEasy 3 or 4 not found on classpath");
+            }
+        }
+    }
+
+    public static ClientBuilder create(SSLContext sslContext, boolean disableTrustManager) {
+        try {
+            Object o = clazz.newInstance();
+            clazz.getMethod("sslContext", SSLContext.class).invoke(o, sslContext);
+            clazz.getMethod("connectionPoolSize", int.class).invoke(o, 10);
+            if (disableTrustManager) {
+                clazz.getMethod("disableTrustManager").invoke(o);
+            }
+            return (ClientBuilder) o;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/Config.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/Config.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client;
+
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public class Config {
+
+    private String serverUrl;
+    private String realm;
+    private String username;
+    private String password;
+    private String clientId;
+    private String clientSecret;
+    private String grantType;
+    private String scope;
+
+    public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
+        this(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, null);
+    }
+
+    public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, String scope) {
+        this.serverUrl = serverUrl;
+        this.realm = realm;
+        this.username = username;
+        this.password = password;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.grantType = grantType;
+        checkGrantType(grantType);
+        this.scope = scope;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public boolean isPublicClient() {
+        return clientSecret == null;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public void setGrantType(String grantType) {
+        this.grantType = grantType;
+        checkGrantType(grantType);
+    }
+
+    public static void checkGrantType(String grantType) {
+        if (grantType != null && !PASSWORD.equals(grantType) && !CLIENT_CREDENTIALS.equals(grantType)) {
+            throw new IllegalArgumentException("Unsupported grantType: " + grantType +
+                    " (only " + PASSWORD + " and " + CLIENT_CREDENTIALS + " are supported)");
+        }
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/CreatedResponseUtil.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/CreatedResponseUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+/**
+ * A Utility class that parses the Response object into the underlying ID attribute
+ *
+ * @author John D. Ament
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class CreatedResponseUtil {
+    /**
+     * Reads the Response object, confirms that it returns a 201 created and parses the ID from the location
+     * It always assumes the ID is the last segment of the URI
+     *
+     * @param response The JAX-RS Response received
+     * @return The String ID portion of the URI
+     * @throws WebApplicationException if the response is not a 201 Created
+     */
+    public static String getCreatedId(Response response) throws WebApplicationException {
+        URI location = response.getLocation();
+        if (!response.getStatusInfo().equals(Response.Status.CREATED)) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new WebApplicationException("Create method returned status " +
+                    statusInfo.getReasonPhrase() + " (Code: " + statusInfo.getStatusCode() + "); " +
+                    "expected status: Created (201)", response);
+        }
+        if (location == null) {
+            return null;
+        }
+        String path = location.getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
@@ -1,0 +1,6 @@
+package org.keycloak.admin.client;
+
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+
+public class JacksonProvider extends ResteasyJackson2Provider {
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client;
+
+import javax.ws.rs.client.WebTarget;
+import org.keycloak.admin.client.resource.BearerAuthFilter;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RealmsResource;
+import org.keycloak.admin.client.resource.ServerInfoResource;
+import org.keycloak.admin.client.spi.ResteasyClientProvider;
+import org.keycloak.admin.client.token.TokenManager;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
+/**
+ * Provides a Keycloak client. By default, this implementation uses a the default RestEasy client builder settings.
+ * To customize the underling client, use a {@link KeycloakBuilder} to create a Keycloak client.
+ *
+ * To read Responses, you can use {@link CreatedResponseUtil} for objects created
+ *
+ * @author rodrigo.sasaki@icarros.com.br
+ * @see KeycloakBuilder
+ */
+public class Keycloak implements AutoCloseable {
+
+    private static volatile ResteasyClientProvider CLIENT_PROVIDER = resolveResteasyClientProvider();
+
+    private static ResteasyClientProvider resolveResteasyClientProvider() {
+        Iterator<ResteasyClientProvider> providers = ServiceLoader.load(ResteasyClientProvider.class).iterator();
+
+        if (providers.hasNext()) {
+            ResteasyClientProvider provider = providers.next();
+
+            if (providers.hasNext()) {
+                throw new IllegalArgumentException("Multiple " + ResteasyClientProvider.class + " implementations found");
+            }
+
+            return provider;
+        }
+
+        return createDefaultResteasyClientProvider();
+    }
+
+    private static ResteasyClientProvider createDefaultResteasyClientProvider() {
+        try {
+            return (ResteasyClientProvider) Keycloak.class.getClassLoader().loadClass("org.keycloak.admin.client.spi.ResteasyClientClassicProvider").getDeclaredConstructor().newInstance();
+        } catch (Exception cause) {
+            throw new RuntimeException("Could not instantiate default client provider", cause);
+        }
+    }
+
+    public static void setClientProvider(ResteasyClientProvider provider) {
+        CLIENT_PROVIDER = provider;
+    }
+
+    public static ResteasyClientProvider getClientProvider() {
+        return CLIENT_PROVIDER;
+    }
+
+    private final Config config;
+    private final TokenManager tokenManager;
+    private final String authToken;
+    private final WebTarget target;
+    private final Client client;
+    private boolean closed = false;
+
+    Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, Client resteasyClient, String authtoken, String scope) {
+        config = new Config(serverUrl, realm, username, password, clientId, clientSecret, grantType, scope);
+        client = resteasyClient != null ? resteasyClient : newRestEasyClient(null, null, false);
+        authToken = authtoken;
+        tokenManager = authtoken == null ? new TokenManager(config, client) : null;
+
+        target = client.target(config.getServerUrl());
+        target.register(newAuthFilter());
+    }
+
+    private static Client newRestEasyClient(Object customJacksonProvider, SSLContext sslContext, boolean disableTrustManager) {
+        return CLIENT_PROVIDER.newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager);
+    }
+
+    private BearerAuthFilter newAuthFilter() {
+        return authToken != null ? new BearerAuthFilter(authToken) : new BearerAuthFilter(tokenManager);
+    }
+    
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, Object customJacksonProvider, boolean disableTrustManager, String authToken, String scope) {
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, scope);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, Object customJacksonProvider, boolean disableTrustManager, String authToken) {
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
+        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, null, null, false, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext) {
+        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, sslContext, null, false, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, Object customJacksonProvider) {
+        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, sslContext, customJacksonProvider, false, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId) {
+        return getInstance(serverUrl, realm, username, password, clientId, null, null, null, false, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, SSLContext sslContext) {
+        return getInstance(serverUrl, realm, username, password, clientId, null, sslContext, null, false, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String clientId, String authToken) {
+        return getInstance(serverUrl, realm, null, null, clientId, null, null, null, false, authToken);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String clientId, String authToken, SSLContext sllSslContext) {
+        return getInstance(serverUrl, realm, null, null, clientId, null, sllSslContext, null, false, authToken);
+    }
+
+    public RealmsResource realms() {
+        return CLIENT_PROVIDER.targetProxy(target, RealmsResource.class);
+    }
+
+    public RealmResource realm(String realmName) {
+        return realms().realm(realmName);
+    }
+
+    public ServerInfoResource serverInfo() {
+        return CLIENT_PROVIDER.targetProxy(target, ServerInfoResource.class);
+    }
+
+    public TokenManager tokenManager() {
+        return tokenManager;
+    }
+
+    /**
+     * Create a secure proxy based on an absolute URI.
+     * All set up with appropriate token
+     *
+     * @param proxyClass
+     * @param absoluteURI
+     * @param <T>
+     * @return
+     */
+    public <T> T proxy(Class<T> proxyClass, URI absoluteURI) {
+        WebTarget register = client.target(absoluteURI).register(newAuthFilter());
+        return CLIENT_PROVIDER.targetProxy(register, proxyClass);
+    }
+
+    /**
+     * Closes the underlying client. After calling this method, this <code>Keycloak</code> instance cannot be reused.
+     */
+    @Override
+    public void close() {
+        closed = true;
+        client.close();
+    }
+
+    /**
+     * @return true if the underlying client is closed.
+     */
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client;
+
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
+import javax.ws.rs.client.Client;
+
+/**
+ * Provides a {@link Keycloak} client builder with the ability to customize the underlying
+ * {@link javax.ws.rs.client.Client RESTEasy client} used to communicate with the Keycloak server.
+ * <p>
+ * <p>Example usage with a connection pool size of 20:</p>
+ * <pre>
+ *   Keycloak keycloak = KeycloakBuilder.builder()
+ *     .serverUrl("https://sso.example.com/auth")
+ *     .realm("realm")
+ *     .username("user")
+ *     .password("pass")
+ *     .clientId("client")
+ *     .clientSecret("secret")
+ *     .resteasyClient(new ResteasyClientBuilder().connectionPoolSize(20).build())
+ *     .build();
+ * </pre>
+ * <p>Example usage with grant_type=client_credentials</p>
+ * <pre>
+ *   Keycloak keycloak = KeycloakBuilder.builder()
+ *     .serverUrl("https://sso.example.com/auth")
+ *     .realm("example")
+ *     .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+ *     .clientId("client")
+ *     .clientSecret("secret")
+ *     .build();
+ * </pre>
+ *
+ * @author Scott Rossillo
+ * @see javax.ws.rs.client.Client
+ */
+public class KeycloakBuilder {
+    private String serverUrl;
+    private String realm;
+    private String username;
+    private String password;
+    private String clientId;
+    private String clientSecret;
+    private String grantType;
+    private Client resteasyClient;
+    private String authorization;
+    private String scope;
+
+    public KeycloakBuilder serverUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
+        return this;
+    }
+
+    public KeycloakBuilder realm(String realm) {
+        this.realm = realm;
+        return this;
+    }
+
+    public KeycloakBuilder grantType(String grantType) {
+        Config.checkGrantType(grantType);
+        this.grantType = grantType;
+        return this;
+    }
+
+    public KeycloakBuilder username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public KeycloakBuilder password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public KeycloakBuilder clientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public KeycloakBuilder scope(String scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    public KeycloakBuilder clientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+
+    public KeycloakBuilder resteasyClient(Client resteasyClient) {
+        this.resteasyClient = resteasyClient;
+        return this;
+    }
+
+    public KeycloakBuilder authorization(String auth) {
+        this.authorization = auth;
+        return this;
+    }
+
+    /**
+     * Builds a new Keycloak client from this builder.
+     */
+    public Keycloak build() {
+        if (serverUrl == null) {
+            throw new IllegalStateException("serverUrl required");
+        }
+
+        if (realm == null) {
+            throw new IllegalStateException("realm required");
+        }
+
+        if (authorization == null && grantType == null) {
+            grantType = PASSWORD;
+        }
+
+        if (PASSWORD.equals(grantType)) {
+            if (username == null) {
+                throw new IllegalStateException("username required");
+            }
+
+            if (password == null) {
+                throw new IllegalStateException("password required");
+            }
+        } else if (CLIENT_CREDENTIALS.equals(grantType)) {
+            if (clientSecret == null) {
+                throw new IllegalStateException("clientSecret required with grant_type=client_credentials");
+            }
+        }
+
+        if (authorization == null && clientId == null) {
+            throw new IllegalStateException("clientId required");
+        }
+
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, grantType, resteasyClient, authorization, scope);
+    }
+
+    private KeycloakBuilder() {
+    }
+
+    /**
+     * Returns a new Keycloak builder.
+     */
+    public static KeycloakBuilder builder() {
+        return new KeycloakBuilder();
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/annotation/ServerSupports.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/annotation/ServerSupports.java
@@ -1,0 +1,31 @@
+package org.keycloak.admin.client.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used on "resource" interfaces or some methods on those interfaces pointing to REST endpoints.
+ *
+ * Indicates from which Keycloak server is the particular REST endpoint supported. If used on class, it means that whole resource is supported from that version.
+ *
+ * Note @Retention type SOURCE, so annotation is removed after compilation
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.SOURCE)
+public @interface ServerSupports {
+
+    /**
+     * @return from which version of Keycloak server is this method supported. Empty means that it was supported from early Keycloak version
+     */
+    String from() default "";
+
+    /**
+     * @return to which version of Keycloak server is this method supported. Useful for deprecated REST methods, which are not supported on latest Keycloak
+     * server or are planned to be removed on that version
+     */
+    String to() default "";
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AggregatePoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AggregatePoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.AggregatePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface AggregatePoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(AggregatePolicyRepresentation representation);
+
+    @Path("{id}")
+    AggregatePolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AggregatePolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AggregatePolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AggregatePolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.AggregatePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface AggregatePolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AggregatePolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(AggregatePolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AttackDetectionResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AttackDetectionResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public interface AttackDetectionResource {
+
+    @GET
+    @Path("brute-force/users/{userId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> bruteForceUserStatus(@PathParam("userId") String userId);
+
+    @Path("brute-force/users/{userId}")
+    @DELETE
+    void clearBruteForceForUser(@PathParam("userId") String userId);
+
+    @Path("brute-force/users")
+    @DELETE
+    void clearAllBruteForce();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.AuthenticatorConfigInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.representations.idm.ConfigPropertyRepresentation;
+import org.keycloak.representations.idm.RequiredActionConfigInfoRepresentation;
+import org.keycloak.representations.idm.RequiredActionConfigRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public interface AuthenticationManagementResource {
+
+    @GET
+    @Path("/form-providers")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<Map<String, Object>> getFormProviders();
+
+    @Path("/authenticator-providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<Map<String, Object>> getAuthenticatorProviders();
+
+    @Path("/client-authenticator-providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<Map<String, Object>> getClientAuthenticatorProviders();
+
+    @Path("/form-action-providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<Map<String, Object>> getFormActionProviders();
+
+    @Path("/flows")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AuthenticationFlowRepresentation> getFlows();
+
+    @Path("/flows")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response createFlow(AuthenticationFlowRepresentation model);
+
+    @Path("/flows/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AuthenticationFlowRepresentation getFlow(@PathParam("id") String id);
+
+    @Path("/flows/{id}")
+    @DELETE
+    void deleteFlow(@PathParam("id") String id);
+
+    @Path("/flows/{flowAlias}/copy")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response copy(@PathParam("flowAlias") String flowAlias, Map<String, Object> data);
+
+    @Path("/flows/{id}")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateFlow(@PathParam("id") String id, AuthenticationFlowRepresentation flow);
+
+    @Path("/flows/{flowAlias}/executions/flow")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void addExecutionFlow(@PathParam("flowAlias") String flowAlias, Map<String, Object> data);
+
+    @Path("/flows/{flowAlias}/executions/execution")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void addExecution(@PathParam("flowAlias") String flowAlias, Map<String, Object> data);
+
+    @Path("/flows/{flowAlias}/executions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AuthenticationExecutionInfoRepresentation> getExecutions(@PathParam("flowAlias") String flowAlias);
+
+    @Path("/flows/{flowAlias}/executions")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateExecutions(@PathParam("flowAlias") String flowAlias, AuthenticationExecutionInfoRepresentation rep);
+
+    @Path("/executions")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response addExecution(AuthenticationExecutionRepresentation model);
+
+    @Path("/executions/{executionId}")
+	@GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AuthenticationExecutionRepresentation getExecution(final @PathParam("executionId") String executionId);
+
+    @Path("/executions/{executionId}/raise-priority")
+    @POST
+    void raisePriority(@PathParam("executionId") String execution);
+
+    @Path("/executions/{executionId}/lower-priority")
+    @POST
+    void lowerPriority(@PathParam("executionId") String execution);
+
+    @Path("/executions/{executionId}")
+    @DELETE
+    void removeExecution(@PathParam("executionId") String execution);
+
+    @Path("/executions/{executionId}/config")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response newExecutionConfig(@PathParam("executionId") String executionId, AuthenticatorConfigRepresentation config);
+
+    @Path("unregistered-required-actions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RequiredActionProviderSimpleRepresentation> getUnregisteredRequiredActions();
+
+    @Path("register-required-action")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void registerRequiredAction(RequiredActionProviderSimpleRepresentation action);
+
+    @Path("required-actions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RequiredActionProviderRepresentation> getRequiredActions();
+
+    @Path("required-actions/{alias}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RequiredActionProviderRepresentation getRequiredAction(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateRequiredAction(@PathParam("alias") String alias, RequiredActionProviderRepresentation rep);
+
+    @Path("required-actions/{alias}")
+    @DELETE
+    void removeRequiredAction(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/raise-priority")
+    @POST
+    void raiseRequiredActionPriority(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/lower-priority")
+    @POST
+    void lowerRequiredActionPriority(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/config-description")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RequiredActionConfigInfoRepresentation getRequiredActionConfigDescription(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/config")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RequiredActionConfigRepresentation getRequiredActionConfig(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/config")
+    @DELETE
+    void removeRequiredActionConfig(@PathParam("alias") String alias);
+
+    @Path("required-actions/{alias}/config")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateRequiredActionConfig(@PathParam("alias") String alias, RequiredActionConfigRepresentation rep);
+
+    @Path("config-description/{providerId}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AuthenticatorConfigInfoRepresentation getAuthenticatorConfigDescription(@PathParam("providerId") String providerId);
+
+    @Path("per-client-config-description")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, List<ConfigPropertyRepresentation>> getPerClientConfigDescription();
+
+    @Path("config/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AuthenticatorConfigRepresentation getAuthenticatorConfig(@PathParam("id") String id);
+
+    @Path("config/{id}")
+    @DELETE
+    void removeAuthenticatorConfig(@PathParam("id") String id);
+
+    @Path("config/{id}")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateAuthenticatorConfig(@PathParam("id") String id, AuthenticatorConfigRepresentation config);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AuthorizationResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/AuthorizationResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface AuthorizationResource {
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    void update(ResourceServerRepresentation server);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ResourceServerRepresentation getSettings();
+
+    @Path("/import")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void importSettings(ResourceServerRepresentation server);
+
+    @Path("/settings")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ResourceServerRepresentation exportSettings();
+
+    @Path("/resource")
+    ResourcesResource resources();
+
+    @Path("/scope")
+    ResourceScopesResource scopes();
+
+    @Path("/policy")
+    PoliciesResource policies();
+
+    @Path("/permission")
+    PermissionsResource permissions();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/BasicAuthFilter.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/BasicAuthFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+import org.keycloak.common.util.Base64;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public class BasicAuthFilter implements ClientRequestFilter {
+
+    private final String username;
+    private final String password;
+
+    public BasicAuthFilter(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String pair = username + ":" + password;
+        String authHeader = "Basic " + Base64.encodeBytes(pair.getBytes());
+        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, authHeader);
+    }
+    
+    
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/BearerAuthFilter.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/BearerAuthFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.admin.client.token.TokenManager;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public class BearerAuthFilter implements ClientRequestFilter, ClientResponseFilter {
+
+    public static final String AUTH_HEADER_PREFIX = "Bearer ";
+    private final String tokenString;
+    private final TokenManager tokenManager;
+
+    public BearerAuthFilter(String tokenString) {
+        this.tokenString = tokenString;
+        this.tokenManager = null;
+    }
+
+    public BearerAuthFilter(TokenManager tokenManager) {
+        this.tokenManager = tokenManager;
+        this.tokenString = null;
+    }
+
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String authHeader = (tokenManager != null ? tokenManager.getAccessTokenString() : tokenString);
+        if (!authHeader.startsWith(AUTH_HEADER_PREFIX)) {
+            authHeader = AUTH_HEADER_PREFIX + authHeader;
+        }
+        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, authHeader);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        if (responseContext.getStatus() == 401 && tokenManager != null) {
+            List<Object> authHeaders = requestContext.getHeaders().get(HttpHeaders.AUTHORIZATION);
+            if (authHeaders == null) {
+                return;
+            }
+            for (Object authHeader : authHeaders) {
+                if (authHeader instanceof String) {
+                    String headerValue = (String) authHeader;
+                    if (headerValue.startsWith(AUTH_HEADER_PREFIX)) {
+                        String token = headerValue.substring( AUTH_HEADER_PREFIX.length() );
+                        tokenManager.invalidate( token );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientAttributeCertificateResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientAttributeCertificateResource.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.KeyStoreConfig;
+import org.keycloak.representations.idm.CertificateRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public interface ClientAttributeCertificateResource {
+
+    /**
+     * Get key info
+     *
+     * @return
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    CertificateRepresentation getKeyInfo();
+
+    /**
+     * Generate a new certificate with new key pair
+     *
+     * @return
+     */
+    @POST
+    @Path("generate")
+    @Produces(MediaType.APPLICATION_JSON)
+    CertificateRepresentation generate();
+
+    /**
+     * Upload certificate and eventually private key
+     *
+     * @param output
+     * @return
+     */
+    @POST
+    @Path("upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    CertificateRepresentation uploadJks(Object output);
+
+    /**
+     * Upload only certificate, not private key
+     *
+     * @param output
+     * @return
+     */
+    @POST
+    @Path("upload-certificate")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    CertificateRepresentation uploadJksCertificate(Object output);
+
+    /**
+     * Get a keystore file for the client, containing private key and public certificate
+     *
+     * @param config Keystore configuration as JSON
+     * @return
+     */
+    @POST
+    @Path("/download")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Consumes(MediaType.APPLICATION_JSON)
+    byte[] getKeystore(final KeyStoreConfig config);
+
+    /**
+     * Generate a new keypair and certificate, and get the private key file
+     *
+     * Generates a keypair and certificate and serves the private key in a specified keystore format.
+     * Only generated public certificate is saved in Keycloak DB - the private key is not.
+     *
+     * @param config Keystore configuration as JSON
+     * @return
+     */
+    @POST
+    @Path("/generate-and-download")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Consumes(MediaType.APPLICATION_JSON)
+    byte[] generateAndGetKeystore(final KeyStoreConfig config);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientInitialAccessResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientInitialAccessResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
+import org.keycloak.representations.idm.ClientInitialAccessPresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public interface ClientInitialAccessResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientInitialAccessPresentation create(ClientInitialAccessCreatePresentation rep);
+    
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientInitialAccessPresentation> list();
+
+    @DELETE
+    @Path("{id}")
+    void delete(final @PathParam("id") String id);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesPoliciesResource.java
@@ -1,0 +1,29 @@
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public interface ClientPoliciesPoliciesResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientPoliciesRepresentation getPolicies();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientPoliciesRepresentation getPolicies(@QueryParam("include-global-policies") Boolean includeGlobalPolicies);
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updatePolicies(final ClientPoliciesRepresentation clientPolicies);
+}
+

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesProfilesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesProfilesResource.java
@@ -1,0 +1,29 @@
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public interface ClientPoliciesProfilesResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientProfilesRepresentation getProfiles(@QueryParam("include-global-profiles") Boolean includeGlobalProfiles);
+
+    /**
+     * Update client profiles in the realm. The "globalProfiles" field of clientProfiles is ignored as it is not possible to update global profiles
+     *
+     * @param clientProfiles
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateProfiles(final ClientProfilesRepresentation clientProfiles);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ClientPoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ClientPolicyRepresentation representation);
+
+    @Path("{id}")
+    ClientPolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientPolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientPolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ClientPolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientPolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ClientPolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientRegistrationPolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientRegistrationPolicyResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public interface ClientRegistrationPolicyResource {
+
+    @Path("providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentTypeRepresentation> getProviders();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.adapters.action.GlobalRequestResult;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface ClientResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
+
+    @Path("protocol-mappers")
+    ProtocolMappersResource getProtocolMappers();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ClientRepresentation clientRepresentation);
+
+    @DELETE
+    void remove();
+
+    @POST
+    @Path("client-secret")
+    @Produces(MediaType.APPLICATION_JSON)
+    CredentialRepresentation generateNewSecret();
+
+    @GET
+    @Path("client-secret")
+    @Produces(MediaType.APPLICATION_JSON)
+    CredentialRepresentation getSecret();
+
+    /**
+     * Generate a new registration access token for the client
+     *
+     * @return
+     */
+    @Path("registration-access-token")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    ClientRepresentation regenerateRegistrationAccessToken();
+
+    /**
+     * Get representation of certificate resource
+     *
+     * @param attributePrefix
+     * @return
+     */
+    @Path("certificates/{attr}")
+    ClientAttributeCertificateResource getCertficateResource(@PathParam("attr") String attributePrefix);
+
+    @GET
+    @Path("installation/providers/{providerId}")
+    String getInstallationProvider(@PathParam("providerId") String providerId);
+
+    @Path("session-count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Integer> getApplicationSessionCount();
+
+    @Path("user-sessions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserSessionRepresentation> getUserSessions(@QueryParam("first") Integer firstResult, @QueryParam("max") Integer maxResults);
+
+    @Path("offline-session-count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Long> getOfflineSessionCount();
+
+    @Path("offline-sessions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserSessionRepresentation> getOfflineUserSessions(@QueryParam("first") Integer firstResult, @QueryParam("max") Integer maxResults);
+
+    @POST
+    @Path("push-revocation")
+    @Produces(MediaType.APPLICATION_JSON)
+    void pushRevocation();
+
+    @Path("/scope-mappings")
+    RoleMappingResource getScopeMappings();
+
+    @Path("/roles")
+    RolesResource roles();
+
+    /**
+     * Get default client scopes.  Only name and ids are returned.
+     *
+     * @return default client scopes
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("default-client-scopes")
+    List<ClientScopeRepresentation> getDefaultClientScopes();
+
+    @PUT
+    @Path("default-client-scopes/{clientScopeId}")
+    void addDefaultClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @DELETE
+    @Path("default-client-scopes/{clientScopeId}")
+    void removeDefaultClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    /**
+     * Get optional client scopes.  Only name and ids are returned.
+     *
+     * @return optional client scopes
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("optional-client-scopes")
+    List<ClientScopeRepresentation> getOptionalClientScopes();
+
+    @PUT
+    @Path("optional-client-scopes/{clientScopeId}")
+    void addOptionalClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @DELETE
+    @Path("optional-client-scopes/{clientScopeId}")
+    void removeOptionalClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @Path("/service-account-user")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    UserRepresentation getServiceAccountUser();
+
+    @Path("nodes")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void registerNode(Map<String, String> formParams);
+
+    @Path("nodes/{node}")
+    @DELETE
+    void unregisterNode(final @PathParam("node") String node);
+
+    @Path("test-nodes-available")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    GlobalRequestResult testNodesAvailable();
+
+    @Path("/authz/resource-server")
+    AuthorizationResource authorization();
+
+
+    @Path("client-secret/rotated")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public CredentialRepresentation getClientRotatedSecret();
+
+    @Path("client-secret/rotated")
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void invalidateRotatedSecret();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopePoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopePoliciesResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.ClientScopePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
+ */
+public interface ClientScopePoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ClientScopePolicyRepresentation representation);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientScopePolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopeResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopeResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface ClientScopeResource {
+
+    @Path("protocol-mappers")
+    ProtocolMappersResource getProtocolMappers();
+
+    @Path("/scope-mappings")
+    RoleMappingResource getScopeMappings();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientScopeRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ClientScopeRepresentation rep);
+
+    @DELETE
+    void remove();
+
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientScopesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface ClientScopesResource {
+
+    @Path("{id}")
+    ClientScopeResource get(@PathParam("id") String id);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(ClientScopeRepresentation clientScopeRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientScopeRepresentation> findAll();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientTypesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientTypesResource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.cache.NoCache;
+import org.keycloak.representations.idm.ClientTypesRepresentation;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public interface ClientTypesResource {
+
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientTypesRepresentation getClientTypes();
+
+
+    /**
+     * Update client types in the realm. The "global-client-types" field of client types is ignored as it is not possible to update global types
+     *
+     * @param clientTypes
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateClientTypes(final ClientTypesRepresentation clientTypes);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface ClientsResource {
+
+    @Path("{id}")
+    ClientResource get(@PathParam("id") String id);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(ClientRepresentation clientRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> findAll();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> findAll(@QueryParam("viewableOnly") boolean viewableOnly);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> findAll(@QueryParam("clientId") String clientId,
+                                                 @QueryParam("viewableOnly") Boolean viewableOnly,
+                                                 @QueryParam("search") Boolean search,
+                                                 @QueryParam("first") Integer firstResult,
+                                                 @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> findByClientId(@QueryParam("clientId") String clientId);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> query(@QueryParam("q") String searchQuery);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface ComponentResource {
+    @GET
+    ComponentRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ComponentRepresentation rep);
+
+    @DELETE
+    void remove();
+
+    /**
+     * List of subcomponent types that are available to configure for a particular parent component.
+     *
+     * @param subtype fully qualified name of the java class of the provider, which is subtype of this component
+     * @return
+     */
+    @GET
+    @Path("sub-component-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentTypeRepresentation> getSubcomponentConfig(@QueryParam("type") String subtype);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ComponentsResource.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ComponentRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface ComponentsResource {
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentRepresentation> query();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentRepresentation> query(@QueryParam("parent") String parent);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentRepresentation> query(@QueryParam("parent") String parent, @QueryParam("type") String type);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentRepresentation> query(@QueryParam("parent") String parent,
+                                        @QueryParam("type") String type,
+                                        @QueryParam("name") String name);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response add(ComponentRepresentation rep);
+
+    @Path("{id}")
+    ComponentResource component(@PathParam("id") String id);
+
+    @Path("{id}")
+    @DELETE
+    ComponentResource removeComponent(@PathParam("id") String id);
+
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupPoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface GroupPoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(GroupPolicyRepresentation representation);
+
+    @Path("{id}")
+    GroupPolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    GroupPolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupPolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupPolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface GroupPolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    GroupPolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(GroupPolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupResource.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface GroupResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
+
+    /**
+     * Does not expand hierarchy.  Subgroups will not be set.
+     *
+     * @return
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    GroupRepresentation toRepresentation();
+
+    /**
+     * Update group
+     *
+     * @param rep
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(GroupRepresentation rep);
+
+    @DELETE
+    void remove();
+
+    /**
+     * Get the paginated list of subgroups belonging to this group.
+     *
+     * @param first the position of the first result to be returned.
+     * @param max the maximum number of results that are to be returned.
+     * @param briefRepresentation if {@code true}, each returned subgroup representation will only contain basic information
+     *                           (id, name, path, and parentId). If {@code false}, the complete representations of the subgroups
+     *                            are returned (include role mappings and attributes).
+     */
+    @GET
+    @Path("children")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> getSubGroups(@QueryParam("first") Integer first, @QueryParam("max") Integer max, @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    /**
+     * Get the paginated list of subgroups belonging to this group, filtered according to the specified parameters.
+     *
+     * @param search a {@code String} representing either an exact group name or a partial name. If empty or {@code null}
+     *              then all subgroups of this group are returned.
+     * @param exact if {@code true}, the subgroups will be searched using exact match for the {@code search} param. If false
+     *              or {@code null}, the method returns all subgroups that partially match the specified name.
+     * @param first the position of the first result to be returned.
+     * @param max the maximum number of results that are to be returned.
+     * @param briefRepresentation if {@code true}, each returned subgroup representation will only contain basic information
+     *                           (id, name, path, and parentId). If {@code false}, the complete representations of the subgroups
+     *                            are returned (including role mappings and attributes).
+     */
+    @GET
+    @Path("children")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> getSubGroups(
+            @QueryParam("search") String search,
+            @QueryParam("exact") Boolean exact,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max,
+            @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+
+    /**
+     * Set or create child.  This will just set the parent if it exists.  Create it and set the parent
+     * if the group doesn't exist.
+     *
+     * @param rep
+     */
+    @POST
+    @Path("children")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response subGroup(GroupRepresentation rep);
+
+
+    @Path("role-mappings")
+    RoleMappingResource roles();
+
+    /**
+     * Get users
+     * <p/>
+     * Returns a list of all users in group.
+     *
+     * @return  Returns a max size of 100 users
+     */
+    @GET
+    @Path("/members")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> members();
+
+    /**
+     * Get users
+     * <p/>
+     * Returns a list of users, filtered according to query parameters
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @return
+     */
+    @GET
+    @Path("/members")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> members(@QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults);
+
+    /**
+     * Get users
+     * <p/>
+     * Returns a list of users, filtered according to query parameters
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @param briefRepresentation Only return basic information (only guaranteed to return id, username, created, first and last name,
+     *      email, enabled state, email verification state, federation link, and access.
+     *      Note that it means that namely user attributes, required actions, and not before are not returned.)
+     * @return
+     */
+    @GET
+    @Path("/members")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> members(@QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults,
+                                     @QueryParam("briefRepresentation") Boolean briefRepresentation);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.GroupRepresentation;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface GroupsResource {
+
+    /**
+     * Get all groups.
+     * @return A list containing all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups();
+
+    /**
+     * Get groups by pagination params.
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("first") Integer first, @QueryParam("max") Integer max);
+
+    /**
+     * Get groups by pagination params.
+     * @param search A {@code String} representing either an exact or partial group name.
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer first,
+                                     @QueryParam("max") Integer max);
+
+    /**
+     * Get groups by pagination params.
+     * @param search A {@code String} representing either an exact or partial group name.
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @param briefRepresentation if {@code true}, each returned group representation will only contain basic information
+     *                            (id, name, path, and parentId). If {@code false}, the complete representations of the groups
+     *                            are returned (including role mappings and attributes).
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer first,
+                                     @QueryParam("max") Integer max,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    /**
+     * Get groups by pagination params.
+     * @param search A {@code String} representing either an exact or partial group name.
+     * @param exact if {@code true}, the groups will be searched using exact match for the {@code search} param. If false,
+     *      *              the method returns all groups that partially match the specified name.
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @param briefRepresentation if {@code true}, each returned group representation will only contain basic information
+     *                            (id, name, path, and parentId). If {@code false}, the complete representations of the groups
+     *                            are returned (including role mappings and attributes).
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("exact") Boolean exact,
+                                     @QueryParam("first") Integer first,
+                                     @QueryParam("max") Integer max,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    /**
+     * Counts all groups.
+     * @return A map containing key "count" with number of groups as value.
+     */
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Map<String, Long> count();
+
+    /**
+     * Counts groups by name search.
+     * @param search max number of occurrences
+     * @return A map containing key "count" with number of groups as value which matching with search.
+     */
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Map<String, Long> count(@QueryParam("search") String search);
+
+    /**
+     * Counts groups by name search.
+     * @param onlyTopGroups <code>true</code> or <code>false</code> for filter only top level groups count
+     * @return A map containing key "count" with number of top level groups.
+     */
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Map<String, Long> count(@QueryParam("top") @DefaultValue("true") boolean onlyTopGroups);
+
+    /**
+     * create or add a top level realm groupSet or create child.  This will update the group and set the parent if it exists.  Create it and set the parent
+     * if the group doesn't exist.
+     *
+     * @param rep
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response add(GroupRepresentation rep);
+
+    @Path("{id}")
+    GroupResource group(@PathParam("id") String id);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> query(@QueryParam("q") String searchQuery);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> query(@QueryParam("q") String searchQuery, @QueryParam("populateHierarchy") boolean populateHierarchy);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> query(@QueryParam("q") String searchQuery,
+            @QueryParam("populateHierarchy") boolean populateHierarchy, @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max, @QueryParam("briefRepresentation") boolean briefRepresentation);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/IdentityProviderResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/IdentityProviderResource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderMapperTypeRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author pedroigor
+ */
+public interface IdentityProviderResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    IdentityProviderRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(IdentityProviderRepresentation identityProviderRepresentation);
+
+    @DELETE
+    void remove();
+
+    @GET
+    @Path("export")
+    Response export(@QueryParam("format") String format);
+
+    @GET
+    @Path("mapper-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, IdentityProviderMapperTypeRepresentation> getMapperTypes();
+
+    @GET
+    @Path("mappers")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<IdentityProviderMapperRepresentation> getMappers();
+
+    @POST
+    @Path("mappers")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response addMapper(IdentityProviderMapperRepresentation mapper);
+
+    @GET
+    @Path("mappers/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    IdentityProviderMapperRepresentation getMapperById(@PathParam("id") String id);
+
+    @PUT
+    @Path("mappers/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(@PathParam("id") String id, IdentityProviderMapperRepresentation rep);
+
+    @DELETE
+    @Path("mappers/{id}")
+    void delete(@PathParam("id") String id);
+
+    @GET
+    @Path("reload-keys")
+    boolean reloadKeys();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/IdentityProvidersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/IdentityProvidersResource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author pedroigor
+ */
+public interface IdentityProvidersResource {
+
+    @Path("instances/{alias}")
+    IdentityProviderResource get(@PathParam("alias") String alias);
+
+    @GET
+    @Path("instances")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<IdentityProviderRepresentation> findAll();
+
+    @GET
+    @Path("instances")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<IdentityProviderRepresentation> find(@QueryParam("search") String search, @QueryParam("briefRepresentation") Boolean briefRepresentation, @QueryParam("first") Integer firstResult, @QueryParam("max") Integer maxResults);
+
+    @POST
+    @Path("instances")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(IdentityProviderRepresentation identityProvider);
+
+    @GET
+    @Path("/providers/{provider_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getIdentityProviders(@PathParam("provider_id") String providerId);
+
+    @POST
+    @Path("import-config")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, String> importFrom(Object data);
+
+    @POST
+    @Path("import-config")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, String> importFrom(Map<String, Object> data);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/JSPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/JSPoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface JSPoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(JSPolicyRepresentation representation);
+
+    @Path("{id}")
+    JSPolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    JSPolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/JSPolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/JSPolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface JSPolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    JSPolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(JSPolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/KeyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/KeyResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.KeysMetadataRepresentation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public interface KeyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    KeysMetadataRepresentation getKeyMetadata();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProviderResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProviderResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+public interface OrganizationIdentityProviderResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    IdentityProviderRepresentation toRepresentation();
+
+    @DELETE
+    Response delete();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProvidersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProvidersResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+public interface OrganizationIdentityProvidersResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response addIdentityProvider(String id);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<IdentityProviderRepresentation> getIdentityProviders();
+
+    @Path("{id}")
+    OrganizationIdentityProviderResource get(@PathParam("id") String id);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.UserRepresentation;
+
+public interface OrganizationMemberResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    UserRepresentation toRepresentation();
+
+    @DELETE
+    Response delete();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+public interface OrganizationMembersResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response addMember(String userId);
+
+    /**
+     * Return all members in the organization.
+     *
+     * @return a list containing the organization members.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getAll();
+
+    /**
+     * Return all organization members that match the specified filters.
+     *
+     * @param search a {@code String} representing either a member's username, e-mail, first name, or last name.
+     * @param exact if {@code true}, the members will be searched using exact match for the {@code search} param - i.e.
+     *              at least one of the username main attributes must match exactly the {@code search} param. If false,
+     *              the method returns all members with at least one main attribute partially matching the {@code search} param.
+     * @param first index of the first element (pagination offset).
+     * @param max the maximum number of results.
+     * @return a list containing the matched organization members.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(
+            @QueryParam("search") String search,
+            @QueryParam("exact") Boolean exact,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max
+    );
+
+    @Path("{id}/organization")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    OrganizationRepresentation getOrganization(@PathParam("id") String id);
+
+    @Path("{id}")
+    OrganizationMemberResource member(@PathParam("id") String id);
+
+    @POST
+    @Path("invite-user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Response inviteUser(@FormParam("email") String email,
+                        @FormParam("firstName") String firstName,
+                        @FormParam("lastName") String lastName);
+
+    @POST
+    @Path("invite-existing-user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Response inviteExistingUser(@FormParam("id") String id);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+
+public interface OrganizationResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    OrganizationRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response update(OrganizationRepresentation organization);
+
+    @DELETE
+    Response delete();
+
+    @Path("members")
+    OrganizationMembersResource members();
+
+    @Path("identity-providers")
+    OrganizationIdentityProvidersResource identityProviders();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationsResource.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+
+public interface OrganizationsResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(OrganizationRepresentation organization);
+
+    @Path("{id}")
+    OrganizationResource get(@PathParam("id") String id);
+
+    /**
+     * Returns all organizations in the realm.
+     *
+     * @return a list containing the organizations.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> getAll();
+
+    /**
+     * Returns all organizations that match the specified filter.
+     *
+     * @param search a {@code String} representing either an organization name or domain.
+     * @return a list containing the matched organizations.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> search(@QueryParam("search") String search);
+
+    /**
+     * Returns all organizations that match the specified filters.
+     *
+     * @param search a {@code String} representing either an organization name or domain.
+     * @param exact if {@code true}, the organizations will be searched using exact match for the {@code search} param - i.e.
+     *              either the organization name or one of its domains must match exactly the {@code search} param. If false,
+     *              the method returns all organizations whose name or (domains) partially match the {@code search} param.
+     * @param first the position of the first result to be processed (pagination offset). Ignored if negative or {@code null}.
+     * @param max the maximum number of results to be returned. Ignored if negative or {@code null}.
+     * @return a list containing the matched organizations.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> search(
+            @QueryParam("search") String search,
+            @QueryParam("exact") Boolean exact,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max
+    );
+
+    /**
+     * Returns all organizations that contain attributes matching the specified query.
+     *
+     * @param searchQuery a query to search for organization attributes, in the format 'key1:value2 key2:value2'.
+     * @return a list containing the organizations that match the attribute query.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> searchByAttribute(
+            @QueryParam("q") String searchQuery
+    );
+
+    /**
+     * Returns all organizations that contain attributes matching the specified query.
+     *
+     * @param searchQuery a query to search for organization attributes, in the format 'key1:value2 key2:value2'.
+     * @param first the position of the first result to be processed (pagination offset). Ignored if negative or {@code null}.
+     * @param max the maximum number of results to be returned. Ignored if negative or {@code null}.
+     * @return a list containing the organizations that match the attribute query.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> searchByAttribute(
+            @QueryParam("q") String searchQuery,
+            @QueryParam("first") Integer first,
+            @QueryParam("max") Integer max
+    );
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PermissionsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PermissionsResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Path;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface PermissionsResource {
+
+    @Path("resource")
+    ResourcePermissionsResource resource();
+
+    @Path("scope")
+    ScopePermissionsResource scope();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PoliciesResource.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.authorization.PolicyEvaluationRequest;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationResponse;
+import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface PoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(PolicyRepresentation representation);
+
+    @Path("{id}")
+    PolicyResource policy(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    PolicyRepresentation findByName(@QueryParam("name") String name);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> policies();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> policies(@QueryParam("policyId") String id,
+            @QueryParam("name") String name,
+            @QueryParam("type") String type,
+            @QueryParam("resource") String resource,
+            @QueryParam("scope") String scope,
+            @QueryParam("permission") Boolean permission,
+            @QueryParam("owner") String owner,
+            @QueryParam("fields") String fields,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResult);
+
+    @Path("providers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyProviderRepresentation> policyProviders();
+
+    @POST
+    @Consumes("application/json")
+    @Produces("application/json")
+    @Path("evaluate")
+    PolicyEvaluationResponse evaluate(PolicyEvaluationRequest evaluationRequest);
+
+    @Path("role")
+    RolePoliciesResource role();
+
+    @Path("user")
+    UserPoliciesResource user();
+
+    @Path("js")
+    JSPoliciesResource js();
+
+    @Path("time")
+    TimePoliciesResource time();
+
+    @Path("aggregate")
+    AggregatePoliciesResource aggregate();
+
+    @Path("client")
+    ClientPoliciesResource client();
+
+    @Path("group")
+    GroupPoliciesResource group();
+
+    @Path("client-scope")
+    ClientScopePoliciesResource clientScope();
+    
+    @Path("regex")
+    RegexPoliciesResource regex();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/PolicyResource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface PolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    PolicyRepresentation toRepresentation();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    PolicyRepresentation toRepresentation(@QueryParam("fields") String fields);
+    
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(PolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/scopes")
+    @GET
+    @Produces("application/json")
+    List<ScopeRepresentation> scopes();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ProtocolMappersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ProtocolMappersResource.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public interface ProtocolMappersResource {
+
+    @GET
+    @Path("protocol/{protocol}")
+    @Produces("application/json")
+    List<ProtocolMapperRepresentation> getMappersPerProtocol(@PathParam("protocol") String protocol);
+
+    @Path("models")
+    @POST
+    @Consumes("application/json")
+    Response createMapper(ProtocolMapperRepresentation rep);
+
+    @Path("add-models")
+    @POST
+    @Consumes("application/json")
+    void createMapper(List<ProtocolMapperRepresentation> reps);
+
+    @GET
+    @Path("models")
+    @Produces("application/json")
+    List<ProtocolMapperRepresentation> getMappers();
+
+    @GET
+    @Path("models/{id}")
+    @Produces("application/json")
+    ProtocolMapperRepresentation getMapperById(@PathParam("id") String id);
+
+    @PUT
+    @Path("models/{id}")
+    @Consumes("application/json")
+    void update(@PathParam("id") String id, ProtocolMapperRepresentation rep);
+
+    @DELETE
+    @Path("models/{id}")
+    void delete(@PathParam("id") String id);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmLocalizationResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmLocalizationResource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+public interface RealmLocalizationResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getRealmSpecificLocales();
+
+    /**
+     * Get the localization texts for the given locale.
+     *
+     * @param locale the locale
+     * @return the localization texts
+     */
+    @Path("{locale}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, String> getRealmLocalizationTexts(final @PathParam("locale") String locale);
+
+
+    /**
+     * DEPRECATED - Get the localization texts for the given locale.
+     *
+     * @param locale the locale
+     * @param useRealmDefaultLocaleFallback whether the localization texts for the realm default locale should be used
+     *        as fallbacks in the result
+     * @return the localization texts
+     * @deprecated use {@link #getRealmLocalizationTexts(String)}, in order to retrieve localization texts without
+     *             fallbacks. If you need fallbacks, call the endpoint multiple time with all the relevant locales (e.g.
+     *             "de" in case of "de-CH") - the realm default locale is NOT the only fallback to be considered.
+     */
+    @Deprecated
+    @Path("{locale}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, String> getRealmLocalizationTexts(final @PathParam("locale") String locale,
+            @QueryParam("useRealmDefaultLocaleFallback") Boolean useRealmDefaultLocaleFallback);
+
+
+    @Path("{locale}/{key}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    String getRealmLocalizationText(final @PathParam("locale") String locale, final @PathParam("key") String key);
+
+
+    @Path("{locale}")
+    @DELETE
+    void deleteRealmLocalizationTexts(@PathParam("locale") String locale);
+
+    @Path("{locale}/{key}")
+    @DELETE
+    void deleteRealmLocalizationText(@PathParam("locale") String locale, @PathParam("key") String key);
+
+    @Path("{locale}/{key}")
+    @PUT
+    @Consumes(MediaType.TEXT_PLAIN)
+    void saveRealmLocalizationText(@PathParam("locale") String locale, @PathParam("key") String key, String text);
+
+    @Path("{locale}")
+    @POST
+    @Consumes("application/json")
+    void createOrUpdateRealmLocalizationTexts(@PathParam("locale") String locale, Map<String, String> localizationTexts);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.adapters.action.GlobalRequestResult;
+import org.keycloak.representations.idm.AdminEventRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.LDAPCapabilityRepresentation;
+import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.RealmEventsConfigRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.TestLdapConnectionRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface RealmResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RealmRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(RealmRepresentation realmRepresentation);
+
+    @Path("clients")
+    ClientsResource clients();
+
+    @Path("client-scopes")
+    ClientScopesResource clientScopes();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("default-default-client-scopes")
+    List<ClientScopeRepresentation> getDefaultDefaultClientScopes();
+
+    @PUT
+    @Path("default-default-client-scopes/{clientScopeId}")
+    void addDefaultDefaultClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @DELETE
+    @Path("default-default-client-scopes/{clientScopeId}")
+    void removeDefaultDefaultClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("default-optional-client-scopes")
+    List<ClientScopeRepresentation> getDefaultOptionalClientScopes();
+
+    @PUT
+    @Path("default-optional-client-scopes/{clientScopeId}")
+    void addDefaultOptionalClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @DELETE
+    @Path("default-optional-client-scopes/{clientScopeId}")
+    void removeDefaultOptionalClientScope(@PathParam("clientScopeId") String clientScopeId);
+
+    @Path("client-description-converter")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ClientRepresentation convertClientDescription(String description);
+
+    @Path("users")
+    UsersResource users();
+
+    @Path("roles")
+    RolesResource roles();
+
+    @Path("roles-by-id")
+    RoleByIdResource rolesById();
+
+    @Path("groups")
+    GroupsResource groups();
+
+    @DELETE
+    @Path("events")
+    void clearEvents();
+
+    @GET
+    @Path("events")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<EventRepresentation> getEvents();
+
+    @Path("events")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<EventRepresentation> getEvents(@QueryParam("type") List<String> types, @QueryParam("client") String client,
+            @QueryParam("user") String user, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
+            @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
+
+    @DELETE
+    @Path("admin-events")
+    void clearAdminEvents();
+
+    @GET
+    @Path("admin-events")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AdminEventRepresentation> getAdminEvents();
+
+    @GET
+    @Path("admin-events")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AdminEventRepresentation> getAdminEvents(@QueryParam("operationTypes") List<String> operationTypes, @QueryParam("authRealm") String authRealm, @QueryParam("authClient") String authClient,
+            @QueryParam("authUser") String authUser, @QueryParam("authIpAddress") String authIpAddress,
+            @QueryParam("resourcePath") String resourcePath, @QueryParam("dateFrom") String dateFrom,
+            @QueryParam("dateTo") String dateTo, @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Path("admin-events")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AdminEventRepresentation> getAdminEvents(@QueryParam("operationTypes") List<String> operationTypes, @QueryParam("authRealm") String authRealm, @QueryParam("authClient") String authClient,
+            @QueryParam("authUser") String authUser, @QueryParam("authIpAddress") String authIpAddress,
+            @QueryParam("resourcePath") String resourcePath, @QueryParam("resourceTypes") List<String> resourceTypes, @QueryParam("dateFrom") String dateFrom,
+            @QueryParam("dateTo") String dateTo, @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Path("events/config")
+    @Produces(MediaType.APPLICATION_JSON)
+    RealmEventsConfigRepresentation getRealmEventsConfig();
+
+    @PUT
+    @Path("events/config")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateRealmEventsConfig(RealmEventsConfigRepresentation rep);
+
+    @GET
+    @Path("group-by-path/{path: .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    GroupRepresentation getGroupByPath(@PathParam("path") String path);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("default-groups")
+    List<GroupRepresentation> getDefaultGroups();
+
+    @PUT
+    @Path("default-groups/{groupId}")
+    void addDefaultGroup(@PathParam("groupId") String groupId);
+
+    @DELETE
+    @Path("default-groups/{groupId}")
+    void removeDefaultGroup(@PathParam("groupId") String groupId);
+
+    @Path("identity-provider")
+    IdentityProvidersResource identityProviders();
+
+    @DELETE
+    void remove();
+
+    @Path("client-session-stats")
+    @GET
+    List<Map<String, String>> getClientSessionStats();
+
+    @Path("clients-initial-access")
+    ClientInitialAccessResource clientInitialAccess();
+
+    @Path("client-registration-policy")
+    ClientRegistrationPolicyResource clientRegistrationPolicy();
+
+    @Path("partialImport")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response partialImport(PartialImportRepresentation rep);
+
+    @Path("partial-export")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    RealmRepresentation partialExport(@QueryParam("exportGroupsAndRoles") Boolean exportGroupsAndRoles,
+                                             @QueryParam("exportClients") Boolean exportClients);
+    @Path("authentication")
+    @Consumes(MediaType.APPLICATION_JSON)
+    AuthenticationManagementResource flows();
+
+    @Path("attack-detection")
+    AttackDetectionResource attackDetection();
+
+    @Path("testLDAPConnection")
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Deprecated
+    Response testLDAPConnection(@FormParam("action") String action, @FormParam("connectionUrl") String connectionUrl,
+                                @FormParam("bindDn") String bindDn, @FormParam("bindCredential") String bindCredential,
+                                @FormParam("useTruststoreSpi") String useTruststoreSpi, @FormParam("connectionTimeout") String connectionTimeout);
+
+    @Path("testLDAPConnection")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response testLDAPConnection(TestLdapConnectionRepresentation config);
+
+    @POST
+    @Path("ldap-server-capabilities")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(javax.ws.rs.core.MediaType.APPLICATION_JSON)
+    List<LDAPCapabilityRepresentation> ldapServerCapabilities(TestLdapConnectionRepresentation config);
+
+    @Path("testSMTPConnection")
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Deprecated
+    Response testSMTPConnection(@FormParam("config") String config);
+
+    @Path("testSMTPConnection")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response testSMTPConnection(Map<String, String> config);
+
+    @Path("clear-realm-cache")
+    @POST
+    void clearRealmCache();
+
+    @Path("clear-user-cache")
+    @POST
+    void clearUserCache();
+
+    @Path("clear-keys-cache")
+    @POST
+    void clearKeysCache();
+
+    @Path("push-revocation")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    GlobalRequestResult pushRevocation();
+
+    @Path("logout-all")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    GlobalRequestResult logoutAll();
+
+    @Path("sessions/{session}")
+    @DELETE
+    void deleteSession(@PathParam("session") String sessionId, @DefaultValue("false") @QueryParam("isOffline") boolean offline);
+
+    @Path("components")
+    ComponentsResource components();
+
+    @Path("user-storage")
+    UserStorageProviderResource userStorage();
+
+
+    @Path("keys")
+    KeyResource keys();
+
+    @Path("localization")
+    RealmLocalizationResource localization();
+
+    @Path("client-policies/policies")
+    ClientPoliciesPoliciesResource clientPoliciesPoliciesResource();
+
+    @Path("client-policies/profiles")
+    ClientPoliciesProfilesResource clientPoliciesProfilesResource();
+
+    @Path("organizations")
+    OrganizationsResource organizations();
+
+    @Path("client-types")
+    ClientTypesResource clientTypes();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RealmsResource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+@Path("/admin/realms")
+@Consumes(MediaType.APPLICATION_JSON)
+public interface RealmsResource {
+
+    @Path("/{realm}")
+    RealmResource realm(@PathParam("realm") String realm);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void create(RealmRepresentation realmRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RealmRepresentation> findAll();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RegexPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RegexPoliciesResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.RegexPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
+ */
+public interface RegexPoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(RegexPolicyRepresentation representation);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcePermissionResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcePermissionResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourcePermissionResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ResourcePermissionRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ResourcePermissionRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcePermissionsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcePermissionsResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourcePermissionsResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ResourcePermissionRepresentation representation);
+
+    @Path("{id}")
+    ResourcePermissionResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ResourcePermissionRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourceResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ResourceRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ResourceRepresentation resource);
+
+    @DELETE
+    void remove();
+
+    @Path("permissions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> permissions();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceScopeResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceScopeResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourceScopeResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ScopeRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ScopeRepresentation scope);
+
+    @DELETE
+    void remove();
+
+    @Path("/permissions")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> permissions();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceScopesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourceScopesResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourceScopesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ScopeRepresentation scope);
+
+    @Path("{id}")
+    ResourceScopeResource scope(@PathParam("id") String id);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ScopeRepresentation> scopes();
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ScopeRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ResourcesResource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ResourcesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ResourceRepresentation resource);
+
+    @Path("{id}")
+    ResourceResource resource(@PathParam("id") String id);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ResourceRepresentation> find(@QueryParam("name") String name,
+                  @QueryParam("uri") String uri,
+                  @QueryParam("owner") String owner,
+                  @QueryParam("type") String type,
+                  @QueryParam("scope") String scope,
+                  @QueryParam("first") Integer firstResult,
+                  @QueryParam("max") Integer maxResult);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ResourceRepresentation> findByName(@QueryParam("name") String name);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ResourceRepresentation> findByName(@QueryParam("name") String name, @QueryParam("owner") String owner);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ResourceRepresentation> resources();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleByIdResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleByIdResource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Sometimes its easier to just interact with roles by their ID instead of container/role-name
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface RoleByIdResource {
+
+    @Path("{role-id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RoleRepresentation getRole(final @PathParam("role-id") String id);
+
+    @Path("{role-id}")
+    @DELETE
+    void deleteRole(final @PathParam("role-id") String id);
+
+    @Path("{role-id}")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateRole(final @PathParam("role-id") String id, RoleRepresentation rep);
+
+    @Path("{role-id}/composites")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void addComposites(final @PathParam("role-id") String id, List<RoleRepresentation> roles);
+
+    @Path("{role-id}/composites")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getRoleComposites(@PathParam("role-id") String id);
+
+    @Path("{role-id}/composites")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> searchRoleComposites(@PathParam("role-id") String id,
+                                                 @QueryParam("search") String search,
+                                                 @QueryParam("first") Integer first,
+                                                 @QueryParam("max") Integer max);
+
+    @Path("{role-id}/composites/realm")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getRealmRoleComposites(@PathParam("role-id") String id);
+
+    @Path("{role-id}/composites/clients/{clientUuid}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getClientRoleComposites(@PathParam("role-id") String id, @PathParam("clientUuid") String clientUuid);
+
+    @Path("{role-id}/composites")
+    @DELETE
+    @Consumes(MediaType.APPLICATION_JSON)
+    void deleteComposites(final @PathParam("role-id") String id, List<RoleRepresentation> roles);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleMappingResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleMappingResource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.MappingsRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface RoleMappingResource {
+
+    @GET
+    MappingsRepresentation getAll();
+
+    @Path("realm")
+    RoleScopeResource realmLevel();
+
+    @Path("clients/{clientUUID}")
+    RoleScopeResource clientLevel(@PathParam("clientUUID") String clientUUID);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolePoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolePoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface RolePoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(RolePolicyRepresentation representation);
+
+    @Path("{id}")
+    RolePolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RolePolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolePolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolePolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface RolePolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RolePolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(RolePolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface RoleResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RoleRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(RoleRepresentation roleRepresentation);
+
+    @DELETE
+    void remove();
+
+    @GET
+    @Path("composites")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getRoleComposites();
+
+    @GET
+    @Path("composites/realm")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getRealmRoleComposites();
+
+    @GET
+    @Path("composites/clients/{clientUuid}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<RoleRepresentation> getClientRoleComposites(@PathParam("clientUuid") String clientUuid);
+
+    @POST
+    @Path("composites")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void addComposites(List<RoleRepresentation> rolesToAdd);
+
+    @DELETE
+    @Path("composites")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void deleteComposites(List<RoleRepresentation> rolesToRemove);
+
+    /**
+     * Get role members.
+     * <p>
+     * Returns users that have the given role, sorted by username ascending.
+     * </p>
+     * <p>
+     * Note: This method just returns the first 100 users. In order to retrieve all users, use paging (see
+     * {@link #getUserMembers(Integer, Integer)}).
+     * </p>
+     * 
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUserMembers();
+
+    /**
+     * Get role members.
+     * <p>Returns users that have the given role, sorted by username ascending, paginated according to the query
+     * parameters.</p>
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults Pagination size
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUserMembers(@QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
+
+    /**
+     * Get role members.
+     * <p>Returns users that have the given role, sorted by username ascending, paginated according to the query
+     * parameters.</p>
+     *
+     * @param briefRepresentation If the user should be returned in brief or full representation
+     * @param firstResult Pagination offset
+     * @param maxResults Pagination size
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUserMembers(@QueryParam("briefRepresentation") Boolean briefRepresentation,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults);
+    
+    /**
+     * Get role groups.
+     * <p>Returns groups that have the given role.</p>
+     *
+     * @return a list of groups with the given role
+     */
+    @GET
+    @Path("groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<GroupRepresentation> getRoleGroupMembers();
+
+    /**
+     * Get role groups.
+     * <p>Returns groups that have the given role, paginated according to the query parameters.</p>
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @return a list of groups with the given role
+     */
+    @GET
+    @Path("groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<GroupRepresentation> getRoleGroupMembers(@QueryParam("first") Integer firstResult,
+                                               @QueryParam("max") Integer maxResults);
+
+    /**
+     * Get role members.
+     * <p>Returns users that have the given role.</p>
+     *
+     * @return a set of users with the given role
+     *
+     * @deprecated please use {@link #getUserMembers()}
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Deprecated
+    Set<UserRepresentation> getRoleUserMembers();
+
+    /**
+     * Get role members.
+     * <p>Returns users that have the given role, paginated according to the query parameters.</p>
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @return a set of users with the given role
+     *
+     * @deprecated please use {@link #getUserMembers(Integer, Integer)}
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Deprecated
+    Set<UserRepresentation> getRoleUserMembers(@QueryParam("first") Integer firstResult,
+                                               @QueryParam("max") Integer maxResults);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleScopeResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RoleScopeResource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface RoleScopeResource {
+
+    @GET
+    List<RoleRepresentation> listAll();
+
+    @GET
+    @Path("available")
+    List<RoleRepresentation> listAvailable();
+
+    @GET
+    @Path("composite")
+    List<RoleRepresentation> listEffective();
+    
+    @GET
+    @Path("composite")
+    List<RoleRepresentation> listEffective(@QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    @POST
+    void add(List<RoleRepresentation> rolesToAdd);
+
+    @DELETE
+    void remove(List<RoleRepresentation> rolesToRemove);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/RolesResource.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public interface RolesResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list();
+    
+    /**
+     * @param briefRepresentation if false, return roles with their attributes
+     * @return A list containing all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+    
+    /**
+     * Get roles by pagination params.
+     * @param search max number of occurrences
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @return A list containing the slice of all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("first") Integer firstResult,
+                                  @QueryParam("max") Integer maxResults);
+    
+    /**
+     * Get roles by pagination params.
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @param briefRepresentation if false, return roles with their attributes
+     * @return A list containing the slice of all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("first") Integer firstResult,
+                                  @QueryParam("max") Integer maxResults,
+                                  @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+    
+    /**
+     * Get roles by pagination params.
+     * @param search max number of occurrences
+     * @param briefRepresentation if false, return roles with their attributes
+     * @return A list containing the slice of all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("search") @DefaultValue("") String search,
+                                  @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+    
+    /**
+     * Get roles by pagination params.
+     * @param search max number of occurrences
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @return A list containing the slice of all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("search") @DefaultValue("") String search,
+                                  @QueryParam("first") Integer firstResult,
+                                  @QueryParam("max") Integer maxResults);
+    
+    /**
+     * Get roles by pagination params.
+     * @param search max number of occurrences
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @param briefRepresentation if false, return roles with their attributes
+     * @return A list containing the slice of all roles.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> list(@QueryParam("search") @DefaultValue("") String search,
+                                  @QueryParam("first") Integer firstResult,
+                                  @QueryParam("max") Integer maxResults,
+                                  @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    void create(RoleRepresentation roleRepresentation);
+
+    @Path("{roleName}")
+    RoleResource get(@PathParam("roleName") String roleName);
+
+    @Path("{role-name}")
+    @DELETE
+    void deleteRole(final @PathParam("role-name") String roleName);
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ScopePermissionResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ScopePermissionResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ScopePermissionResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ScopePermissionRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(ScopePermissionRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+    @Path("/scopes")
+    @GET
+    @Produces("application/json")
+    List<ScopeRepresentation> scopes();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ScopePermissionsResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ScopePermissionsResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface ScopePermissionsResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(ScopePermissionRepresentation representation);
+
+    @Path("{id}")
+    ScopePermissionResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ScopePermissionRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ServerInfoResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/ServerInfoResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.info.ServerInfoRepresentation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+@Path("/admin/serverinfo")
+public interface ServerInfoResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    ServerInfoRepresentation getInfo();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/TimePoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/TimePoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.TimePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface TimePoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(TimePolicyRepresentation representation);
+
+    @Path("{id}")
+    TimePolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    TimePolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/TimePolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/TimePolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.TimePolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface TimePolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    TimePolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(TimePolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserPoliciesResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserPoliciesResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface UserPoliciesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response create(UserPolicyRepresentation representation);
+
+    @Path("{id}")
+    UserPolicyResource findById(@PathParam("id") String id);
+
+    @Path("/search")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    UserPolicyRepresentation findByName(@QueryParam("name") String name);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserPolicyResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserPolicyResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface UserPolicyResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    UserPolicyRepresentation toRepresentation();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(UserPolicyRepresentation representation);
+
+    @DELETE
+    void remove();
+
+    @Path("/associatedPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> associatedPolicies();
+
+    @Path("/dependentPolicies")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PolicyRepresentation> dependentPolicies();
+
+    @Path("/resources")
+    @GET
+    @Produces("application/json")
+    List<ResourceRepresentation> resources();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserProfileResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserProfileResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.UserProfileMetadata;
+import org.keycloak.representations.userprofile.config.UPConfig;
+
+/**
+ * @author Vlastimil Elias <velias@redhat.com>
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface UserProfileResource {
+
+    /**
+     * @return user profile configuration
+     */
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    UPConfig getConfiguration();
+
+    @GET
+    @Path("/metadata")
+    @Consumes(MediaType.APPLICATION_JSON)
+    UserProfileMetadata getMetadata();
+
+    /**
+     * Updates user profile configuration. Using null as an argument could mean restart of the configuration to the default configuration
+     *
+     * @param config Could be null, which can mean restart to the default user-profile configuration (Can depend on the implementation)
+     * @return
+     */
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    void update(UPConfig config);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface UserResource {
+
+    @GET
+    UserRepresentation toRepresentation();
+
+    @GET
+    UserRepresentation toRepresentation(@QueryParam("userProfileMetadata") boolean userProfileMetadata);
+
+    @PUT
+    void update(UserRepresentation userRepresentation);
+
+    @DELETE
+    void remove();
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups();
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults);
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults);
+    
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer firstResult,
+                                     @QueryParam("max") Integer maxResults,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    @Path("groups/count")
+    @GET
+    Map<String, Long> groupsCount(@QueryParam("search") String search);
+
+    @Path("groups/{groupId}")
+    @PUT
+    void joinGroup(@PathParam("groupId") String groupId);
+
+    @Path("groups/{groupId}")
+    @DELETE
+    void leaveGroup(@PathParam("groupId") String groupId);
+
+
+
+
+    @POST
+    @Path("logout")
+    void logout();
+
+
+
+    @GET
+    @Path("credentials")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<CredentialRepresentation> credentials();
+
+
+    /**
+     * Return credential types, which are provided by the user storage where user is stored. Returned values can contain for example "password", "otp" etc.
+     * This will always return empty list for "local" users, which are not backed by any user storage
+     *
+     * @return
+     */
+    @GET
+    @Path("configured-user-storage-credential-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getConfiguredUserStorageCredentialTypes();
+
+    /**
+     * Remove a credential for a user
+     *
+     */
+    @DELETE
+    @Path("credentials/{credentialId}")
+    void removeCredential(@PathParam("credentialId")String credentialId);
+
+    /**
+     * Update a credential label for a user
+     */
+    @PUT
+    @Consumes(javax.ws.rs.core.MediaType.TEXT_PLAIN)
+    @Path("credentials/{credentialId}/userLabel")
+    void setCredentialUserLabel(final @PathParam("credentialId") String credentialId, String userLabel);
+
+    /**
+     * Move a credential to a first position in the credentials list of the user
+     * @param credentialId The credential to move
+     */
+    @Path("credentials/{credentialId}/moveToFirst")
+    @POST
+    void moveCredentialToFirst(final @PathParam("credentialId") String credentialId);
+
+    /**
+     * Move a credential to a position behind another credential
+     * @param credentialId The credential to move
+     * @param newPreviousCredentialId The credential that will be the previous element in the list. If set to null, the moved credential will be the first element in the list.
+     */
+    @Path("credentials/{credentialId}/moveAfter/{newPreviousCredentialId}")
+    @POST
+    void moveCredentialAfter(final @PathParam("credentialId") String credentialId, final @PathParam("newPreviousCredentialId") String newPreviousCredentialId);
+
+
+    /**
+     * Disables or deletes all credentials for specific types.
+     * Type examples "otp", "password"
+     *
+     * This is typically supported just for the users backed by user storage providers. See {@link UserRepresentation#getDisableableCredentialTypes()}
+     * to see what credential types can be disabled for the particular user
+     *
+     * @param credentialTypes
+     */
+    @Path("disable-credential-types")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void disableCredentialType(List<String> credentialTypes);
+
+    @PUT
+    @Path("reset-password")
+    void resetPassword(CredentialRepresentation credentialRepresentation);
+
+    /**
+     * Use executeActionsEmail and pass in the UPDATE_PASSWORD required action
+     *
+     */
+    @PUT
+    @Path("reset-password-email")
+    @Deprecated
+    void resetPasswordEmail();
+
+    /**
+     * Use executeActionsEmail and pass in the UPDATE_PASSWORD required action
+     *
+     */
+    @PUT
+    @Path("reset-password-email")
+    @Deprecated
+    void resetPasswordEmail(@QueryParam("client_id") String clientId);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. {@code VERIFY_EMAIL, UPDATE_PROFILE, CONFIGURE_TOTP, UPDATE_PASSWORD, TERMS_AND_CONDITIONS}, etc.
+     *
+     * @param actions a {@link List} of string representation of {@link org.keycloak.models.UserModel.RequiredAction}
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(List<String> actions);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. {@code VERIFY_EMAIL, UPDATE_PROFILE, CONFIGURE_TOTP, UPDATE_PASSWORD, TERMS_AND_CONDITIONS}, etc.
+     *
+     * The lifespan decides the number of seconds after which the generated token in the email link expires. The default
+     * value is 12 hours.
+     *
+     * @param actions a {@link List} of string representation of {@link org.keycloak.models.UserModel.RequiredAction}
+     * @param lifespan
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(List<String> actions, @QueryParam("lifespan") Integer lifespan);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. {@code VERIFY_EMAIL, UPDATE_PROFILE, CONFIGURE_TOTP, UPDATE_PASSWORD, TERMS_AND_CONDITIONS}, etc.
+     *
+     * If redirectUri is not null, then you must specify a client id.  This will set the URI you want the flow to link
+     * to after the email link is clicked and actions completed.  If both parameters are null, then no page is linked to
+     * at the end of the flow.
+     *
+     * The lifespan decides the number of seconds after which the generated token in the email link expires. The default
+     * value is 12 hours.
+     *
+     * @param clientId
+     * @param redirectUri
+     * @param lifespan
+     * @param actions a {@link List} of string representation of {@link org.keycloak.models.UserModel.RequiredAction}
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(@QueryParam("client_id") String clientId,
+                             @QueryParam("redirect_uri") String redirectUri,
+                             @QueryParam("lifespan") Integer lifespan,
+                             List<String> actions);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. {@code VERIFY_EMAIL, UPDATE_PROFILE, CONFIGURE_TOTP, UPDATE_PASSWORD, TERMS_AND_CONDITIONS}, etc.
+     *
+     * If redirectUri is not null, then you must specify a client id.  This will set the URI you want the flow to link
+     * to after the email link is clicked and actions completed.  If both parameters are null, then no page is linked to
+     * at the end of the flow.
+     *
+     * @param clientId
+     * @param redirectUri
+     * @param actions a {@link List} of string representation of {@link org.keycloak.models.UserModel.RequiredAction}
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(@QueryParam("client_id") String clientId, @QueryParam("redirect_uri") String redirectUri, List<String> actions);
+
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail();
+
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("client_id") String clientId);
+
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("client_id") String clientId, @QueryParam("redirect_uri") String redirectUri);
+
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("lifespan") Integer lifespan);
+
+    /**
+     * Send an email-verification email to the user
+     *
+     * An email contains a link the user can click to verify their email address.
+     * The redirectUri and clientId parameters are optional. The default for the
+     * redirect is the account client. The default for the lifespan is 12 hours.
+     *
+     * @param redirectUri Redirect uri
+     * @param clientId Client id
+     * @param lifespan Number of seconds after which the generated token expires
+     * @return
+     */
+    @PUT
+    @Path("send-verify-email")
+    void sendVerifyEmail(@QueryParam("client_id") String clientId, @QueryParam("redirect_uri") String redirectUri, @QueryParam("lifespan") Integer lifespan);
+
+    @GET
+    @Path("sessions")
+    List<UserSessionRepresentation> getUserSessions();
+
+    @GET
+    @Path("offline-sessions/{clientId}")
+    List<UserSessionRepresentation> getOfflineSessions(@PathParam("clientId") String clientId);
+
+    @GET
+    @Path("federated-identity")
+    List<FederatedIdentityRepresentation> getFederatedIdentity();
+
+    @POST
+    @Path("federated-identity/{provider}")
+    Response addFederatedIdentity(@PathParam("provider") String provider, FederatedIdentityRepresentation rep);
+
+    @Path("federated-identity/{provider}")
+    @DELETE
+    void removeFederatedIdentity(final @PathParam("provider") String provider);
+
+    @Path("role-mappings")
+    RoleMappingResource roles();
+
+
+    @GET
+    @Path("consents")
+    List<Map<String, Object>> getConsents();
+
+    @DELETE
+    @Path("consents/{client}")
+    void revokeConsent(@PathParam("client") String clientId);
+
+    @POST
+    @Path("impersonation")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> impersonate();
+
+    @GET
+    @Path("unmanagedAttributes")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, List<String>> getUnmanagedAttributes();
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserStorageProviderResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UserStorageProviderResource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.SynchronizationResultRepresentation;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface UserStorageProviderResource {
+    /**
+     * If the provider supports synchronization, this will invoke it.
+     *
+     * Action can be "triggerFullSync" or "triggerChangedUsersSync"
+     *
+     *
+     * @param componentId
+     * @param action
+     * @return
+     */
+    @POST
+    @Path("{componentId}/sync")
+    @Produces(MediaType.APPLICATION_JSON)
+    SynchronizationResultRepresentation syncUsers(@PathParam("componentId") String componentId, @QueryParam("action") String action);
+
+    /**
+     * Remove imported users
+     *
+     *
+     * @param componentId
+     * @return
+     */
+    @POST
+    @Path("{componentId}/remove-imported-users")
+    @Produces(MediaType.APPLICATION_JSON)
+    void removeImportedUsers(@PathParam("componentId") String componentId);
+
+    /**
+     * Unlink imported users from a storage provider
+     *
+     * @param componentId
+     * @return
+     */
+    @POST
+    @Path("{componentId}/unlink-users")
+    @Produces(MediaType.APPLICATION_JSON)
+    void unlink(@PathParam("componentId") String componentId);
+
+    /**
+     * REST invocation for initiating sync for an ldap mapper.  This method may be moved in the future.  Right now
+     * don't have a good place for it.
+     *
+     * direction is "fedToKeycloak" or "keycloakToFed"
+     *
+     *
+     * @param componentId
+     * @param mapperId
+     * @param direction
+     * @return
+     */
+    @POST
+    @Path("{componentId}/mappers/{mapperId}/sync")
+    @Produces(MediaType.APPLICATION_JSON)
+    SynchronizationResultRepresentation syncMapperData(@PathParam("componentId") String componentId, @PathParam("mapperId") String mapperId, @QueryParam("direction") String direction);
+
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.resource;
+
+import org.keycloak.representations.idm.UserRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+public interface UsersResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    /**
+     * Search for users based on the given filters.
+     *
+     * @param username a value contained in username
+     * @param firstName a value contained in first name
+     * @param lastName a value contained in last name
+     * @param email a value contained in email
+     * @param emailVerified whether the email has been verified
+     * @param idpAlias the alias of the Identity Provider
+     * @param idpUserId the userId at the Identity Provider
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @param enabled only return enabled or disabled users
+     * @param briefRepresentation Only return basic information (only guaranteed to return id, username, created, first
+     *        and last name, email, enabled state, email verification state, federation link, and access.
+     *        Note that it means that namely user attributes, required actions, and not before are not returned.)
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("idpAlias") String idpAlias,
+                                    @QueryParam("idpUserId") String idpUserId,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByAttributes(@QueryParam("q") String searchQuery);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByAttributes(@QueryParam("first") Integer firstResult,
+                                                @QueryParam("max") Integer maxResults,
+                                                @QueryParam("enabled") Boolean enabled,
+                                                @QueryParam("briefRepresentation") Boolean briefRepresentation,
+                                                @QueryParam("q") String searchQuery);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username, @QueryParam("exact") Boolean exact);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByUsername(@QueryParam("username") String username, @QueryParam("exact") Boolean exact);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByEmail(@QueryParam("email") String email, @QueryParam("exact") Boolean exact);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByFirstName(@QueryParam("firstName") String email, @QueryParam("exact") Boolean exact);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByLastName(@QueryParam("lastName") String email, @QueryParam("exact") Boolean exact);
+
+    /**
+     * Search for users based on the given filters.
+     *
+     * @param username a value contained in username
+     * @param firstName a value contained in first name
+     * @param lastName a value contained in last name
+     * @param email a value contained in email
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @param enabled only return enabled or disabled users
+     * @param briefRepresentation Only return basic information (only guaranteed to return id, username, created, first
+     *        and last name, email, enabled state, email verification state, federation link, and access.
+     *        Note that it means that namely user attributes, required actions, and not before are not returned.)
+     * @param exact search with exact matching by filters (username, email, firstName, lastName)
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation,
+                                    @QueryParam("exact") Boolean exact);
+
+    /**
+     * Search for users whose username or email matches the value provided by {@code search}. The {@code search}
+     * argument also allows finding users by specific attributes as follows:
+     *
+     * <ul>
+     *     <li><i>id:</i> - Find users by identifier. For instance, <i>id:aa497859-bbf5-44ac-bf1a-74dbffcaf197</i></li>
+     * </ul>
+     *
+     * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("search") String search,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults);
+
+    /**
+     * Search for users whose username or email matches the value provided by {@code search}. The {@code search}
+     * argument also allows finding users by specific attributes as follows:
+     *
+     * <ul>
+     *     <li><i>id:</i> - Find users by identifier. For instance, <i>id:aa497859-bbf5-44ac-bf1a-74dbffcaf197</i></li>
+     * </ul>
+     *
+     * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @param briefRepresentation Only return basic information (only guaranteed to return id, username, created, first and last name,
+     *      email, enabled state, email verification state, federation link, and access.
+     *      Note that it means that namely user attributes, required actions, and not before are not returned.)
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("search") String search,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    /**
+     * Search for users whose username, first or last name or email matches the value provided by {@code search}. The {@code search}
+     * argument also allows finding users by specific attributes as follows:
+     *
+     * <ul>
+     *     <li><i>id:</i> - Find users by identifier. For instance, <i>id:aa497859-bbf5-44ac-bf1a-74dbffcaf197</i></li>
+     * </ul>
+     *
+     * @param search the value to search. It can be the username, email or any of the supported options to query based on user attributes
+     * @param enabled if true, only users that are enabled are returned
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("search") String search,
+      @QueryParam("enabled") Boolean enabled,
+      @QueryParam("first") Integer firstResult,
+      @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> list(@QueryParam("first") Integer firstResult,
+                                  @QueryParam("max") Integer maxResults);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> list();
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(UserRepresentation userRepresentation);
+
+    /**
+     * Returns the number of users that can be viewed.
+     *
+     * @return number of users
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count();
+
+    /**
+     * Returns the number of users that can be viewed and match the given search criteria.
+     * If none is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param search criteria to search for
+     * @return number of users matching the search criteria
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search);
+
+    /**
+     * Returns the number of users that can be viewed and match the given filters.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param last     last name field of a user
+     * @param first    first name field of a user
+     * @param email    email field of a user
+     * @param username username field of a user
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("username") String username);
+
+    /**
+     * Returns the number of users that can be viewed and match the given filters.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param last          last name field of a user
+     * @param first         first name field of a user
+     * @param email         email field of a user
+     * @param emailVerified emailVerified field of a user
+     * @param username      username field of a user
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("emailVerified") Boolean emailVerified,
+                  @QueryParam("username") String username);
+
+    /**
+     * Returns the number of users that can be viewed and match the given filters.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param search        arbitrary search string for all the fields below
+     * @param last          last name field of a user
+     * @param first         first name field of a user
+     * @param email         email field of a user
+     * @param emailVerified emailVerified field of a user
+     * @param username      username field of a user
+     * @param enabled       Boolean representing if user is enabled or not
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search,
+                  @QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("emailVerified") Boolean emailVerified,
+                  @QueryParam("username") String username,
+                  @QueryParam("enabled") Boolean enabled,
+                  @QueryParam("q") String searchQuery);
+
+    /**
+     * Returns the number of users with the given status for emailVerified.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param emailVerified emailVerified field of a user
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer countEmailVerified(@QueryParam("emailVerified") Boolean emailVerified);
+
+    @Path("{id}")
+    UserResource get(@PathParam("id") String id);
+
+    @Path("{id}")
+    @DELETE
+    Response delete(@PathParam("id") String id);
+
+    @Path("profile")
+    UserProfileResource userProfile();
+
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/spi/ResteasyClientClassicProvider.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/spi/ResteasyClientClassicProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.spi;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.keycloak.admin.client.ClientBuilderWrapper;
+import org.keycloak.admin.client.JacksonProvider;
+
+/**
+ * An implementation of {@link ResteasyClientProvider} based on RESTEasy classic.
+ */
+public class ResteasyClientClassicProvider implements ResteasyClientProvider {
+
+    @Override
+    public Client newRestEasyClient(Object customJacksonProvider, SSLContext sslContext, boolean disableTrustManager) {
+        ClientBuilder clientBuilder = ClientBuilderWrapper.create(sslContext, disableTrustManager);
+
+        if (customJacksonProvider != null) {
+            clientBuilder.register(customJacksonProvider, 100);
+        } else {
+            clientBuilder.register(JacksonProvider.class, 100);
+        }
+
+        return clientBuilder.build();
+    }
+
+    @Override
+    public <R> R targetProxy(WebTarget client, Class<R> targetClass) {
+        return ResteasyWebTarget.class.cast(client).proxy(targetClass);
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/spi/ResteasyClientProvider.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/spi/ResteasyClientProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.spi;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+
+/**
+ * An SPI for using the JAX-RS Client API regardless of the underlying stack.
+ */
+public interface ResteasyClientProvider {
+
+    /**
+     * Creates a new {@link Client}.
+     *
+     * @param messageHandler a {@link javax.ws.rs.ext.MessageBodyReader} and/or {@link javax.ws.rs.ext.MessageBodyWriter} instance.
+     * @param sslContext an optional {@link SSLContext}
+     * @param disableTrustManager if the client should not validate the server certificates when using TLS
+     * @return
+     */
+    Client newRestEasyClient(Object messageHandler, SSLContext sslContext, boolean disableTrustManager);
+
+    /**
+     * Creates a implementation-specific proxy for a given {@code targetClass}.
+     *
+     * @param target the {@link WebTarget} instance
+     * @param targetClass the JAX-RS client resource class
+     * @return an instance of {@code targetClass}
+     */
+    <R> R targetProxy(WebTarget target, Class<R> targetClass);
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.token;
+
+import javax.ws.rs.client.WebTarget;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.keycloak.admin.client.Config;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.BasicAuthFilter;
+import org.keycloak.common.util.Time;
+import org.keycloak.representations.AccessTokenResponse;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Form;
+
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.CLIENT_ID;
+import static org.keycloak.OAuth2Constants.GRANT_TYPE;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+import static org.keycloak.OAuth2Constants.REFRESH_TOKEN;
+import static org.keycloak.OAuth2Constants.SCOPE;
+import static org.keycloak.OAuth2Constants.USERNAME;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+public class TokenManager {
+    private static final long DEFAULT_MIN_VALIDITY = 30;
+
+    private AccessTokenResponse currentToken;
+    private long expirationTime;
+    private long refreshExpirationTime;
+    private long minTokenValidity = DEFAULT_MIN_VALIDITY;
+    private final Config config;
+    private final TokenService tokenService;
+    private final String accessTokenGrantType;
+
+    public TokenManager(Config config, Client client) {
+        this.config = config;
+        WebTarget target = client.target(config.getServerUrl());
+        if (!config.isPublicClient()) {
+            target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
+        }
+        this.tokenService = Keycloak.getClientProvider().targetProxy(target, TokenService.class);
+        this.accessTokenGrantType = config.getGrantType();
+
+        if (CLIENT_CREDENTIALS.equals(accessTokenGrantType) && config.isPublicClient()) {
+            throw new IllegalArgumentException("Can't use " + GRANT_TYPE + "=" + CLIENT_CREDENTIALS + " with public client");
+        }
+    }
+
+    public String getAccessTokenString() {
+        return getAccessToken().getToken();
+    }
+
+    public synchronized AccessTokenResponse getAccessToken() {
+        if (currentToken == null) {
+            grantToken();
+        } else if (tokenExpired()) {
+            refreshToken();
+        }
+        return currentToken;
+    }
+
+    public AccessTokenResponse grantToken() {
+        Form form = new Form().param(GRANT_TYPE, accessTokenGrantType);
+        if (PASSWORD.equals(accessTokenGrantType)) {
+            form.param(USERNAME, config.getUsername())
+                .param(PASSWORD, config.getPassword());
+        }
+
+        if (config.getScope() != null) {
+            form.param(SCOPE, config.getScope());
+        }
+
+        if (config.isPublicClient()) {
+            form.param(CLIENT_ID, config.getClientId());
+        }
+
+        int requestTime = Time.currentTime();
+        synchronized (this) {
+            currentToken = tokenService.grantToken(config.getRealm(), form.asMap());
+            expirationTime = requestTime + currentToken.getExpiresIn();
+            refreshExpirationTime = requestTime + currentToken.getRefreshExpiresIn();
+        }
+        return currentToken;
+    }
+
+    public synchronized AccessTokenResponse refreshToken() {
+        if (currentToken.getRefreshToken() == null || refreshTokenExpired()) {
+            return grantToken();
+        }
+
+        Form form = new Form().param(GRANT_TYPE, REFRESH_TOKEN)
+                              .param(REFRESH_TOKEN, currentToken.getRefreshToken());
+
+        if (config.isPublicClient()) {
+            form.param(CLIENT_ID, config.getClientId());
+        }
+
+        try {
+            int requestTime = Time.currentTime();
+
+            currentToken = tokenService.refreshToken(config.getRealm(), form.asMap());
+            expirationTime = requestTime + currentToken.getExpiresIn();
+            return currentToken;
+        } catch (BadRequestException e) {
+            return grantToken();
+        }
+    }
+
+    public synchronized void logout() {
+        if (currentToken.getRefreshToken() == null) {
+            return;
+        }
+
+        Form form = new Form().param(REFRESH_TOKEN, currentToken.getRefreshToken());
+
+        if (config.isPublicClient()) {
+            form.param(CLIENT_ID, config.getClientId());
+        }
+
+        tokenService.logout(config.getRealm(), form.asMap());
+        currentToken = null;
+    }
+
+    public synchronized void setMinTokenValidity(long minTokenValidity) {
+        this.minTokenValidity = minTokenValidity;
+    }
+
+    private synchronized boolean tokenExpired() {
+        return (Time.currentTime() + minTokenValidity) >= expirationTime;
+    }
+
+    private synchronized boolean refreshTokenExpired() { return (Time.currentTime() + minTokenValidity) >= refreshExpirationTime; }
+
+    /**
+     * Invalidates the current token, but only when it is equal to the token passed as an argument.
+     *
+     * @param token the token to invalidate (cannot be null).
+     */
+    public synchronized void invalidate(String token) {
+        if (currentToken == null) {
+            return; // There's nothing to invalidate.
+        }
+        if (token.equals(currentToken.getToken())) {
+            // When used next, this cause a refresh attempt, that in turn will cause a grant attempt if refreshing fails.
+            expirationTime = -1;
+        }
+    }
+}

--- a/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/token/TokenService.java
+++ b/integration/admin-client-jee/src/main/java/org/keycloak/admin/client/token/TokenService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.token;
+
+import org.keycloak.representations.AccessTokenResponse;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * @author rodrigo.sasaki@icarros.com.br
+ */
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+public interface TokenService {
+
+    @POST
+    @Path("/realms/{realm}/protocol/openid-connect/token")
+    AccessTokenResponse grantToken(@PathParam("realm") String realm, MultivaluedMap<String, String> map);
+
+    @POST
+    @Path("/realms/{realm}/protocol/openid-connect/token")
+    AccessTokenResponse refreshToken(@PathParam("realm") String realm, MultivaluedMap<String, String> map);
+
+    @POST
+    @Path("/realms/{realm}/protocol/openid-connect/logout")
+    void logout(@PathParam("realm") String realm, MultivaluedMap<String, String> map);
+
+}

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>keycloak-client-integration-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-admin-client</artifactId>
+    <name>Keycloak Admin REST Client</name>
+    <description/>
+
+    <properties>
+        <jakarta-transformer-sources>${project.basedir}/../admin-client-jee/src</jakarta-transformer-sources>
+        <jakarta-transformer-target>${project.basedir}/src</jakarta-transformer-target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>transform</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="plugin_classpath" refid="maven.plugin.classpath"/>
+                                <delete dir="${jakarta-transformer-target}"/>
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
+                                    <arg value="${jakarta-transformer-sources}"/>
+                                    <arg value="${jakarta-transformer-target}"/>
+                                    <classpath>
+                                        <pathelement path="${plugin_classpath}"/>
+                                    </classpath>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.transformer</groupId>
+                        <artifactId>org.eclipse.transformer.cli</artifactId>
+                        <version>0.5.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>1.10.14</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <!-- delete the files created by the transformer -->
+                            <directory>src</directory>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -1,0 +1,37 @@
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-client-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <name>Keycloak Integration</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-client-integration-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>admin-client-jee</module>
+        <module>admin-client</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Keycloak Client Libraries</name>
+    <description>Keycloak Client Libraries</description>
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-client-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- TODO: How to sync these version with Keycloak pom? Manually? -->
+        <jackson.version>2.15.2</jackson.version>
+        <resteasy.version>6.2.7.Final</resteasy.version>
+        <resteasy-legacy.version>4.7.7.Final</resteasy-legacy.version>
+        <jboss.logging.version>3.5.3.Final</jboss.logging.version>
+        <eclipse.microprofile.version>3.1.1</eclipse.microprofile.version>
+
+        <!-- TODO: Check what should be correct version -->
+        <version.maven.source.plugin>3.0.0</version.maven.source.plugin>
+
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <modules>
+        <module>client-common</module>
+        <module>client-core</module>
+        <module>integration</module>
+        <module>test</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- keycloak-client-* dependencies -->
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-client-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-client-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- 3rd party dependencies. Make sure to not include any quarkus dependencies OR any keycloak server dependencies!! -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.openapi</groupId>
+                <artifactId>microprofile-openapi-api</artifactId>
+                <version>${eclipse.microprofile.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-multipart-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jackson2-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxb-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${version.maven.source.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-client-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-client-test</artifactId>
+    <name>Keycloak Client Test</name>
+    <packaging>jar</packaging>
+    <description>Client test</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/src/test/java/org/keycloak/client/tests/TestAdminClient.java
+++ b/test/src/test/java/org/keycloak/client/tests/TestAdminClient.java
@@ -1,0 +1,31 @@
+package org.keycloak.client.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import java.util.Optional;
+
+public class TestAdminClient {
+
+    @Test
+    public void getRealm() {
+        Keycloak keycloak = Keycloak.getInstance("http://localhost:8080", "master", "admin", "admin", "admin-cli");
+
+        RealmRepresentation realmRepresentation = keycloak.realm("master").toRepresentation();
+        Assertions.assertNotNull(realmRepresentation);
+        Assertions.assertEquals("master", realmRepresentation.getRealm());
+    }
+
+    @Test
+    public void getUser() {
+        Keycloak keycloak = Keycloak.getInstance("http://localhost:8080", "master", "admin", "admin", "admin-cli");
+
+        Optional<UserRepresentation> first = keycloak.realm("master").users().search("admin").stream().findFirst();
+        Assertions.assertTrue(first.isPresent());
+        Assertions.assertEquals("admin", first.get().getUsername());
+    }
+
+}


### PR DESCRIPTION
closes https://github.com/keycloak/keycloak/issues/30799
closes https://github.com/keycloak/keycloak/issues/30800

- Prototype with the approach of syncing/copying Java classes from Keycloak sources to this module

- The Java classes inside this project (with the exception of testsuite) are not supposed to be directly updated as they are supposed to be copied from Keycloak

- There is bash script `.github/scripts/sync-keycloak-sources.sh`, which does the work of syncing classes from specified branch of Keycloak

- The classes in `client-common` are subset of classes from Keycloak `common` and `client-core` are subset of classes from Keycloak `core` . Those are just the classes needed for Java admin-client
 
- Modules `integration/admin-client` and `integration-admin-client-jee` are copies from Keycloak Java admin-client

- This PR assumes this PR to be merged inside Keycloak https://github.com/keycloak/keycloak/pull/30588 .