### PR TITLE
Make authz-client working with suffix added in keycloak repository

### DIFF
--- a/authz-client/pom.xml
+++ b/authz-client/pom.xml
@@ -82,8 +82,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.keycloak</groupId>
-                                    <!-- TODO: artifactId needs to be different than the one copied over from upstream Keycloak -->
-                                    <artifactId>keycloak-authz-client</artifactId>
+                                    <artifactId>keycloak-authz-client-tests</artifactId>
                                     <version>${keycloak.version}</version>
                                     <type>jar</type>
                                     <classifier>sources</classifier>


### PR DESCRIPTION
closes keycloak/keycloak#31264

This is related to the PR https://github.com/keycloak/keycloak/pull/31371 and should be merged together with that one.