### PR TITLE
Sync admin client from Keycloak main and re-enable testing with 24

### DIFF
--- a/.github/scripts/sync-keycloak-sources.sh
+++ b/.github/scripts/sync-keycloak-sources.sh
@@ -21,6 +21,11 @@ function syncFiles() {
   MODULE=$1;
   echo_header "Syncing files in the module $MODULE";
   cd $MODULE
+
+  # Remove the existing files before sync
+  rm -rf src/main/java/*
+  rm -rf src/main/resources/*
+
   mvn clean install -Psync
   mv target/unpacked/* src/main/java/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        keycloak_server_version: [ "25.0", "nightly" ]
+        keycloak_server_version: [ "24.0", "25.0", "nightly" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Keycloak-client java modules
 
+The files in the modules:
+
+* [admin-client](admin-client)
+* [admin-client-jee](admin-client-jee)
+* [authz-client](authz-client)
+* [policy-enforcer](policy-enforcer)
+
+are not "owned" by this repository and hence the Java files should ideally not be directly updated. Those files are "owned" by the [main Keycloak server repository](https://github.com/keycloak/keycloak)
+and hence are supposed to be updated there (whenever needed) and synced into this repository by the bash script [sync-keycloak-sources.sh](.github/scripts/sync-keycloak-sources.sh)
+
+## Syncing the files from Keycloak repository
+
+* Checkout [main Keycloak server repository](https://github.com/keycloak/keycloak) and build it on your laptop to make sure latest Keycloak stuff available in your local maven repository.
+
+* Run [sync-keycloak-sources.sh](.github/scripts/sync-keycloak-sources.sh)
+
+* Send PR with the changes to update corresponding branch (usually `main`) of [Keycloak client repository](https://github.com/keycloak/keycloak-client)
+
 ## Building the project
 
 ```

--- a/admin-client-jee/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/admin-client-jee/src/main/java/org/keycloak/OAuth2Constants.java
@@ -152,6 +152,8 @@ public interface OAuth2Constants {
     String ISSUER = "iss";
 
     String AUTHENTICATOR_METHOD_REFERENCE = "amr";
+
+    String CNF = "cnf";
 }
 
 

--- a/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
+++ b/admin-client-jee/src/main/java/org/keycloak/admin/client/JacksonProvider.java
@@ -1,6 +1,20 @@
 package org.keycloak.admin.client;
 
+import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 
 public class JacksonProvider extends ResteasyJackson2Provider {
+
+    @Override
+    public ObjectMapper locateMapper(Class<?> type, MediaType mediaType) {
+        ObjectMapper objectMapper = super.locateMapper(type, mediaType);
+
+        // Same like JSONSerialization class. Makes it possible to use admin-client against older versions of Keycloak server where the properties on representations might be different
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        
+        return objectMapper;
+    }
 }

--- a/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -17,19 +17,28 @@
 
 package org.keycloak.admin.client.resource;
 
+import java.util.List;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
 
 public interface OrganizationMemberResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    UserRepresentation toRepresentation();
+    MemberRepresentation toRepresentation();
 
     @DELETE
     Response delete();
+
+    @Path("organizations")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> getOrganizations();
 }

--- a/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/admin-client-jee/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -29,8 +29,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 
 public interface OrganizationMembersResource {
 
@@ -45,7 +45,7 @@ public interface OrganizationMembersResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> getAll();
+    List<MemberRepresentation> getAll();
 
     /**
      * Return all organization members that match the specified filters.
@@ -60,17 +60,12 @@ public interface OrganizationMembersResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> search(
+    List<MemberRepresentation> search(
             @QueryParam("search") String search,
             @QueryParam("exact") Boolean exact,
             @QueryParam("first") Integer first,
             @QueryParam("max") Integer max
     );
-
-    @Path("{id}/organization")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    OrganizationRepresentation getOrganization(@PathParam("id") String id);
 
     @Path("{id}")
     OrganizationMemberResource member(@PathParam("id") String id);

--- a/admin-client-jee/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
+++ b/admin-client-jee/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class MemberRepresentation extends UserRepresentation {
+
+    private MembershipType membershipType;
+
+    public MemberRepresentation() {
+        super();
+    }
+
+    public MemberRepresentation(UserRepresentation user) {
+        super(user);
+    }
+
+    public MembershipType getMembershipType() {
+        return membershipType;
+    }
+
+    public void setMembershipType(MembershipType membershipType) {
+        this.membershipType = membershipType;
+    }
+}

--- a/admin-client-jee/src/main/java/org/keycloak/representations/idm/MembershipType.java
+++ b/admin-client-jee/src/main/java/org/keycloak/representations/idm/MembershipType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+public enum MembershipType {
+
+    /**
+     * Indicates that member can exist without group/organization.
+     */
+    UNMANAGED,
+
+    /**
+     * Indicates that member cannot exist without group/organization.
+     */
+    MANAGED;
+}

