### PR TITLE
Add GitHub workflow to build with Keycloak Nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Keycloak Quickstarts CI
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          check-latest: true
+          cache: maven
+
+      - name: Build with Keycloak Nightly
+        run: mvn -B package -Pnightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Keycloak Quickstarts CI
+name: Keycloak Client CI
 on:
   push:
   pull_request:

--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,28 @@
 
     <profiles>
         <profile>
+            <id>nightly</id>
+            <activation>
+                <property>
+                    <name>nightly</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>sonatype-snapshots</id>
+                    <name>Sonatype Snapshots</name>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>daily</updatePolicy>
+                    </snapshots>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
             <id>jdk9</id>
             <activation>
                 <jdk>[9,)</jdk>


### PR DESCRIPTION
Adds a workflow that builds the artifacts in the repository with a `nightly` profile that pulls the latest snapshot artifacts of Keycloak from the Sonatype staging repository.