--- a/admin-client-jee/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/admin-client-jee/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -34,7 +34,7 @@ public class OrganizationRepresentation {
     private String description;
     private Map<String, List<String>> attributes;
     private Set<OrganizationDomainRepresentation> domains;
-    private List<UserRepresentation> members;
+    private List<MemberRepresentation> members;
     private List<IdentityProviderRepresentation> identityProviders;
 
     public String getId() {
@@ -119,19 +119,19 @@ public class OrganizationRepresentation {
         getDomains().remove(domain);
     }
 
-    public List<UserRepresentation> getMembers() {
+    public List<MemberRepresentation> getMembers() {
         return members;
     }
 
-    public void setMembers(List<UserRepresentation> members) {
+    public void setMembers(List<MemberRepresentation> members) {
         this.members = members;
     }
 
-    public void addMember(UserRepresentation user) {
+    public void addMember(MemberRepresentation member) {
         if (members == null) {
             members = new ArrayList<>();
         }
-        members.add(user);
+        members.add(member);
     }
 
     public List<IdentityProviderRepresentation> getIdentityProviders() {

--- a/admin-client-jee/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/admin-client-jee/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -52,6 +52,43 @@ public class UserRepresentation extends AbstractUserRepresentation{
     protected List<String> groups;
     private Map<String, Boolean> access;
 
+    public UserRepresentation() {
+    }
+
+    public UserRepresentation(UserRepresentation rep) {
+        // AbstractUserRepresentation
+        this.id = rep.getId();
+        this.username = rep.getUsername();
+        this.firstName = rep.getFirstName();
+        this.lastName = rep.getLastName();
+        this.email = rep.getEmail();
+        this.emailVerified = rep.isEmailVerified();
+        this.attributes = rep.getAttributes();
+        this.setUserProfileMetadata(rep.getUserProfileMetadata());
+
+        this.self = rep.getSelf();
+        this.origin = rep.getOrigin();
+        this.createdTimestamp = rep.getCreatedTimestamp();
+        this.enabled = rep.isEnabled();
+        this.totp = rep.isTotp();
+        this.federationLink = rep.getFederationLink();
+        this.serviceAccountClientId = rep.getServiceAccountClientId();
+        this.credentials = rep.getCredentials();
+        this.disableableCredentialTypes = rep.getDisableableCredentialTypes();
+        this.requiredActions = rep.getRequiredActions();
+        this.federatedIdentities = rep.getFederatedIdentities();
+        this.realmRoles = rep.getRealmRoles();
+        this.clientRoles = rep.getClientRoles();
+        this.clientConsents = rep.getClientConsents();
+        this.notBefore = rep.getNotBefore();
+
+        this.applicationRoles = rep.getApplicationRoles();
+        this.socialLinks = rep.getSocialLinks();
+
+        this.groups = rep.getGroups();
+        this.access = rep.getAccess();
+    }
+
     public String getSelf() {
         return self;
     }

--- a/admin-client/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/admin-client/src/main/java/org/keycloak/OAuth2Constants.java
@@ -152,6 +152,8 @@ public interface OAuth2Constants {
     String ISSUER = "iss";
 
     String AUTHENTICATOR_METHOD_REFERENCE = "amr";
+
+    String CNF = "cnf";
 }
 
 

--- a/admin-client/src/main/java/org/keycloak/admin/client/JacksonProvider.java
+++ b/admin-client/src/main/java/org/keycloak/admin/client/JacksonProvider.java
@@ -1,6 +1,20 @@
 package org.keycloak.admin.client;
 
+import jakarta.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 
 public class JacksonProvider extends ResteasyJackson2Provider {
+
+    @Override
+    public ObjectMapper locateMapper(Class<?> type, MediaType mediaType) {
+        ObjectMapper objectMapper = super.locateMapper(type, mediaType);
+
+        // Same like JSONSerialization class. Makes it possible to use admin-client against older versions of Keycloak server where the properties on representations might be different
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        
+        return objectMapper;
+    }
 }

--- a/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -17,19 +17,28 @@
 
 package org.keycloak.admin.client.resource;
 
+import java.util.List;
+
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
 
 public interface OrganizationMemberResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    UserRepresentation toRepresentation();
+    MemberRepresentation toRepresentation();
 
     @DELETE
     Response delete();
+
+    @Path("organizations")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> getOrganizations();
 }

--- a/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -29,8 +29,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 
 public interface OrganizationMembersResource {
 
@@ -45,7 +45,7 @@ public interface OrganizationMembersResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> getAll();
+    List<MemberRepresentation> getAll();
 
     /**
      * Return all organization members that match the specified filters.
@@ -60,17 +60,12 @@ public interface OrganizationMembersResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> search(
+    List<MemberRepresentation> search(
             @QueryParam("search") String search,
             @QueryParam("exact") Boolean exact,
             @QueryParam("first") Integer first,
             @QueryParam("max") Integer max
     );
-
-    @Path("{id}/organization")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    OrganizationRepresentation getOrganization(@PathParam("id") String id);
 
     @Path("{id}")
     OrganizationMemberResource member(@PathParam("id") String id);

--- a/admin-client/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
+++ b/admin-client/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class MemberRepresentation extends UserRepresentation {
+
+    private MembershipType membershipType;
+
+    public MemberRepresentation() {
+        super();
+    }
+
+    public MemberRepresentation(UserRepresentation user) {
+        super(user);
+    }
+
+    public MembershipType getMembershipType() {
+        return membershipType;
+    }
+
+    public void setMembershipType(MembershipType membershipType) {
+        this.membershipType = membershipType;
+    }
+}

--- a/admin-client/src/main/java/org/keycloak/representations/idm/MembershipType.java
+++ b/admin-client/src/main/java/org/keycloak/representations/idm/MembershipType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+public enum MembershipType {
+
+    /**
+     * Indicates that member can exist without group/organization.
+     */
+    UNMANAGED,
+
+    /**
+     * Indicates that member cannot exist without group/organization.
+     */
+    MANAGED;
+}

--- a/admin-client/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/admin-client/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -34,7 +34,7 @@ public class OrganizationRepresentation {
     private String description;
     private Map<String, List<String>> attributes;
     private Set<OrganizationDomainRepresentation> domains;
-    private List<UserRepresentation> members;
+    private List<MemberRepresentation> members;
     private List<IdentityProviderRepresentation> identityProviders;
 
     public String getId() {
@@ -119,19 +119,19 @@ public class OrganizationRepresentation {
         getDomains().remove(domain);
     }
 
-    public List<UserRepresentation> getMembers() {
+    public List<MemberRepresentation> getMembers() {
         return members;
     }
 
-    public void setMembers(List<UserRepresentation> members) {
+    public void setMembers(List<MemberRepresentation> members) {
         this.members = members;
     }
 
-    public void addMember(UserRepresentation user) {
+    public void addMember(MemberRepresentation member) {
         if (members == null) {
             members = new ArrayList<>();
         }
-        members.add(user);
+        members.add(member);
     }
 
     public List<IdentityProviderRepresentation> getIdentityProviders() {

--- a/admin-client/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/admin-client/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -52,6 +52,43 @@ public class UserRepresentation extends AbstractUserRepresentation{
     protected List<String> groups;
     private Map<String, Boolean> access;
 
+    public UserRepresentation() {
+    }
+
+    public UserRepresentation(UserRepresentation rep) {
+        // AbstractUserRepresentation
+        this.id = rep.getId();
+        this.username = rep.getUsername();
+        this.firstName = rep.getFirstName();
+        this.lastName = rep.getLastName();
+        this.email = rep.getEmail();
+        this.emailVerified = rep.isEmailVerified();
+        this.attributes = rep.getAttributes();
+        this.setUserProfileMetadata(rep.getUserProfileMetadata());
+
+        this.self = rep.getSelf();
+        this.origin = rep.getOrigin();
+        this.createdTimestamp = rep.getCreatedTimestamp();
+        this.enabled = rep.isEnabled();
+        this.totp = rep.isTotp();
+        this.federationLink = rep.getFederationLink();
+        this.serviceAccountClientId = rep.getServiceAccountClientId();
+        this.credentials = rep.getCredentials();
+        this.disableableCredentialTypes = rep.getDisableableCredentialTypes();
+        this.requiredActions = rep.getRequiredActions();
+        this.federatedIdentities = rep.getFederatedIdentities();
+        this.realmRoles = rep.getRealmRoles();
+        this.clientRoles = rep.getClientRoles();
+        this.clientConsents = rep.getClientConsents();
+        this.notBefore = rep.getNotBefore();
+
+        this.applicationRoles = rep.getApplicationRoles();
+        this.socialLinks = rep.getSocialLinks();
+
+        this.groups = rep.getGroups();
+        this.access = rep.getAccess();
+    }
+
     public String getSelf() {
         return self;
     }

--- a/authz-client/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/authz-client/src/main/java/org/keycloak/OAuth2Constants.java
@@ -152,6 +152,8 @@ public interface OAuth2Constants {
     String ISSUER = "iss";
 
     String AUTHENTICATOR_METHOD_REFERENCE = "amr";
+
+    String CNF = "cnf";
 }
 
 

--- a/authz-client/src/main/java/org/keycloak/common/Profile.java
+++ b/authz-client/src/main/java/org/keycloak/common/Profile.java
@@ -103,6 +103,7 @@ public class Profile {
         TRANSIENT_USERS("Transient users for brokering", Type.EXPERIMENTAL),
 
         MULTI_SITE("Multi-site support", Type.DISABLED_BY_DEFAULT),
+
         REMOTE_CACHE("Remote caches support. Requires Multi-site support to be enabled as well.", Type.EXPERIMENTAL),
 
         CLIENT_TYPES("Client Types", Type.EXPERIMENTAL),

--- a/authz-client/src/main/java/org/keycloak/common/crypto/CryptoConstants.java
+++ b/authz-client/src/main/java/org/keycloak/common/crypto/CryptoConstants.java
@@ -10,6 +10,10 @@ public class CryptoConstants {
     public static final String RSA1_5 = "RSA1_5";
     public static final String RSA_OAEP = "RSA-OAEP";
     public static final String RSA_OAEP_256 = "RSA-OAEP-256";
+    public static final String ECDH_ES = "ECDH-ES";
+    public static final String ECDH_ES_A128KW = "ECDH-ES+A128KW";
+    public static final String ECDH_ES_A192KW = "ECDH-ES+A192KW";
+    public static final String ECDH_ES_A256KW = "ECDH-ES+A256KW";
 
     // Constant for the OCSP provider
     // public static final String OCSP = "OCSP";

--- a/authz-client/src/main/java/org/keycloak/common/enums/SslRequired.java
+++ b/authz-client/src/main/java/org/keycloak/common/enums/SslRequired.java
@@ -51,10 +51,23 @@ public enum SslRequired {
     private boolean isLocal(String remoteAddress) {
         try {
             InetAddress inetAddress = InetAddress.getByName(remoteAddress);
-            return inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress();
+            return inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress() || inetAddress.isLinkLocalAddress() || isUniqueLocal(inetAddress);
         } catch (UnknownHostException e) {
             return false;
         }
+    }
+
+    /**
+     * Check if the address is within IPv6 unique local address (ULA) range RFC4193.
+     */
+    private boolean isUniqueLocal(InetAddress address) {
+        if (address instanceof java.net.Inet6Address) {
+            byte[] addr = address.getAddress();
+            // Check if address is in unique local range fc00::/7
+            return ((byte) (addr[0] & 0b11111110)) == (byte) 0xFC;
+        }
+
+        return false;
     }
 
 }

--- a/authz-client/src/main/java/org/keycloak/common/util/MultiSiteUtils.java
+++ b/authz-client/src/main/java/org/keycloak/common/util/MultiSiteUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.util;
+
+import org.keycloak.common.Profile;
+
+public class MultiSiteUtils {
+
+    public static boolean isMultiSiteEnabled() {
+        return Profile.isFeatureEnabled(Profile.Feature.MULTI_SITE);
+    }
+
+    /**
+     * @return true when user sessions are stored in the database. In multi-site setup this is false when REMOTE_CACHE feature is enabled
+     */
+    public static boolean isPersistentSessionsEnabled() {
+        return Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS) || (isMultiSiteEnabled() && !Profile.isFeatureEnabled(Profile.Feature.REMOTE_CACHE));
+    }
+}

--- a/authz-client/src/main/java/org/keycloak/crypto/Algorithm.java
+++ b/authz-client/src/main/java/org/keycloak/crypto/Algorithm.java
@@ -49,4 +49,9 @@ public interface Algorithm {
 
     /* AES */
     String AES = "AES";
+
+    String ECDH_ES = CryptoConstants.ECDH_ES;
+    String ECDH_ES_A128KW = CryptoConstants.ECDH_ES_A128KW;
+    String ECDH_ES_A192KW = CryptoConstants.ECDH_ES_A192KW;
+    String ECDH_ES_A256KW = CryptoConstants.ECDH_ES_A256KW;
 }

--- a/authz-client/src/main/java/org/keycloak/crypto/JavaAlgorithm.java
+++ b/authz-client/src/main/java/org/keycloak/crypto/JavaAlgorithm.java
@@ -37,7 +37,7 @@ public class JavaAlgorithm {
     public static final String SHA256 = "SHA-256";
     public static final String SHA384 = "SHA-384";
     public static final String SHA512 = "SHA-512";
-    public static final String SHAKE256 = "SHAKE-256";
+    public static final String SHAKE256 = "SHAKE256";
 
     public static String getJavaAlgorithm(String algorithm) {
         return getJavaAlgorithm(algorithm, null);

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/JWE.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/JWE.java
@@ -20,6 +20,7 @@ package org.keycloak.jose.jwe;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.JOSE;
 import org.keycloak.jose.JOSEHeader;
+import org.keycloak.jose.jwe.JWEHeader.JWEHeaderBuilder;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 import org.keycloak.util.JsonSerialization;
@@ -143,8 +144,10 @@ public class JWE implements JOSE {
             keyStorage.setEncryptionProvider(encryptionProvider);
             keyStorage.getCEKKey(JWEKeyStorage.KeyUse.ENCRYPTION, true); // Will generate CEK if it's not already present
 
-            byte[] encodedCEK = algorithmProvider.encodeCek(encryptionProvider, keyStorage, keyStorage.getEncryptionKey());
+            JWEHeaderBuilder headerBuilder = header.toBuilder();
+            byte[] encodedCEK = algorithmProvider.encodeCek(encryptionProvider, keyStorage, keyStorage.getEncryptionKey(), headerBuilder);
             base64Cek = Base64Url.encode(encodedCEK);
+            header = headerBuilder.build();
 
             encryptionProvider.encodeJwe(this);
 
@@ -191,7 +194,7 @@ public class JWE implements JOSE {
 
         keyStorage.setEncryptionProvider(encryptionProvider);
 
-        byte[] decodedCek = algorithmProvider.decodeCek(Base64Url.decode(base64Cek), keyStorage.getDecryptionKey());
+        byte[] decodedCek = algorithmProvider.decodeCek(Base64Url.decode(base64Cek), keyStorage.getDecryptionKey(), this.header, encryptionProvider);
         keyStorage.setCEKBytes(decodedCek);
 
         encryptionProvider.verifyAndDecodeJwe(this);

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/JWEConstants.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/JWEConstants.java
@@ -29,6 +29,10 @@ public class JWEConstants {
     public static final String RSA1_5 = CryptoConstants.RSA1_5;
     public static final String RSA_OAEP = CryptoConstants.RSA_OAEP;
     public static final String RSA_OAEP_256 = CryptoConstants.RSA_OAEP_256;
+    public static final String ECDH_ES = CryptoConstants.ECDH_ES;
+    public static final String ECDH_ES_A128KW = CryptoConstants.ECDH_ES_A128KW;
+    public static final String ECDH_ES_A192KW = CryptoConstants.ECDH_ES_A192KW;
+    public static final String ECDH_ES_A256KW = CryptoConstants.ECDH_ES_A256KW;
 
     public static final String A128CBC_HS256 = "A128CBC-HS256";
     public static final String A192CBC_HS384 = "A192CBC-HS384";

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
@@ -18,6 +18,7 @@
 package org.keycloak.jose.jwe;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.jose.JOSEHeader;
+import org.keycloak.jose.jwk.ECPublicJWK;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -41,7 +43,6 @@ public class JWEHeader implements JOSEHeader {
     @JsonProperty("zip")
     private String compressionAlgorithm;
 
-
     @JsonProperty("typ")
     private String type;
 
@@ -50,6 +51,15 @@ public class JWEHeader implements JOSEHeader {
 
     @JsonProperty("kid")
     private String keyId;
+
+    @JsonProperty("epk")
+    private ECPublicJWK ephemeralPublicKey;
+
+    @JsonProperty("apu")
+    private String agreementPartyUInfo;
+
+    @JsonProperty("apv")
+    private String agreementPartyVInfo;
 
     public JWEHeader() {
     }
@@ -73,6 +83,19 @@ public class JWEHeader implements JOSEHeader {
         this.compressionAlgorithm = compressionAlgorithm;
         this.keyId = keyId;
         this.contentType = contentType;
+    }
+
+    public JWEHeader(String algorithm, String encryptionAlgorithm, String compressionAlgorithm, String keyId, String contentType, 
+            String type, ECPublicJWK ephemeralPublicKey, String agreementPartyUInfo, String agreementPartyVInfo) {
+        this.algorithm = algorithm;
+        this.encryptionAlgorithm = encryptionAlgorithm;
+        this.compressionAlgorithm = compressionAlgorithm;
+        this.keyId = keyId;
+        this.type = type;
+        this.contentType = contentType;
+        this.ephemeralPublicKey = ephemeralPublicKey;
+        this.agreementPartyUInfo = agreementPartyUInfo;
+        this.agreementPartyVInfo = agreementPartyVInfo;
     }
 
     public String getAlgorithm() {
@@ -105,21 +128,102 @@ public class JWEHeader implements JOSEHeader {
         return keyId;
     }
 
+    public ECPublicJWK getEphemeralPublicKey() {
+        return ephemeralPublicKey;
+    }
+
+    public String getAgreementPartyUInfo() {
+        return agreementPartyUInfo;
+    }
+
+    public String getAgreementPartyVInfo() {
+        return agreementPartyVInfo;
+    }
+
     private static final ObjectMapper mapper = new ObjectMapper();
 
     static {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
     }
 
     public String toString() {
         try {
             return mapper.writeValueAsString(this);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
-
-
     }
 
+    public JWEHeaderBuilder toBuilder() {
+        return builder().algorithm(algorithm).encryptionAlgorithm(encryptionAlgorithm)
+                .compressionAlgorithm(compressionAlgorithm).type(type).contentType(contentType)
+                .keyId(keyId).ephemeralPublicKey(ephemeralPublicKey).agreementPartyUInfo(agreementPartyUInfo)
+                .agreementPartyVInfo(agreementPartyVInfo);
+    }
+
+    public static JWEHeaderBuilder builder() {
+        return new JWEHeaderBuilder();
+    }
+
+    public static class JWEHeaderBuilder {
+        private String algorithm = null;
+        private String encryptionAlgorithm = null;
+        private String compressionAlgorithm = null;
+        private String type = null;
+        private String contentType = null;
+        private String keyId = null;
+        private ECPublicJWK ephemeralPublicKey = null;
+        private String agreementPartyUInfo = null;
+        private String agreementPartyVInfo = null;
+
+        public JWEHeaderBuilder algorithm(String algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        public JWEHeaderBuilder encryptionAlgorithm(String encryptionAlgorithm) {
+            this.encryptionAlgorithm = encryptionAlgorithm;
+            return this;
+        }
+
+        public JWEHeaderBuilder compressionAlgorithm(String compressionAlgorithm) {
+            this.compressionAlgorithm = compressionAlgorithm;
+            return this;
+        }
+
+        public JWEHeaderBuilder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public JWEHeaderBuilder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public JWEHeaderBuilder keyId(String keyId) {
+            this.keyId = keyId;
+            return this;
+        }
+
+        public JWEHeaderBuilder ephemeralPublicKey(ECPublicJWK ephemeralPublicKey) {
+            this.ephemeralPublicKey = ephemeralPublicKey;
+            return this;
+        }
+
+        public JWEHeaderBuilder agreementPartyUInfo(String agreementPartyUInfo) {
+            this.agreementPartyUInfo = agreementPartyUInfo;
+            return this;
+        }
+
+        public JWEHeaderBuilder agreementPartyVInfo(String agreementPartyVInfo) {
+            this.agreementPartyVInfo = agreementPartyVInfo;
+            return this;
+        }
+
+        public JWEHeader build() {
+            return new JWEHeader(algorithm, encryptionAlgorithm, compressionAlgorithm, keyId, contentType,
+                    type, ephemeralPublicKey, agreementPartyUInfo, agreementPartyVInfo);
+        }
+    }
 }

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
@@ -38,6 +38,8 @@ class JWERegistry {
     private static final Map<String, JWEEncryptionProvider> ENC_PROVIDERS = new HashMap<>();
 
     static {
+        ENC_PROVIDERS.put(JWEConstants.A128GCM, new AesGcmJWEEncryptionProvider(JWEConstants.A128GCM));
+        ENC_PROVIDERS.put(JWEConstants.A192GCM, new AesGcmJWEEncryptionProvider(JWEConstants.A192GCM));
         ENC_PROVIDERS.put(JWEConstants.A256GCM, new AesGcmJWEEncryptionProvider(JWEConstants.A256GCM));
         ENC_PROVIDERS.put(JWEConstants.A128CBC_HS256, new AesCbcHmacShaEncryptionProvider.Aes128CbcHmacSha256Provider());
         ENC_PROVIDERS.put(JWEConstants.A192CBC_HS384, new AesCbcHmacShaEncryptionProvider.Aes192CbcHmacSha384Provider());

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/alg/DirectAlgorithmProvider.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/alg/DirectAlgorithmProvider.java
@@ -19,6 +19,8 @@ package org.keycloak.jose.jwe.alg;
 
 import java.security.Key;
 
+import org.keycloak.jose.jwe.JWEHeader;
+import org.keycloak.jose.jwe.JWEHeader.JWEHeaderBuilder;
 import org.keycloak.jose.jwe.JWEKeyStorage;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 
@@ -28,12 +30,12 @@ import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 public class DirectAlgorithmProvider implements JWEAlgorithmProvider {
 
     @Override
-    public byte[] decodeCek(byte[] encodedCek, Key encryptionKey) {
+    public byte[] decodeCek(byte[] encodedCek, Key encryptionKey, JWEHeader header, JWEEncryptionProvider encryptionProvider) {
         return new byte[0];
     }
 
     @Override
-    public byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey) {
+    public byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey, JWEHeaderBuilder headerBuilder) {
         return new byte[0];
     }
 }

--- a/authz-client/src/main/java/org/keycloak/jose/jwe/alg/JWEAlgorithmProvider.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jwe/alg/JWEAlgorithmProvider.java
@@ -19,7 +19,9 @@ package org.keycloak.jose.jwe.alg;
 
 import java.security.Key;
 
+import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jwe.JWEKeyStorage;
+import org.keycloak.jose.jwe.JWEHeader.JWEHeaderBuilder;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 
 /**
@@ -27,8 +29,8 @@ import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
  */
 public interface JWEAlgorithmProvider {
 
-    byte[] decodeCek(byte[] encodedCek, Key encryptionKey) throws Exception;
+    byte[] decodeCek(byte[] encodedCek, Key encryptionKey, JWEHeader header, JWEEncryptionProvider encryptionProvider) throws Exception;
 
-    byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey) throws Exception;
+    byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey, JWEHeaderBuilder headerBuilder) throws Exception;
 
 }

--- a/authz-client/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -17,9 +17,11 @@
 
 package org.keycloak.jose.jws;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.Base64Url;
-import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.crypto.HMACProvider;
 import org.keycloak.jose.jws.crypto.RSAProvider;
 import org.keycloak.util.JsonSerialization;
@@ -28,17 +30,22 @@ import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public class JWSBuilder {
-    String type;
-    String kid;
-    String x5t;
-    String contentType;
-    byte[] contentBytes;
+    protected String type;
+    protected String kid;
+    protected String x5t;
+    protected JWK jwk;
+    protected List<X509Certificate> x5c;
+    protected String contentType;
+    protected byte[] contentBytes;
 
     public JWSBuilder type(String type) {
         this.type = type;
@@ -52,6 +59,16 @@ public class JWSBuilder {
 
     public JWSBuilder x5t(String x5t) {
         this.x5t = x5t;
+        return this;
+    }
+
+    public JWSBuilder jwk(JWK jwk) {
+        this.jwk = jwk;
+        return this;
+    }
+
+    public JWSBuilder x5c(List<X509Certificate> x5c) {
+        this.x5c = x5c;
         return this;
     }
 
@@ -88,6 +105,28 @@ public class JWSBuilder {
         if (type != null) builder.append(",\"typ\" : \"").append(type).append("\"");
         if (kid != null) builder.append(",\"kid\" : \"").append(kid).append("\"");
         if (x5t != null) builder.append(",\"x5t\" : \"").append(x5t).append("\"");
+        if (x5c != null && !x5c.isEmpty()) {
+            builder.append(",\"x5c\" : [");
+            for (int i = 0; i < x5c.size(); i++) {
+                X509Certificate certificate = x5c.get(i);
+                if (i > 0) {
+                    builder.append(",");
+                }
+                try {
+                    builder.append("\"").append(Base64.encodeBytes(certificate.getEncoded())).append("\"");
+                } catch (CertificateEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            builder.append("]");
+        }
+        if (jwk != null) {
+            try {
+                builder.append(",\"jwk\" : ").append(JsonSerialization.mapper.writeValueAsString(jwk));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
         if (contentType != null) builder.append(",\"cty\":\"").append(contentType).append("\"");
         builder.append("}");
         return Base64Url.encode(builder.toString().getBytes(StandardCharsets.UTF_8));

--- a/authz-client/src/main/java/org/keycloak/jose/jws/JWSHeader.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jws/JWSHeader.java
@@ -27,6 +27,7 @@ import org.keycloak.jose.JOSEHeader;
 import org.keycloak.jose.jwk.JWK;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -48,6 +49,9 @@ public class JWSHeader implements JOSEHeader {
 
     @JsonProperty("jwk")
     private JWK key;
+
+    @JsonProperty("x5c")
+    private List<String> x5c;
 
     public JWSHeader() {
     }
@@ -89,6 +93,10 @@ public class JWSHeader implements JOSEHeader {
 
     public JWK getKey() {
         return key;
+    }
+
+    public List<String> getX5c() {
+        return x5c;
     }
 
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/authz-client/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
+++ b/authz-client/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
@@ -34,15 +34,23 @@ public class HashUtils {
     // - "at_hash" and "c_hash" in OIDC specification (full = false)
     // - "ath" in DPoP specification (full = true)
     public static String accessTokenHash(String jwtAlgorithmName, String input, boolean full) {
+        return accessTokenHash(jwtAlgorithmName, null, input, full);
+    }
+
+    public static String accessTokenHash(String jwtAlgorithmName, String curve, String input, boolean full) {
         byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
-        String javaAlgName = JavaAlgorithm.getJavaAlgorithmForHash(jwtAlgorithmName);
+        String javaAlgName = JavaAlgorithm.getJavaAlgorithmForHash(jwtAlgorithmName, curve);
         byte[] hash = hash(javaAlgName, inputBytes);
 
         return encodeHashToOIDC(hash, full);
     }
 
     public static String accessTokenHash(String jwtAlgorithmName, String input) {
-        return HashUtils.accessTokenHash(jwtAlgorithmName, input, false);
+        return HashUtils.accessTokenHash(jwtAlgorithmName, null, input, false);
+    }
+
+    public static String accessTokenHash(String jwtAlgorithmName, String curve, String input) {
+        return HashUtils.accessTokenHash(jwtAlgorithmName, curve, input, false);
     }
 
     public static byte[] hash(String javaAlgorithmName, byte[] inputBytes) {

--- a/authz-client/src/main/java/org/keycloak/representations/RefreshToken.java
+++ b/authz-client/src/main/java/org/keycloak/representations/RefreshToken.java
@@ -36,7 +36,6 @@ public class RefreshToken extends AccessToken {
     /**
      * Deep copies issuer, subject, issuedFor, sessionState from AccessToken.
      *
-     * @param token
      */
     public RefreshToken(AccessToken token) {
         this();
@@ -47,6 +46,25 @@ public class RefreshToken extends AccessToken {
         this.nonce = token.nonce;
         this.audience = new String[] { token.issuer };
         this.scope = token.scope;
+    }
+
+    /**
+     * Deep copies issuer, subject, issuedFor, sessionState from AccessToken.
+     *
+     * @param token
+     * @param confirmation optional confirmation parameter that might be processed during authentication but should not
+     *                     always be included in the response
+     */
+    public RefreshToken(AccessToken token, Confirmation confirmation) {
+        this();
+        this.issuer = token.issuer;
+        this.subject = token.subject;
+        this.issuedFor = token.issuedFor;
+        this.sessionId = token.sessionId;
+        this.nonce = token.nonce;
+        this.audience = new String[] { token.issuer };
+        this.scope = token.scope;
+        this.confirmation = confirmation;
     }
 
     @Override

--- a/authz-client/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
+++ b/authz-client/src/main/java/org/keycloak/representations/idm/MemberRepresentation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class MemberRepresentation extends UserRepresentation {
+
+    private MembershipType membershipType;
+
+    public MemberRepresentation() {
+        super();
+    }
+
+    public MemberRepresentation(UserRepresentation user) {
+        super(user);
+    }
+
+    public MembershipType getMembershipType() {
+        return membershipType;
+    }
+
+    public void setMembershipType(MembershipType membershipType) {
+        this.membershipType = membershipType;
+    }
+}

--- a/authz-client/src/main/java/org/keycloak/representations/idm/MembershipType.java
+++ b/authz-client/src/main/java/org/keycloak/representations/idm/MembershipType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.representations.idm;
+
+public enum MembershipType {
+
+    /**
+     * Indicates that member can exist without group/organization.
+     */
+    UNMANAGED,
+
+    /**
+     * Indicates that member cannot exist without group/organization.
+     */
+    MANAGED;
+}

--- a/authz-client/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/authz-client/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -34,7 +34,7 @@ public class OrganizationRepresentation {
     private String description;
     private Map<String, List<String>> attributes;
     private Set<OrganizationDomainRepresentation> domains;
-    private List<UserRepresentation> members;
+    private List<MemberRepresentation> members;
     private List<IdentityProviderRepresentation> identityProviders;
 
     public String getId() {
@@ -119,19 +119,19 @@ public class OrganizationRepresentation {
         getDomains().remove(domain);
     }
 
-    public List<UserRepresentation> getMembers() {
+    public List<MemberRepresentation> getMembers() {
         return members;
     }
 
-    public void setMembers(List<UserRepresentation> members) {
+    public void setMembers(List<MemberRepresentation> members) {
         this.members = members;
     }
 
-    public void addMember(UserRepresentation user) {
+    public void addMember(MemberRepresentation member) {
         if (members == null) {
             members = new ArrayList<>();
         }
-        members.add(user);
+        members.add(member);
     }
 
     public List<IdentityProviderRepresentation> getIdentityProviders() {

--- a/authz-client/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/authz-client/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -52,6 +52,43 @@ public class UserRepresentation extends AbstractUserRepresentation{
     protected List<String> groups;
     private Map<String, Boolean> access;
 
+    public UserRepresentation() {
+    }
+
+    public UserRepresentation(UserRepresentation rep) {
+        // AbstractUserRepresentation
+        this.id = rep.getId();
+        this.username = rep.getUsername();
+        this.firstName = rep.getFirstName();
+        this.lastName = rep.getLastName();
+        this.email = rep.getEmail();
+        this.emailVerified = rep.isEmailVerified();
+        this.attributes = rep.getAttributes();
+        this.setUserProfileMetadata(rep.getUserProfileMetadata());
+
+        this.self = rep.getSelf();
+        this.origin = rep.getOrigin();
+        this.createdTimestamp = rep.getCreatedTimestamp();
+        this.enabled = rep.isEnabled();
+        this.totp = rep.isTotp();
+        this.federationLink = rep.getFederationLink();
+        this.serviceAccountClientId = rep.getServiceAccountClientId();
+        this.credentials = rep.getCredentials();
+        this.disableableCredentialTypes = rep.getDisableableCredentialTypes();
+        this.requiredActions = rep.getRequiredActions();
+        this.federatedIdentities = rep.getFederatedIdentities();
+        this.realmRoles = rep.getRealmRoles();
+        this.clientRoles = rep.getClientRoles();
+        this.clientConsents = rep.getClientConsents();
+        this.notBefore = rep.getNotBefore();
+
+        this.applicationRoles = rep.getApplicationRoles();
+        this.socialLinks = rep.getSocialLinks();
+
+        this.groups = rep.getGroups();
+        this.access = rep.getAccess();
+    }
+
     public String getSelf() {
         return self;
     }


### PR DESCRIPTION
closes keycloak/keycloak#32036

Summary of changes in this repository:

- Small update in `sync-keycloak-sources.sh` as it is needed to remove existing files before overwrite from latest keycloak files provided by maven-dependency-plugin

- Update in README.md with a notes for how to sync files

- Re-added testing with Keycloak 24 (disabled before because of the issue keycloak/keycloak#32035 )

- Sync files from latest Keycloak (containing the fix of keycloak/keycloak#32035 and other changes added to Keycloak in the meantime)