### PR TITLE
Move PolicyEnforcerTest to keycloak-client repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Run client tests
         run: |
+          mvn -B -f testsuite/providers/pom.xml package -DskipTests=true
           mvn -B -f testsuite/admin-client-tests/pom.xml test -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}
           mvn -B -f testsuite/admin-client-jee-tests/pom.xml test -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}
           mvn -B -f testsuite/authz-tests/pom.xml test -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}

--- a/admin-client-jee/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/admin-client-jee/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -101,12 +101,7 @@ public final class StringPropertyReplacer
         if (props == null) {
             return replaceProperties(string, (PropertyResolver) null);
         }
-        return replaceProperties(string, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });
+        return replaceProperties(string, props::getProperty);
     }
 
     public static String replaceProperties(final String string, PropertyResolver resolver)
@@ -247,29 +242,6 @@ public final class StringPropertyReplacer
         
         // Done
         return buffer.toString();
-    }
-
-    /**
-     * Try to resolve a "key" from the provided properties by
-     * checking if it is actually a "key1,key2", in which case
-     * try first "key1", then "key2". If all fails, return null.
-     *
-     * It also accepts "key1," and ",key2".
-     *
-     * @param key the key to resolve
-     * @param props the properties to use
-     * @return the resolved key or null
-     */
-    private static String resolveCompositeKey(String key, final Properties props) {
-        if (props == null) {
-            return resolveCompositeKey(key, (PropertyResolver) null);
-        }
-        return resolveCompositeKey(key, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });        
     }
 
     private static String resolveCompositeKey(String key, PropertyResolver resolver)

--- a/admin-client-jee/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
+++ b/admin-client-jee/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
 
     private Set<RoleDefinition> roles;
-    private boolean fetchRoles;
+    private Boolean fetchRoles;
 
     @Override
     public String getType() {
@@ -40,7 +40,7 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         this.roles = roles;
     }
 
-    public void addRole(String name, boolean required) {
+    public void addRole(String name, Boolean required) {
         if (roles == null) {
             roles = new HashSet<>();
         }
@@ -59,24 +59,24 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         addRole(clientId + "/" + name, required);
     }
 
-    public boolean isFetchRoles() {
+    public Boolean isFetchRoles() {
         return fetchRoles;
     }
 
-    public void setFetchRoles(boolean fetchRoles) {
+    public void setFetchRoles(Boolean fetchRoles) {
         this.fetchRoles = fetchRoles;
     }
 
     public static class RoleDefinition implements Comparable<RoleDefinition> {
 
         private String id;
-        private boolean required;
+        private Boolean required;
 
         public RoleDefinition() {
             this(null, false);
         }
 
-        public RoleDefinition(String id, boolean required) {
+        public RoleDefinition(String id, Boolean required) {
             this.id = id;
             this.required = required;
         }
@@ -89,11 +89,11 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
             this.id = id;
         }
 
-        public boolean isRequired() {
+        public Boolean isRequired() {
             return required;
         }
 
-        public void setRequired(boolean required) {
+        public void setRequired(Boolean required) {
             this.required = required;
         }
 

--- a/admin-client/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/admin-client/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -101,12 +101,7 @@ public final class StringPropertyReplacer
         if (props == null) {
             return replaceProperties(string, (PropertyResolver) null);
         }
-        return replaceProperties(string, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });
+        return replaceProperties(string, props::getProperty);
     }
 
     public static String replaceProperties(final String string, PropertyResolver resolver)
@@ -247,29 +242,6 @@ public final class StringPropertyReplacer
         
         // Done
         return buffer.toString();
-    }
-
-    /**
-     * Try to resolve a "key" from the provided properties by
-     * checking if it is actually a "key1,key2", in which case
-     * try first "key1", then "key2". If all fails, return null.
-     *
-     * It also accepts "key1," and ",key2".
-     *
-     * @param key the key to resolve
-     * @param props the properties to use
-     * @return the resolved key or null
-     */
-    private static String resolveCompositeKey(String key, final Properties props) {
-        if (props == null) {
-            return resolveCompositeKey(key, (PropertyResolver) null);
-        }
-        return resolveCompositeKey(key, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });        
     }
 
     private static String resolveCompositeKey(String key, PropertyResolver resolver)

--- a/admin-client/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
+++ b/admin-client/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
 
     private Set<RoleDefinition> roles;
-    private boolean fetchRoles;
+    private Boolean fetchRoles;
 
     @Override
     public String getType() {
@@ -40,7 +40,7 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         this.roles = roles;
     }
 
-    public void addRole(String name, boolean required) {
+    public void addRole(String name, Boolean required) {
         if (roles == null) {
             roles = new HashSet<>();
         }
@@ -59,24 +59,24 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         addRole(clientId + "/" + name, required);
     }
 
-    public boolean isFetchRoles() {
+    public Boolean isFetchRoles() {
         return fetchRoles;
     }
 
-    public void setFetchRoles(boolean fetchRoles) {
+    public void setFetchRoles(Boolean fetchRoles) {
         this.fetchRoles = fetchRoles;
     }
 
     public static class RoleDefinition implements Comparable<RoleDefinition> {
 
         private String id;
-        private boolean required;
+        private Boolean required;
 
         public RoleDefinition() {
             this(null, false);
         }
 
-        public RoleDefinition(String id, boolean required) {
+        public RoleDefinition(String id, Boolean required) {
             this.id = id;
             this.required = required;
         }
@@ -89,11 +89,11 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
             this.id = id;
         }
 
-        public boolean isRequired() {
+        public Boolean isRequired() {
             return required;
         }
 
-        public void setRequired(boolean required) {
+        public void setRequired(Boolean required) {
             this.required = required;
         }
 

--- a/authz-client/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/authz-client/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -101,12 +101,7 @@ public final class StringPropertyReplacer
         if (props == null) {
             return replaceProperties(string, (PropertyResolver) null);
         }
-        return replaceProperties(string, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });
+        return replaceProperties(string, props::getProperty);
     }
 
     public static String replaceProperties(final String string, PropertyResolver resolver)
@@ -247,29 +242,6 @@ public final class StringPropertyReplacer
         
         // Done
         return buffer.toString();
-    }
-
-    /**
-     * Try to resolve a "key" from the provided properties by
-     * checking if it is actually a "key1,key2", in which case
-     * try first "key1", then "key2". If all fails, return null.
-     *
-     * It also accepts "key1," and ",key2".
-     *
-     * @param key the key to resolve
-     * @param props the properties to use
-     * @return the resolved key or null
-     */
-    private static String resolveCompositeKey(String key, final Properties props) {
-        if (props == null) {
-            return resolveCompositeKey(key, (PropertyResolver) null);
-        }
-        return resolveCompositeKey(key, new PropertyResolver() {
-            @Override
-            public String resolve(String property) {
-                return props.getProperty(property);
-            }
-        });        
     }
 
     private static String resolveCompositeKey(String key, PropertyResolver resolver)

--- a/authz-client/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
+++ b/authz-client/src/main/java/org/keycloak/representations/idm/authorization/RolePolicyRepresentation.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
 
     private Set<RoleDefinition> roles;
-    private boolean fetchRoles;
+    private Boolean fetchRoles;
 
     @Override
     public String getType() {
@@ -40,7 +40,7 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         this.roles = roles;
     }
 
-    public void addRole(String name, boolean required) {
+    public void addRole(String name, Boolean required) {
         if (roles == null) {
             roles = new HashSet<>();
         }
@@ -59,24 +59,24 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
         addRole(clientId + "/" + name, required);
     }
 
-    public boolean isFetchRoles() {
+    public Boolean isFetchRoles() {
         return fetchRoles;
     }
 
-    public void setFetchRoles(boolean fetchRoles) {
+    public void setFetchRoles(Boolean fetchRoles) {
         this.fetchRoles = fetchRoles;
     }
 
     public static class RoleDefinition implements Comparable<RoleDefinition> {
 
         private String id;
-        private boolean required;
+        private Boolean required;
 
         public RoleDefinition() {
             this(null, false);
         }
 
-        public RoleDefinition(String id, boolean required) {
+        public RoleDefinition(String id, Boolean required) {
             this.id = id;
             this.required = required;
         }
@@ -89,11 +89,11 @@ public class RolePolicyRepresentation extends AbstractPolicyRepresentation {
             this.id = id;
         }
 
-        public boolean isRequired() {
+        public Boolean isRequired() {
             return required;
         }
 
-        public void setRequired(boolean required) {
+        public void setRequired(Boolean required) {
             this.required = required;
         }
 

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractAuthzTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractAuthzTest.java
@@ -6,6 +6,8 @@ import java.io.UncheckedIOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmsResource;
+import org.keycloak.client.testsuite.common.OAuthClient;
 import org.keycloak.client.testsuite.framework.Inject;
 import org.keycloak.client.testsuite.common.RealmImporter;
 import org.keycloak.client.testsuite.common.RealmRepsSupplier;
@@ -23,6 +25,9 @@ public abstract class AbstractAuthzTest implements RealmRepsSupplier {
     @Inject
     protected RealmImporter realmImporter;
 
+    @Inject
+    protected OAuthClient oauth;
+
     @BeforeEach
     public void importRealms() {
         realmImporter.importRealmsIfNotImported(this);
@@ -34,5 +39,15 @@ public abstract class AbstractAuthzTest implements RealmRepsSupplier {
         } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);
         }
+    }
+
+    @Override
+    public boolean removeVerifyProfileAtImport() {
+        // remove verify profile by default because most tests are not prepared
+        return true;
+    }
+
+    public RealmsResource realmsResource() {
+        return adminClient.realms();
     }
 }

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/MyCustomCIPFactory.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/MyCustomCIPFactory.java
@@ -1,0 +1,42 @@
+package org.keycloak.client.testsuite.authz;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.adapters.authorization.cip.spi.ClaimInformationPointProvider;
+import org.keycloak.adapters.authorization.cip.spi.ClaimInformationPointProviderFactory;
+import org.keycloak.adapters.authorization.spi.HttpRequest;
+
+public class MyCustomCIPFactory implements ClaimInformationPointProviderFactory<MyCustomCIP> {
+
+    @Override
+    public String getName() {
+        return "my-custom-cip";
+    }
+
+    @Override
+    public MyCustomCIP create(Map<String, Object> config) {
+        return new MyCustomCIP(config);
+    }
+}
+
+class MyCustomCIP implements ClaimInformationPointProvider {
+
+    private final Map<String, Object> config;
+
+    MyCustomCIP(Map<String, Object> config) {
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, List<String>> resolve(HttpRequest request) {
+        Map<String, List<String>> claims = new HashMap<>();
+
+        claims.put("resolved-claim", Arrays.asList(config.get("claim-value").toString()));
+
+        return claims;
+    }
+}
+

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/policyenforcer/PolicyEnforcerTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/policyenforcer/PolicyEnforcerTest.java
@@ -1,0 +1,649 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.policyenforcer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.AuthorizationContext;
+import org.keycloak.adapters.authorization.PolicyEnforcer;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.PermissionsResource;
+import org.keycloak.admin.client.resource.ResourcesResource;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.client.testsuite.authz.AbstractAuthzTest;
+import org.keycloak.client.testsuite.common.OAuthClient;
+import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.testsuite.util.AuthzTestUtils;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.testsuite.util.WaitUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PolicyEnforcerTest extends AbstractAuthzTest {
+
+    private static final String RESOURCE_SERVER_CLIENT_ID = "resource-server-test";
+    private static final String REALM_NAME = "authz-test";
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        RealmRepresentation realm = RealmBuilder.create().name(REALM_NAME)
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                        .realmRole(RoleBuilder.create().name("uma_protection").build())
+                        .realmRole(RoleBuilder.create().name("user").build())
+                )
+                .user(UserBuilder.create().username("marta").password("password")
+                        .addRoles("uma_authorization", "uma_protection", "user")
+                        .role("resource-server-test", "uma_protection"))
+                .user(UserBuilder.create().username("kolo").password("password"))
+                .client(ClientBuilder.create().clientId("resource-server-uma-test")
+                        .secret("secret")
+                        .authorizationServicesEnabled(true)
+                        .redirectUris("http://localhost/resource-server-uma-test")
+                        .defaultRoles("uma_protection")
+                        .directAccessGrants())
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                        .secret("secret")
+                        .authorizationServicesEnabled(true)
+                        .redirectUris("http://localhost/resource-server-test")
+                        .defaultRoles("uma_protection")
+                        .directAccessGrants())
+                .client(ClientBuilder.create().clientId("public-client-test")
+                        .publicClient()
+                        .redirectUris("http://localhost:8180/auth/realms/master/app/auth/*", "https://localhost:8543/auth/realms/master/app/auth/*")
+                        .directAccessGrants())
+                .build();
+        return Collections.singletonList(realm);
+    }
+
+    @BeforeEach
+    public void onBefore() {
+        initAuthorizationSettings(getClientResource(RESOURCE_SERVER_CLIENT_ID));
+    }
+
+    @Test
+    public void testBearerOnlyClientResponse() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only.json", true);
+
+        AuthzTestUtils.TestResponse testResponse = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea"), testResponse);
+
+        assertFalse(context.isGranted());
+        assertEquals(403, testResponse.getStatus());
+
+        String token = doLoginAndGetAccessToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        testResponse = new AuthzTestUtils.TestResponse();
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourceb"), testResponse.clear());
+        assertFalse(context.isGranted());
+        assertEquals(403, testResponse.getStatus());
+    }
+
+    @Test
+    public void testPathConfigurationPrecendenceWhenLazyLoadingPaths() throws IOException {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-paths.json", false);
+
+        AuthzTestUtils.TestResponse testResponse = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea"), testResponse);
+
+        assertFalse(context.isGranted());
+        assertEquals(403, testResponse.getStatus());
+
+        String token = doLoginAndGetAccessToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/"), testResponse.clear());
+        assertTrue(context.isGranted());
+    }
+
+    @Test
+    public void testResolvingClaimsOnce() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only-with-cip.json", true);
+
+        String token = doLoginAndGetAccessToken();
+
+        AuthorizationContext context = policyEnforcer.enforce(
+                AuthzTestUtils.createHttpRequest("/api/resourcea", token, Collections.singletonMap("claim-a", Collections.singletonList("value-claim-a"))),
+                new AuthzTestUtils.TestResponse());
+        Permission permission = context.getPermissions().get(0);
+        Map<String, Set<String>> claims = permission.getClaims();
+
+        assertTrue(context.isGranted());
+        assertEquals("value-claim-a", claims.get("claim-a").iterator().next());
+        assertEquals("claim-b", claims.get("claim-b").iterator().next());
+    }
+
+    @Test
+    public void testCustomClaimProvider() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only-with-cip.json", true);
+
+        String token = doLoginAndGetAccessToken();
+
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea", token), new AuthzTestUtils.TestResponse());
+        Permission permission = context.getPermissions().get(0);
+        Map<String, Set<String>> claims = permission.getClaims();
+
+        assertTrue(context.isGranted());
+        assertEquals("test", claims.get("resolved-claim").iterator().next());
+    }
+
+    @Test
+    public void testOnDenyRedirectTo() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-on-deny-redirect.json", false);
+
+        AuthzTestUtils.TestResponse response = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea"), response);
+
+        assertFalse(context.isGranted());
+        assertEquals(302, response.getStatus());
+        List<String> location = response.getHeaders().getOrDefault("Location", Collections.emptyList());
+        assertFalse(location.isEmpty());
+        assertEquals("/accessDenied", location.get(0));
+    }
+
+    @Test
+    public void testNotAuthenticatedDenyUnmapedPath() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only.json", true);
+
+        AuthzTestUtils.TestResponse response = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/unmmaped"), response);
+
+        assertFalse(context.isGranted());
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testMappedPathEnforcementModeDisabled() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-disabled-enforce-mode-path.json", true);
+
+        AuthzTestUtils.TestResponse response = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/public"), response);
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourceb"), response.clear());
+        assertFalse(context.isGranted());
+        assertEquals(403, response.getStatus());
+
+        String token = doLoginAndGetAccessToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourcea", token), response.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resourceb", token), response.clear());
+        assertFalse(context.isGranted());
+        assertEquals(403, response.getStatus());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/public", token), response.clear());
+        assertTrue(context.isGranted());
+    }
+
+    @Test
+    public void testDisabledPathNoCache() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-disabled-path-nocache.json", true);
+
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/public"), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        ResourceRepresentation resource = clientResource.authorization().resources()
+                .findByName("Root").get(0);
+
+        clientResource.authorization().resources().resource(resource.getId()).remove();
+
+        // first request caches the path and the entry is invalidated due to the lifespan
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/all-public"), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+
+        WaitUtils.pause(1000);
+
+        // second request can not fail because entry should not be invalidated
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/all-public"), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+    }
+
+    @Test
+    public void testLazyLoadedPathIsCached() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        createResource(clientResource, "Static Test Resource", "/api/any-resource/*");
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName("Any Resource Permission");
+        permission.addResource("Static Test Resource");
+        permission.addPolicy("Always Grant Policy");
+
+        clientResource.authorization().permissions().resource().create(permission);
+
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-disabled-path-nocache.json", true);
+
+        String token = doLoginAndGetAccessToken();
+
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/any-resource/test", token), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/any-resource/test", token), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+
+        ResourceRepresentation resource = clientResource.authorization().resources()
+                .findByName("Static Test Resource").get(0);
+
+        clientResource.authorization().resources().resource(resource.getId()).remove();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/any-resource/test", token), new AuthzTestUtils.TestResponse());
+        assertFalse(context.isGranted());
+    }
+
+    @Test
+    public void testEnforcementModeDisabled() {
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-disabled-enforce-mode.json", true);
+
+        AuthzTestUtils.TestResponse response = new AuthzTestUtils.TestResponse();
+        policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource/public"), response);
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void testMatchHttpVerbsToScopes() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        ResourceRepresentation resource = createResource(clientResource, "Resource With HTTP Scopes", "/api/resource-with-scope");
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy("Always Grant Policy");
+
+        PermissionsResource permissions = clientResource.authorization().permissions();
+        permissions.resource().create(permission).close();
+
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-match-http-verbs-scopes.json", true);
+        String token = doLoginAndGetAccessToken();
+
+        AuthzTestUtils.TestResponse testResponse = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse);
+
+        assertFalse(context.isGranted(), "Should fail because resource does not have any scope named GET");
+        assertEquals(403, testResponse.getStatus());
+
+        resource.addScope("GET", "POST");
+
+        clientResource.authorization().resources().resource(resource.getId()).update(resource);
+
+        policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-match-http-verbs-scopes.json", true);
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "POST"), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        // create a PATCH scope without associated it with the resource so that a PATCH request is denied accordingly even though
+        // the scope exists on the server
+        clientResource.authorization().scopes().create(new ScopeRepresentation("PATCH"));
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "PATCH"), testResponse.clear());
+        assertFalse(context.isGranted());
+
+        ScopePermissionRepresentation postPermission = new ScopePermissionRepresentation();
+
+        postPermission.setName("GET permission");
+        postPermission.addScope("GET");
+        postPermission.addPolicy("Always Deny Policy");
+
+        permissions.scope().create(postPermission).close();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertFalse(context.isGranted());
+
+        postPermission = permissions.scope().findByName(postPermission.getName());
+
+        postPermission.addScope("GET");
+        postPermission.addPolicy("Always Grant Policy");
+
+        permissions.scope().findById(postPermission.getId()).update(postPermission);
+
+        AuthzClient authzClient = policyEnforcer.getAuthzClient();
+        AuthorizationResponse authorize = authzClient.authorization(token).authorize();
+        token = authorize.getToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "POST"), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        postPermission = permissions.scope().findByName(postPermission.getName());
+        postPermission.addScope("GET");
+        postPermission.addPolicy("Always Deny Policy");
+        permissions.scope().findById(postPermission.getId()).update(postPermission);
+        authorize = authzClient.authorization(token).authorize();
+        token = authorize.getToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertFalse(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "POST"), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        postPermission = permissions.scope().findByName(postPermission.getName());
+        postPermission.addScope("GET");
+        postPermission.addPolicy("Always Grant Policy");
+        permissions.scope().findById(postPermission.getId()).update(postPermission);
+        authorize = authzClient.authorization(token).authorize();
+        token = authorize.getToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "POST"), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        postPermission = permissions.scope().findByName(postPermission.getName());
+        postPermission.addScope("POST");
+        postPermission.addPolicy("Always Deny Policy");
+        permissions.scope().findById(postPermission.getId()).update(postPermission);
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(null, "GET");
+
+        authorize = authzClient.authorization(token).authorize(request);
+        token = authorize.getToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token), testResponse.clear());
+        assertTrue(context.isGranted());
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/resource-with-scope", token, "POST"), testResponse.clear());
+        assertFalse(context.isGranted());
+    }
+
+    @Test
+    public void testUsingSubjectToken() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        ResourceRepresentation resource = createResource(clientResource, "Resource Subject Token", "/api/check-subject-token");
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy("Only User Policy");
+
+        PermissionsResource permissions = clientResource.authorization().permissions();
+        permissions.resource().create(permission).close();
+
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only.json", true);
+        AuthzTestUtils.TestResponse testResponse = new AuthzTestUtils.TestResponse();
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/check-subject-token"), testResponse);
+
+        assertFalse(context.isGranted());
+        assertEquals(403, testResponse.getStatus());
+
+        String token = doLoginAndGetAccessToken();
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/check-subject-token", token), testResponse.clear());
+        assertTrue(context.isGranted());
+    }
+
+    @Test
+    public void testUsingInvalidToken() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        ResourceRepresentation resource = createResource(clientResource, "Resource Subject Invalid Token", "/api/check-subject-token");
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy("Only User Policy");
+
+        PermissionsResource permissions = clientResource.authorization().permissions();
+        permissions.resource().create(permission).close();
+
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-bearer-only.json", true);
+
+        OAuthClient.AccessTokenResponse response = doLoginAndGetAccessTokenResponse();
+        String token = response.getAccessToken();
+
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/check-subject-token", token), new AuthzTestUtils.TestResponse());
+        assertTrue(context.isGranted());
+
+        oauth.doLogout(response.getRefreshToken(), null);
+
+        context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/check-subject-token", token), new AuthzTestUtils.TestResponse());
+        assertFalse(context.isGranted());
+    }
+
+    @Test
+    public void testLazyLoadPaths() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+
+        for (int i = 0; i < 200; i++) {
+            ResourceRepresentation representation = new ResourceRepresentation();
+
+            representation.setType("test");
+            representation.setName("Resource " + i);
+            representation.setUri("/api/" + i);
+
+            jakarta.ws.rs.core.Response response = clientResource.authorization().resources().create(representation);
+
+            representation.setId(response.readEntity(ResourceRepresentation.class).getId());
+
+            response.close();
+        }
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName("Test Permission");
+        permission.setResourceType("test");
+        permission.addPolicy("Only User Policy");
+
+        PermissionsResource permissions = clientResource.authorization().permissions();
+        permissions.resource().create(permission).close();
+
+        PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-no-lazyload.json", true);
+
+        assertEquals(205, policyEnforcer.getPaths().size());
+
+        policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-lazyload.json", true);
+        assertEquals(0, policyEnforcer.getPathMatcher().getPathCache().size());
+        assertEquals(0, policyEnforcer.getPaths().size());
+
+        String token = doLoginAndGetAccessToken();
+        for (int i = 0; i < 101; i++) {
+            policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/" + i, token), new AuthzTestUtils.TestResponse());
+        }
+
+        assertEquals(101, policyEnforcer.getPathMatcher().getPathCache().size());
+
+        for (int i = 101; i < 200; i++) {
+            policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/" + i, token), new AuthzTestUtils.TestResponse());
+        }
+
+        assertEquals(200, policyEnforcer.getPathMatcher().getPathCache().size());
+        assertEquals(0, policyEnforcer.getPaths().size());
+
+        ResourceRepresentation resource = clientResource.authorization().resources()
+                .findByName("Root").get(0);
+
+        clientResource.authorization().resources().resource(resource.getId()).remove();
+
+        policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-lazyload-with-paths.json", true);
+
+        AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api/0", token), new AuthzTestUtils.TestResponse());
+
+        assertTrue(context.isGranted());
+    }
+
+    @Test
+    public void testSetMethodConfigs() {
+        ClientResource clientResource = getClientResource(RESOURCE_SERVER_CLIENT_ID);
+        ResourceRepresentation representation = new ResourceRepresentation();
+
+        representation.setName(UUID.randomUUID().toString());
+        representation.setUris(Collections.singleton("/api-method/*"));
+
+        ResourcesResource resources = clientResource.authorization().resources();
+        jakarta.ws.rs.core.Response response = resources.create(representation);
+
+        representation.setId(response.readEntity(ResourceRepresentation.class).getId());
+
+        response.close();
+
+        try {
+            PolicyEnforcer policyEnforcer = AuthzTestUtils.createPolicyEnforcer("enforcer-paths-use-method-config.json", true);
+
+            String token = doLoginAndGetAccessToken();
+
+            AuthorizationContext context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api-method/foo", token), new AuthzTestUtils.TestResponse());
+
+            // GET is disabled in the config
+            assertTrue(context.isGranted());
+
+            PolicyEnforcerConfig.PathConfig pathConfig = policyEnforcer.getPaths().get("/api-method/*");
+
+            assertNotNull(pathConfig);
+            List<PolicyEnforcerConfig.MethodConfig> methods = pathConfig.getMethods();
+            assertEquals(1, methods.size());
+            assertTrue(PolicyEnforcerConfig.ScopeEnforcementMode.DISABLED.equals(methods.get(0).getScopesEnforcementMode()));
+
+            // other verbs should be protected
+            context = policyEnforcer.enforce(AuthzTestUtils.createHttpRequest("/api-method/foo", token, "POST"), new AuthzTestUtils.TestResponse());
+
+            assertFalse(context.isGranted());
+        } finally {
+            resources.resource(representation.getId()).remove();
+        }
+    }
+
+    private void initAuthorizationSettings(ClientResource clientResource) {
+        if (clientResource.authorization().resources().findByName("Resource A").isEmpty()) {
+            JSPolicyRepresentation jsPolicy = new JSPolicyRepresentation();
+
+            jsPolicy.setName("Always Grant Policy");
+            jsPolicy.setType("script-scripts/default-policy.js");
+
+            clientResource.authorization().policies().js().create(jsPolicy).close();
+
+            RolePolicyRepresentation rolePolicy = new RolePolicyRepresentation();
+
+            rolePolicy.setName("Only User Policy");
+            rolePolicy.addRole("user");
+
+            clientResource.authorization().policies().role().create(rolePolicy).close();
+
+            createResource(clientResource, "Resource A", "/api/resourcea");
+
+            ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+            permission.setName("Resource A Permission");
+            permission.addResource("Resource A");
+            permission.addPolicy(jsPolicy.getName());
+
+            clientResource.authorization().permissions().resource().create(permission).close();
+        }
+
+        if (clientResource.authorization().resources().findByName("Resource B").isEmpty()) {
+            JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+            policy.setName("Always Deny Policy");
+            policy.setType("script-scripts/always-deny-policy.js");
+
+            clientResource.authorization().policies().js().create(policy).close();
+
+            createResource(clientResource, "Resource B", "/api/resourceb");
+
+            ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+            permission.setName("Resource B Permission");
+            permission.addResource("Resource B");
+            permission.addPolicy(policy.getName());
+
+            clientResource.authorization().permissions().resource().create(permission).close();
+        }
+
+        if (clientResource.authorization().resources().findByName("Root").isEmpty()) {
+            createResource(clientResource, "Root", "/*");
+        }
+    }
+
+    private ResourceRepresentation createResource(ClientResource clientResource, String name, String uri, String... scopes) {
+        ResourceRepresentation representation = new ResourceRepresentation();
+
+        representation.setName(name);
+        representation.setUri(uri);
+        representation.setScopes(Arrays.asList(scopes).stream().map(ScopeRepresentation::new).collect(Collectors.toSet()));
+
+        jakarta.ws.rs.core.Response response = clientResource.authorization().resources().create(representation);
+
+        representation.setId(response.readEntity(ResourceRepresentation.class).getId());
+
+        response.close();
+
+        return representation;
+    }
+
+    private ClientResource getClientResource(String name) {
+        ClientsResource clients = realmsResource().realm(REALM_NAME).clients();
+        ClientRepresentation representation = clients.findByClientId(name).get(0);
+        return clients.get(representation.getId());
+    }
+
+    private OAuthClient.AccessTokenResponse doLoginAndGetAccessTokenResponse() {
+        oauth.realm(REALM_NAME);
+        oauth.clientId("public-client-test");
+        return oauth.doGrantAccessTokenRequest(null, "marta", "password");
+    }
+
+    private String doLoginAndGetAccessToken() {
+        OAuthClient.AccessTokenResponse response = doLoginAndGetAccessTokenResponse();
+        return response.getAccessToken();
+    }
+}
+

--- a/testsuite/authz-tests/src/test/resources/META-INF/services/org.keycloak.adapters.authorization.cip.spi.ClaimInformationPointProviderFactory
+++ b/testsuite/authz-tests/src/test/resources/META-INF/services/org.keycloak.adapters.authorization.cip.spi.ClaimInformationPointProviderFactory
@@ -1,0 +1,18 @@
+#
+# * Copyright 2018 Red Hat, Inc. and/or its affiliates
+# * and other contributors as indicated by the @author tags.
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#
+
+org.keycloak.client.testsuite.authz.MyCustomCIPFactory

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-bearer-only-with-cip.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-bearer-only-with-cip.json
@@ -1,0 +1,26 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "claim-information-point": {
+    "claims": {
+      "claim-b": "claim-b"
+    }
+  },
+  "paths": [
+    {
+      "path": "/api/resourcea",
+      "claim-information-point": {
+        "claims": {
+          "claim-a": "{request.parameter['claim-a']}"
+        },
+        "my-custom-cip": {
+          "claim-value": "test"
+        }
+      }
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-bearer-only.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-bearer-only.json
@@ -1,0 +1,8 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  }
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-config-claims-provider.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-config-claims-provider.json
@@ -1,0 +1,101 @@
+{
+  "realm": "test-realm-authz",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "test-app-authz",
+  "credentials": {
+    "secret": "secret"
+  },
+  "paths": [
+    {
+      "path": "/claims-provider",
+      "methods": [
+        {
+          "method": "POST",
+          "scopes": [
+            "create"
+          ]
+        }
+      ],
+      "claim-information-point": {
+        "claims": {
+          "claim-from-request-parameter": "{request.parameter['a']}",
+          "claim-from-header": "{request.header['b']}",
+          "claim-from-cookie": "{request.cookie['c']}",
+          "claim-from-remoteAddr": "{request.remoteAddr}",
+          "claim-from-method": "{request.method}",
+          "claim-from-uri": "{request.uri}",
+          "claim-from-relativePath": "{request.relativePath}",
+          "claim-from-secure": "{request.secure}",
+          "claim-from-json-body-object": "{request.body['/a/b/c']}",
+          "claim-from-json-body-array": "{request.body['/d/1']}",
+          "claim-from-json-body-number": "{request.body['/e/number']}",
+          "claim-from-body": "{request.body}",
+          "claim-from-static-value": "static value",
+          "claim-from-multiple-static-value": ["static", "value"],
+          "param-replace-multiple-placeholder": "Test {keycloak.access_token['/custom_claim/0']} and {request.parameter['a']} "
+        }
+      }
+    },
+    {
+      "path": "/claims-from-body-json-object",
+      "methods": [
+        {
+          "method": "POST",
+          "scopes": [
+            "create"
+          ]
+        }
+      ],
+      "claim-information-point": {
+        "claims": {
+          "individualRoles": "{request.body['/Individual/individualRoles']}"
+        }
+      }
+    },
+    {
+      "path": "/http-post-claim-provider",
+      "claim-information-point": {
+        "http": {
+          "claims": {
+            "claim-a": "/a",
+            "claim-d": "/d",
+            "claim-d0": "/d/0",
+            "claim-d-all": ["/d/0", "/d/1"]
+          },
+          "url": "http://localhost:8989/post-claim-information-provider",
+          "method": "POST",
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "header-b": ["header-b-value1", "header-b-value2"],
+            "Authorization": "Bearer {keycloak.access_token}"
+          },
+          "parameters": {
+            "param-a": ["param-a-value1", "param-a-value2"],
+            "param-subject": "{keycloak.access_token['/sub']}",
+            "param-user-name": "{keycloak.access_token['/preferred_username']}",
+            "param-other-claims": "{keycloak.access_token['/custom_claim']}"
+          }
+        }
+      }
+    },
+    {
+      "path": "/http-get-claim-provider",
+      "claim-information-point": {
+        "http": {
+          "url": "http://localhost:8989/get-claim-information-provider",
+          "method": "get",
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "header-b": ["header-b-value1", "header-b-value2"],
+            "Authorization": "Bearer {keycloak.access_token}"
+          },
+          "parameters": {
+            "param-a": ["param-a-value1", "param-a-value2"],
+            "param-subject": "{keycloak.access_token['/sub']}",
+            "param-user-name": "{keycloak.access_token['/preferred_username']}"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-enforce-mode-path.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-enforce-mode-path.json
@@ -1,0 +1,15 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "paths": [
+    {
+      "name": "Resource B",
+      "path": "/api/resource/public",
+      "enforcement-mode": "DISABLED"
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-enforce-mode.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-enforce-mode.json
@@ -1,0 +1,15 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "enforcement-mode": "DISABLED",
+  "paths": [
+    {
+      "name": "Resource B",
+      "path": "/api/resource/public"
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-path-nocache.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-disabled-path-nocache.json
@@ -1,0 +1,27 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "path-cache": {
+    "lifespan": 1
+  },
+  "paths": [
+    {
+      "name": "Resource B",
+      "path": "/api/resource/public",
+      "enforcement-mode": "DISABLED"
+    },
+    {
+      "name": "Nonexistent",
+      "path": "/api/resource/all-public/*",
+      "enforcement-mode": "DISABLED"
+    },
+    {
+      "name": "Static Test Resource",
+      "path": "/api/any-resource/test"
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-entitlement-claims-test.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-entitlement-claims-test.json
@@ -1,0 +1,26 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "paths": [
+    {
+      "path": "/api/bank/account/{id}/withdrawal",
+      "methods": [
+        {
+          "method": "POST",
+          "scopes": [
+            "withdrawal"
+          ]
+        }
+      ],
+      "claim-information-point": {
+        "claims": {
+          "withdrawal.amount": "{request.parameter['withdrawal.amount']}"
+        }
+      }
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-lazyload-with-paths.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-lazyload-with-paths.json
@@ -1,0 +1,15 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "lazy-load-paths": true,
+  "paths": [
+    {
+      "path": "/disabled",
+      "enforcement-mode": "DISABLED"
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-lazyload.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-lazyload.json
@@ -1,0 +1,9 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "lazy-load-paths": true
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-match-http-verbs-scopes.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-match-http-verbs-scopes.json
@@ -1,0 +1,9 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "http-method-as-scope": true
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-no-lazyload.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-no-lazyload.json
@@ -1,0 +1,8 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  }
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-on-deny-redirect.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-on-deny-redirect.json
@@ -1,0 +1,9 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "on-deny-redirect-to": "/accessDenied"
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-paths-use-method-config.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-paths-use-method-config.json
@@ -1,0 +1,23 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "lazy-load-paths": true,
+  "paths": [
+    {
+      "path": "/api-method/*",
+      "methods": [
+        {
+          "method": "GET",
+          "scopes": [
+            "withdrawal"
+          ],
+          "scopes-enforcement-mode": "DISABLED"
+        }
+      ]
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-paths.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-paths.json
@@ -1,0 +1,20 @@
+{
+  "realm": "authz-test",
+  "resource": "resource-server-test",
+  "auth-server-url": "http://localhost:8180",
+  "credentials": {
+    "secret": "secret"
+  },
+  "lazy-load-paths": true,
+  "paths": [
+    {
+      "name": "Root",
+      "path": "/*",
+      "enforcement-mode": "DISABLED"
+    },
+    {
+      "name": "Resource A",
+      "path": "/api/*"
+    }
+  ]
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-uma-claims-test.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/enforcer-uma-claims-test.json
@@ -1,0 +1,27 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180",
+  "resource": "resource-server-uma-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "user-managed-access": {},
+  "paths": [
+    {
+      "path": "/api/bank/account/{id}/withdrawal",
+      "methods": [
+        {
+          "method": "POST",
+          "scopes": [
+            "withdrawal"
+          ]
+        }
+      ],
+      "claim-information-point": {
+        "claims": {
+          "withdrawal.amount": "{request.parameter['withdrawal.amount']}"
+        }
+      }
+    }
+  ]
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
@@ -1,0 +1,396 @@
+package org.keycloak.client.testsuite.common;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.client.testsuite.framework.TestRegistry;
+import org.keycloak.client.testsuite.server.KeycloakServerProvider;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.testsuite.util.ServerURLs;
+import org.keycloak.util.BasicAuthHelper;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.TokenUtil;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class OAuthClient {
+
+    private String realm;
+    private String clientId;
+    private boolean openid = true;
+    private String scope = "";
+
+    private final CloseableHttpClient httpClient;
+
+    public OAuthClient(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public OAuthClient realm(String realm) {
+        this.realm = realm;
+        return this;
+    }
+
+    public OAuthClient clientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public AccessTokenResponse doGrantAccessTokenRequest(String clientSecret, String username, String password) {
+        return doGrantAccessTokenRequest(realm, username, password, null, clientId, clientSecret);
+    }
+
+    public AccessTokenResponse doGrantAccessTokenRequest(String clientSecret, String username, String password, String otp) {
+        return doGrantAccessTokenRequest(realm, username, password, otp, clientId, clientSecret);
+    }
+
+    public AccessTokenResponse doGrantAccessTokenRequest(String realm, String username, String password, String totp,
+                                                         String clientId, String clientSecret) {
+        return doGrantAccessTokenRequest(realm, username, password, totp, clientId, clientSecret, null);
+    }
+
+    public AccessTokenResponse doGrantAccessTokenRequest(String realm, String username, String password, String totp,
+                                                         String clientId, String clientSecret, String userAgent) {
+        HttpPost post = new HttpPost(getResourceOwnerPasswordCredentialGrantUrl(realm));
+
+        post.addHeader("Accept", MediaType.APPLICATION_JSON);
+
+//            if (requestHeaders != null) {
+//                for (Map.Entry<String, String> header : requestHeaders.entrySet()) {
+//                    post.addHeader(header.getKey(), header.getValue());
+//                }
+//            }
+//            if (dpopProof != null) {
+//                post.addHeader(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
+//            }
+
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
+        parameters.add(new BasicNameValuePair("username", username));
+        parameters.add(new BasicNameValuePair("password", password));
+        if (totp != null) {
+            parameters.add(new BasicNameValuePair("otp", totp));
+
+        }
+        if (clientSecret != null) {
+            String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
+            post.setHeader("Authorization", authorization);
+        } else {
+            parameters.add(new BasicNameValuePair("client_id", clientId));
+        }
+
+//            if (origin != null) {
+//                post.addHeader("Origin", origin);
+//            }
+//
+//            if (clientSessionState != null) {
+//                parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
+//            }
+//            if (clientSessionHost != null) {
+//                parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
+//            }
+
+        String scopeParam = openid ? TokenUtil.attachOIDCScope(scope) : scope;
+        if (scopeParam != null && !scopeParam.isEmpty()) {
+            parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scopeParam));
+        }
+
+        if (userAgent != null) {
+            post.addHeader("User-Agent", userAgent);
+        }
+
+//            if (customParameters != null) {
+//                customParameters.keySet().stream()
+//                        .forEach(paramName -> parameters.add(new BasicNameValuePair(paramName, customParameters.get(paramName))));
+//            }
+
+        UrlEncodedFormEntity formEntity;
+        try {
+            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        post.setEntity(formEntity);
+
+        try {
+            return new AccessTokenResponse(httpClient.execute(post));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public String getResourceOwnerPasswordCredentialGrantUrl(String realmName) {
+        return KeycloakUriBuilder.fromUri(ServerURLs.AUTH_SERVER_URL + "/realms/{realmName}/protocol/openid-connect/token")
+                .build(realmName)
+                .toString();
+    }
+
+    public LogoutUrlBuilder getLogoutUrl() {
+        return new LogoutUrlBuilder();
+    }
+
+    public CloseableHttpResponse doLogout(String refreshToken, String clientSecret) {
+        try {
+            return doLogout(refreshToken, clientSecret, httpClient);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    // KEYCLOAK-6771 Certificate Bound Token
+    public CloseableHttpResponse doLogout(String refreshToken, String clientSecret, CloseableHttpClient client) throws IOException {
+        HttpPost post = new HttpPost(getLogoutUrl().build());
+
+        List<NameValuePair> parameters = new LinkedList<>();
+        if (refreshToken != null) {
+            parameters.add(new BasicNameValuePair(OAuth2Constants.REFRESH_TOKEN, refreshToken));
+        }
+        if (clientId != null && clientSecret != null) {
+            String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
+            post.setHeader("Authorization", authorization);
+        } else if (clientId != null) {
+            parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, clientId));
+        }
+//        if (origin != null) {
+//            post.addHeader("Origin", origin);
+//        }
+
+        UrlEncodedFormEntity formEntity;
+        try {
+            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        post.setEntity(formEntity);
+
+        return client.execute(post);
+    }
+
+
+    public static class AccessTokenResponse {
+        private int statusCode;
+
+        private String idToken;
+        private String accessToken;
+        private String issuedTokenType;
+        private String tokenType;
+        private int expiresIn;
+        private int refreshExpiresIn;
+        private String refreshToken;
+        // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+        private String scope;
+        private String sessionState;
+
+        private String error;
+        private String errorDescription;
+
+        private Map<String, String> headers;
+
+        private Map<String, Object> otherClaims;
+
+        public AccessTokenResponse(CloseableHttpResponse response) throws Exception {
+            try {
+                statusCode = response.getStatusLine().getStatusCode();
+
+                headers = new HashMap<>();
+
+                for (Header h : response.getAllHeaders()) {
+                    headers.put(h.getName(), h.getValue());
+                }
+
+                Header[] contentTypeHeaders = response.getHeaders("Content-Type");
+                String contentType = (contentTypeHeaders != null && contentTypeHeaders.length > 0) ? contentTypeHeaders[0].getValue() : null;
+                if (!"application/json".equals(contentType)) {
+                    fail("Invalid content type. Status: " + statusCode + ", contentType: " + contentType);
+                }
+
+                String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> responseJson = JsonSerialization.readValue(s, Map.class);
+
+                if (statusCode == 200) {
+                    otherClaims = new HashMap<>();
+
+                    for (Map.Entry<String, Object> entry : responseJson.entrySet()) {
+                        switch (entry.getKey()) {
+                            case OAuth2Constants.ID_TOKEN:
+                                idToken = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.ACCESS_TOKEN:
+                                accessToken = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.ISSUED_TOKEN_TYPE:
+                                issuedTokenType = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.TOKEN_TYPE:
+                                tokenType = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.EXPIRES_IN:
+                                expiresIn = (Integer) entry.getValue();
+                                break;
+                            case "refresh_expires_in":
+                                refreshExpiresIn = (Integer) entry.getValue();
+                                break;
+                            case OAuth2Constants.SESSION_STATE:
+                                sessionState = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.SCOPE:
+                                scope = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.REFRESH_TOKEN:
+                                refreshToken = (String) entry.getValue();
+                                break;
+                            default:
+                                otherClaims.put(entry.getKey(), entry.getValue());
+                                break;
+                        }
+                    }
+                } else {
+                    error = (String) responseJson.get(OAuth2Constants.ERROR);
+                    errorDescription = responseJson.containsKey(OAuth2Constants.ERROR_DESCRIPTION) ? (String) responseJson.get(OAuth2Constants.ERROR_DESCRIPTION) : null;
+                }
+            } finally {
+                response.close();
+            }
+        }
+
+        public String getIdToken() {
+            return idToken;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public String getErrorDescription() {
+            return errorDescription;
+        }
+
+        public int getExpiresIn() {
+            return expiresIn;
+        }
+
+        public int getRefreshExpiresIn() {
+            return refreshExpiresIn;
+        }
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+
+        public String getIssuedTokenType() {
+            return issuedTokenType;
+        }
+
+        public String getTokenType() {
+            return tokenType;
+        }
+
+        // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+        public String getScope() {
+            return scope;
+        }
+
+        public String getSessionState() {
+            return sessionState;
+        }
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        public Map<String, Object> getOtherClaims() {
+            return otherClaims;
+        }
+    }
+
+    public class LogoutUrlBuilder {
+        private KeycloakUriBuilder b = KeycloakUriBuilder.fromUri(ServerURLs.AUTH_SERVER_URL + "/realms/{realmName}/protocol/openid-connect/logout");
+
+        public LogoutUrlBuilder clientId(String clientId) {
+            if (clientId != null) {
+                b.queryParam(OAuth2Constants.CLIENT_ID, clientId);
+            }
+            return this;
+        }
+
+        public LogoutUrlBuilder idTokenHint(String idTokenHint) {
+            if (idTokenHint != null) {
+                b.queryParam(OAuth2Constants.ID_TOKEN_HINT, idTokenHint);
+            }
+            return this;
+        }
+
+        public LogoutUrlBuilder postLogoutRedirectUri(String redirectUri) {
+            if (redirectUri != null) {
+                b.queryParam(OAuth2Constants.POST_LOGOUT_REDIRECT_URI, redirectUri);
+            }
+            return this;
+        }
+
+//        @Deprecated // Use only in backwards compatibility tests
+//        public LogoutUrlBuilder redirectUri(String redirectUri) {
+//            if (redirectUri != null) {
+//                b.queryParam(OAuth2Constants.REDIRECT_URI, redirectUri);
+//            }
+//            return this;
+//        }
+
+        public LogoutUrlBuilder state(String state) {
+            if (state != null) {
+                b.queryParam(OAuth2Constants.STATE, state);
+            }
+            return this;
+        }
+
+        public LogoutUrlBuilder uiLocales(String uiLocales) {
+            if (uiLocales != null) {
+                b.queryParam(OAuth2Constants.UI_LOCALES_PARAM, uiLocales);
+            }
+            return this;
+        }
+
+//        public LogoutUrlBuilder initiatingIdp(String initiatingIdp) {
+//            if (initiatingIdp != null) {
+//                b.queryParam(AuthenticationManager.INITIATING_IDP_PARAM, initiatingIdp);
+//            }
+//            return this;
+//        }
+
+        public String build() {
+            return b.build(realm).toString();
+        }
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClientFactory.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClientFactory.java
@@ -1,0 +1,34 @@
+package org.keycloak.client.testsuite.common;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.client.testsuite.framework.LifeCycle;
+import org.keycloak.client.testsuite.framework.TestProviderFactory;
+import org.keycloak.client.testsuite.framework.TestRegistry;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class OAuthClientFactory implements TestProviderFactory<OAuthClient> {
+
+    @Override
+    public LifeCycle getLifeCycle() {
+        return LifeCycle.CLASS;
+    }
+
+    @Override
+    public Class<OAuthClient> getProviderClass() {
+        return OAuthClient.class;
+    }
+
+    @Override
+    public OAuthClient createProvider(TestRegistry registry) {
+        CloseableHttpClient httpClient = registry.getOrCreateProvider(CloseableHttpClient.class);
+        return new OAuthClient(httpClient);
+    }
+
+    @Override
+    public void closeProvider(OAuthClient provider) {
+
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/RealmRepsSupplier.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/RealmRepsSupplier.java
@@ -17,4 +17,11 @@ public interface RealmRepsSupplier {
      * @return realms, which will be imported
      */
     List<RealmRepresentation> getRealmsForImport();
+
+    /**
+     * Should be "Verify profile" action disabled after import of the realms?
+     *
+     * @return true if should be disabled, false otherwise
+     */
+    boolean removeVerifyProfileAtImport();
 }

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/TestEnvironment.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/TestEnvironment.java
@@ -1,0 +1,22 @@
+package org.keycloak.client.testsuite.common;
+
+import java.io.File;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class TestEnvironment {
+
+    public static String getProjectRootDir() {
+        String userDir = System.getProperty("user.dir");
+        return userDir.substring(0, userDir.lastIndexOf("keycloak-client") + 15);
+    }
+
+    public static String getTestProvidersFile() {
+        return getProjectRootDir()
+                + File.separator + "testsuite"
+                + File.separator + "providers"
+                + File.separator + "target"
+                + File.separator + "keycloak-client-testsuite-providers.jar";
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/framework/TestRegistry.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/framework/TestRegistry.java
@@ -14,6 +14,8 @@ import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.client.testsuite.common.AdminClientFactory;
 import org.keycloak.client.testsuite.common.HttpClientFactory;
+import org.keycloak.client.testsuite.common.OAuthClient;
+import org.keycloak.client.testsuite.common.OAuthClientFactory;
 import org.keycloak.client.testsuite.server.KeycloakServerProvider;
 import org.keycloak.client.testsuite.server.KeycloakServerProviderFactory;
 import org.keycloak.client.testsuite.common.RealmImporter;
@@ -30,7 +32,7 @@ public class TestRegistry {
 
     private final Map<Class<?>, Object> instances = new ConcurrentHashMap<>();
 
-    // Sorted by last added classes being first, so we can cleanup in correct order
+    // Sorted by last added classes being last, so we can cleanup in correct order
     private final List<Class<?>> currentInstanceClasses = new CopyOnWriteArrayList<>();
 
     public static TestRegistry INSTANCE = new TestRegistry();
@@ -40,6 +42,7 @@ public class TestRegistry {
         factories.put(KeycloakServerProvider.class, new KeycloakServerProviderFactory());
         factories.put(Keycloak.class, new AdminClientFactory());
         factories.put(CloseableHttpClient.class, new HttpClientFactory());
+        factories.put(OAuthClient.class, new OAuthClientFactory());
         factories.put(RealmImporter.class, new RealmImporterFactory());
 
         Runtime.getRuntime().addShutdownHook(new Thread(this::afterAllTestClasses));

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/server/KeycloakContainersServerProvider.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/server/KeycloakContainersServerProvider.java
@@ -1,9 +1,13 @@
 package org.keycloak.client.testsuite.server;
 
+import java.io.File;
+import java.util.Collections;
+
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.client.testsuite.TestConstants;
+import org.keycloak.client.testsuite.common.TestEnvironment;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 /**
@@ -35,6 +39,14 @@ public class KeycloakContainersServerProvider implements KeycloakServerProvider 
                         keycloakContainer.waitingFor(new LogMessageWaitStrategy()
                                 .withRegEx(".*Profile dev activated.*\\s"));
                     }
+
+                    String testProvidersFile = TestEnvironment.getTestProvidersFile();
+                    logger.infof("Deploying providers from file %s to Keycloak server", testProvidersFile);
+                    File providersFile = new File(testProvidersFile);
+                    if (!providersFile.exists()) {
+                        throw new IllegalStateException("Providers file " + testProvidersFile + " does not exists");
+                    }
+                    keycloakContainer.withProviderLibsFrom(Collections.singletonList(providersFile));
 
                     keycloakContainer.start();
                     logger.infof("Started Keycloak server on URL %s", keycloakContainer.getAuthServerUrl());

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/ClientBuilder.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/ClientBuilder.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class ClientBuilder {
+
+    private ClientRepresentation rep;
+
+    public static ClientBuilder create() {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setEnabled(Boolean.TRUE);
+        return new ClientBuilder(rep);
+    }
+
+    public static ClientBuilder edit(ClientRepresentation rep) {
+        return new ClientBuilder(rep);
+    }
+
+    private ClientBuilder(ClientRepresentation rep) {
+        this.rep = rep;
+    }
+
+    public ClientBuilder id(String id) {
+        rep.setId(id);
+        return this;
+    }
+
+    public ClientBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public ClientBuilder clientId(String clientId) {
+        rep.setClientId(clientId);
+        return this;
+    }
+
+    public ClientBuilder type(String type) {
+        rep.setType(type);
+        return this;
+    }
+
+    public ClientBuilder consentRequired(boolean consentRequired) {
+        rep.setConsentRequired(consentRequired);
+        return this;
+    }
+
+    public ClientBuilder publicClient() {
+        rep.setPublicClient(true);
+        return this;
+    }
+
+    @Deprecated
+    public ClientBuilder defaultRoles(String... roles) {
+        rep.setDefaultRoles(roles);
+        return this;
+    }
+
+    public ClientBuilder addOptionalClientScopes(String... optionalClientScopes) {
+        if (rep.getOptionalClientScopes() == null) {
+            rep.setOptionalClientScopes(new ArrayList<>());
+        }
+        rep.getOptionalClientScopes().addAll(Arrays.asList(optionalClientScopes));
+        return this;
+    }
+
+    public ClientBuilder serviceAccount() {
+        rep.setServiceAccountsEnabled(true);
+        return this;
+    }
+
+    public ClientBuilder directAccessGrants() {
+        rep.setDirectAccessGrantsEnabled(true);
+        return this;
+    }
+
+    public ClientBuilder fullScopeEnabled(Boolean fullScopeEnabled) {
+        rep.setFullScopeAllowed(fullScopeEnabled);
+        return this;
+    }
+
+    public ClientBuilder frontchannelLogout(Boolean frontchannelLogout) {
+        rep.setFrontchannelLogout(frontchannelLogout);
+        return this;
+    }
+
+    public ClientBuilder secret(String secret) {
+        rep.setSecret(secret);
+        return this;
+    }
+
+    public ClientBuilder serviceAccountsEnabled(Boolean serviceAccountsEnabled) {
+        rep.setServiceAccountsEnabled(serviceAccountsEnabled);
+        return this;
+    }
+
+    public ClientRepresentation build() {
+        return rep;
+    }
+
+    public ClientBuilder attribute(String name, String value) {
+        Map<String, String> attributes = rep.getAttributes();
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        attributes.put(name, value);
+        rep.setAttributes(attributes);
+        return this;
+    }
+
+    public ClientBuilder removeAttribute(String name) {
+        Map<String, String> attributes = rep.getAttributes();
+        if (attributes != null) {
+            attributes.remove(name);
+            rep.setAttributes(attributes);
+        }
+        return this;
+    }
+
+    public ClientBuilder authenticatorType(String providerId) {
+        rep.setClientAuthenticatorType(providerId);
+        return this;
+    }
+
+    public ClientBuilder addWebOrigin(String webOrigin) {
+        List<String> uris = rep.getWebOrigins();
+        if (uris == null) {
+            uris = new LinkedList<>();
+            rep.setWebOrigins(uris);
+        }
+        uris.add(webOrigin);
+        return this;
+    }
+
+    public ClientBuilder addRedirectUri(String redirectUri) {
+        List<String> uris = rep.getRedirectUris();
+        if (uris == null) {
+            uris = new LinkedList<>();
+            rep.setRedirectUris(uris);
+        }
+        uris.add(redirectUri);
+        return this;
+    }
+
+    public ClientBuilder redirectUris(String... redirectUris) {
+        rep.setRedirectUris(Arrays.asList(redirectUris));
+        return this;
+    }
+
+    public ClientBuilder baseUrl(String baseUrl) {
+        rep.setBaseUrl(baseUrl);
+        return this;
+    }
+
+    public ClientBuilder adminUrl(String adminUrl) {
+        rep.setAdminUrl(adminUrl);
+        return this;
+    }
+
+    public ClientBuilder rootUrl(String rootUrl) {
+        rep.setRootUrl(rootUrl);
+        return this;
+    }
+
+    public ClientBuilder protocol(String protocol) {
+        rep.setProtocol(protocol);
+        return this;
+    }
+
+    public ClientBuilder enabled(Boolean enabled) {
+        rep.setEnabled(enabled);
+        return this;
+    }
+
+    public ClientBuilder alwaysDisplayInConsole(Boolean alwaysDisplayInConsole) {
+        rep.setAlwaysDisplayInConsole(alwaysDisplayInConsole);
+        return this;
+    }
+
+    public ClientBuilder authorizationServicesEnabled(boolean enable) {
+        rep.setAuthorizationServicesEnabled(enable);
+        return this;
+    }
+
+    public ClientBuilder protocolMapper(ProtocolMapperRepresentation... mappers) {
+        if (rep.getProtocolMappers() == null) {
+            rep.setProtocolMappers(new ArrayList<>());
+        }
+        rep.getProtocolMappers().addAll(Arrays.asList(mappers));
+        return this;
+    }
+
+//    public ClientBuilder pairwise(String sectorIdentifierUri, String salt) {
+//        return protocolMapper(ProtocolMapperUtil.createPairwiseMapper(sectorIdentifierUri, salt));
+//    }
+//
+//    public ClientBuilder pairwise(String sectorIdentifierUri) {
+//        return protocolMapper(ProtocolMapperUtil.createPairwiseMapper(sectorIdentifierUri, null));
+//    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RealmBuilder.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RealmBuilder.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class RealmBuilder {
+
+    private final RealmRepresentation rep;
+
+    public static RealmBuilder create() {
+        RealmRepresentation rep = new RealmRepresentation();
+        rep.setEnabled(Boolean.TRUE);
+        return new RealmBuilder(rep);
+    }
+
+    public static RealmBuilder edit(RealmRepresentation rep) {
+        return new RealmBuilder(rep);
+    }
+
+    private RealmBuilder(RealmRepresentation rep) {
+        this.rep = rep;
+    }
+
+    public RealmBuilder name(String name) {
+        rep.setRealm(name);
+        return this;
+    }
+
+    public RealmBuilder displayName(String displayName) {
+        rep.setDisplayName(displayName);
+        return this;
+    }
+
+    public RealmBuilder publicKey(String publicKey) {
+        rep.setPublicKey(publicKey);
+        return this;
+    }
+
+    public RealmBuilder privateKey(String privateKey) {
+        rep.setPrivateKey(privateKey);
+        return this;
+    }
+
+    public RealmBuilder roles(RolesBuilder roles) {
+        return roles(roles.build());
+    }
+
+    public RealmBuilder roles(RolesRepresentation roles) {
+        rep.setRoles(roles);
+        return this;
+    }
+
+    public RealmBuilder events() {
+        rep.setEventsEnabled(true);
+        rep.setEnabledEventTypes(Collections.<String>emptyList()); // enables all types
+        return this;
+    }
+
+    public RealmBuilder attribute(String key, String value) {
+        if (rep.getAttributes() == null) {
+            rep.setAttributes(new HashMap<>());
+        }
+        rep.getAttributes().put(key, value);
+        return this;
+    }
+
+//    public RealmBuilder testMail() {
+//        Map<String, String> config = new HashMap<>();
+//        config.put("from", MailServerConfiguration.FROM);
+//        config.put("host", MailServerConfiguration.HOST);
+//        config.put("port", MailServerConfiguration.PORT);
+//        rep.setSmtpServer(config);
+//        return this;
+//    }
+
+//    public RealmBuilder testEventListener() {
+//        if (rep.getEventsListeners() == null) {
+//            rep.setEventsListeners(new LinkedList<String>());
+//        }
+//
+//        if (!rep.getEventsListeners().contains(TestEventsListenerProviderFactory.PROVIDER_ID)) {
+//            rep.getEventsListeners().add(TestEventsListenerProviderFactory.PROVIDER_ID);
+//        }
+//
+//        return this;
+//    }
+//
+//    public RealmBuilder removeTestEventListener() {
+//        if (rep.getEventsListeners() != null && rep.getEventsListeners().contains(TestEventsListenerProviderFactory.PROVIDER_ID)) {
+//            rep.getEventsListeners().remove(TestEventsListenerProviderFactory.PROVIDER_ID);
+//        }
+//
+//        return this;
+//    }
+
+    public RealmBuilder client(ClientBuilder client) {
+        return client(client.build());
+    }
+
+    public RealmBuilder client(ClientRepresentation client) {
+        if (rep.getClients() == null) {
+            rep.setClients(new LinkedList<>());
+        }
+        rep.getClients().add(client);
+        return this;
+    }
+
+//    public RealmBuilder clientScope(ClientScopeBuilder clientScope) {
+//        return clientScope(clientScope.build());
+//    }
+
+    public RealmBuilder clientScope(ClientScopeRepresentation clientScope) {
+        if (rep.getClientScopes() == null) {
+            rep.setClientScopes(new LinkedList<>());
+        }
+        rep.getClientScopes().add(clientScope);
+        return this;
+    }
+
+//    public RealmBuilder identityProvider(IdentityProviderBuilder identityProvider) {
+//        return identityProvider(identityProvider.build());
+//    }
+
+    public RealmBuilder identityProvider(IdentityProviderRepresentation identityProvider) {
+        if (rep.getIdentityProviders()== null) {
+            rep.setIdentityProviders(new LinkedList<>());
+        }
+        rep.getIdentityProviders().add(identityProvider);
+        return this;
+    }
+
+    public RealmBuilder user(UserBuilder user) {
+        return user(user.build());
+    }
+
+    public RealmBuilder user(UserRepresentation user) {
+        if (rep.getUsers() == null) {
+            rep.setUsers(new LinkedList<>());
+        }
+        rep.getUsers().add(user);
+        return this;
+    }
+
+    public RealmBuilder notBefore(int i) {
+        rep.setNotBefore(i);
+        return this;
+    }
+
+    public RealmBuilder otpLookAheadWindow(int i) {
+        rep.setOtpPolicyLookAheadWindow(i);
+        return this;
+    }
+
+    public RealmBuilder bruteForceProtected(boolean bruteForceProtected) {
+        rep.setBruteForceProtected(bruteForceProtected);
+        return this;
+    }
+
+    public RealmBuilder failureFactor(int failureFactor) {
+        rep.setFailureFactor(failureFactor);
+        return this;
+    }
+
+    public RealmBuilder otpDigits(int i) {
+        rep.setOtpPolicyDigits(i);
+        return this;
+    }
+
+    public RealmBuilder otpPeriod(int i) {
+        rep.setOtpPolicyPeriod(i);
+        return this;
+    }
+
+    public RealmBuilder otpType(String type) {
+        rep.setOtpPolicyType(type);
+        return this;
+    }
+
+    public RealmBuilder otpAlgorithm(String algorithm) {
+        rep.setOtpPolicyAlgorithm(algorithm);
+        return this;
+    }
+
+    public RealmBuilder otpInitialCounter(int i) {
+        rep.setOtpPolicyInitialCounter(i);
+        return this;
+    }
+
+    public RealmBuilder passwordPolicy(String passwordPolicy) {
+        rep.setPasswordPolicy(passwordPolicy);
+        return this;
+    }
+
+    public RealmRepresentation build() {
+        return rep;
+    }
+
+    public RealmBuilder accessTokenLifespan(int accessTokenLifespan) {
+        rep.setAccessTokenLifespan(accessTokenLifespan);
+        return this;
+    }
+
+    public RealmBuilder ssoSessionMaxLifespan(int ssoSessionMaxLifespan) {
+        rep.setSsoSessionMaxLifespan(ssoSessionMaxLifespan);
+        return this;
+    }
+
+    public RealmBuilder ssoSessionIdleTimeoutRememberMe(int ssoSessionIdleTimeoutRememberMe){
+        rep.setSsoSessionIdleTimeoutRememberMe(ssoSessionIdleTimeoutRememberMe);
+        return this;
+    }
+
+    public RealmBuilder ssoSessionMaxLifespanRememberMe(int ssoSessionMaxLifespanRememberMe){
+        rep.setSsoSessionMaxLifespanRememberMe(ssoSessionMaxLifespanRememberMe);
+        return this;
+    }
+
+    public RealmBuilder accessCodeLifespanUserAction(int accessCodeLifespanUserAction) {
+        rep.setAccessCodeLifespanUserAction(accessCodeLifespanUserAction);
+        return this;
+    }
+
+    public RealmBuilder accessCodeLifespan(int accessCodeLifespan) {
+        rep.setAccessCodeLifespan(accessCodeLifespan);
+        return this;
+    }
+
+    public RealmBuilder sslRequired(String sslRequired) {
+        rep.setSslRequired(sslRequired);
+        return this;
+    }
+
+    public RealmBuilder ssoSessionIdleTimeout(int sessionIdleTimeout) {
+        rep.setSsoSessionIdleTimeout(sessionIdleTimeout);
+        return this;
+    }
+
+    public RealmBuilder group(GroupRepresentation group) {
+        if (rep.getGroups() == null) {
+            rep.setGroups(new ArrayList<>());
+        }
+        rep.getGroups().add(group);
+        return this;
+    }
+
+    // KEYCLOAK-7688 Offline Session Max for Offline Token
+    public RealmBuilder offlineSessionIdleTimeout(int offlineSessionIdleTimeout) {
+        rep.setOfflineSessionIdleTimeout(offlineSessionIdleTimeout);
+        return this;
+    }
+
+    public RealmBuilder offlineSessionMaxLifespan(int offlineSessionMaxLifespan) {
+        rep.setOfflineSessionMaxLifespan(offlineSessionMaxLifespan);
+        return this;
+    }
+
+    public RealmBuilder offlineSessionMaxLifespanEnabled(boolean offlineSessionMaxLifespanEnabled) {
+        rep.setOfflineSessionMaxLifespanEnabled(offlineSessionMaxLifespanEnabled);
+        return this;
+    }
+
+    public RealmBuilder clientSessionIdleTimeout(int clientSessionIdleTimeout) {
+        rep.setClientSessionIdleTimeout(clientSessionIdleTimeout);
+        return this;
+    }
+
+    public RealmBuilder clientSessionMaxLifespan(int clientSessionMaxLifespan) {
+        rep.setClientSessionMaxLifespan(clientSessionMaxLifespan);
+        return this;
+    }
+
+    public RealmBuilder clientOfflineSessionIdleTimeout(int clientOfflineSessionIdleTimeout) {
+        rep.setClientOfflineSessionIdleTimeout(clientOfflineSessionIdleTimeout);
+        return this;
+    }
+
+    public RealmBuilder clientOfflineSessionMaxLifespan(int clientOfflineSessionMaxLifespan) {
+        rep.setClientOfflineSessionMaxLifespan(clientOfflineSessionMaxLifespan);
+        return this;
+    }
+
+    public RealmBuilder internationalizationEnabled(boolean internationalizationEnabled) {
+        rep.setInternationalizationEnabled(internationalizationEnabled);
+        return this;
+    }
+
+    public RealmBuilder supportedLocales(Set<String> supportedLocales) {
+        rep.setSupportedLocales(supportedLocales);
+        return this;
+    }
+
+    public RealmBuilder defaultLocale(String defaultLocale) {
+        rep.setDefaultLocale(defaultLocale);
+        return this;
+    }
+
+    public RealmBuilder organizationEnabled(boolean enabled) {
+        rep.setOrganizationsEnabled(enabled);
+        return this;
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RoleBuilder.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RoleBuilder.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation.Composites;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class RoleBuilder {
+
+    private final RoleRepresentation rep;
+
+    public static RoleBuilder create() {
+        return new RoleBuilder(new RoleRepresentation());
+    }
+
+    public static RoleBuilder edit(RoleRepresentation rep) {
+        return new RoleBuilder(rep);
+    }
+
+    private RoleBuilder(RoleRepresentation rep) {
+        this.rep = rep;
+    }
+
+    public RoleBuilder id(String id) {
+        rep.setId(id);
+        return this;
+    }
+
+    public RoleBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public RoleBuilder description(String description) {
+        rep.setDescription(description);
+        return this;
+    }
+
+    public RoleBuilder composite() {
+        rep.setComposite(true);
+        return this;
+    }
+    
+    public RoleBuilder attributes(Map<String, List<String>> attributes) {
+        rep.setAttributes(attributes);
+        return this;
+    }
+
+    public RoleBuilder singleAttribute(String name, String value) {
+        rep.singleAttribute(name, value);
+        return this;
+    }
+
+    private void checkCompositesNull() {
+        if (rep.getComposites() == null) {
+            rep.setComposites(new Composites());
+        }
+    }
+
+    public RoleBuilder realmComposite(RoleRepresentation role) {
+        return realmComposite(role.getName());
+    }
+
+    public RoleBuilder realmComposite(String compositeRole) {
+        checkCompositesNull();
+
+        if (rep.getComposites().getRealm() == null) {
+            rep.getComposites().setRealm(new HashSet<>());
+        }
+
+        rep.getComposites().getRealm().add(compositeRole);
+        return this;
+    }
+
+    public RoleBuilder clientComposite(String client, RoleRepresentation compositeRole) {
+        return clientComposite(client, compositeRole.getName());
+    }
+
+    public RoleBuilder clientComposite(String client, String compositeRole) {
+        checkCompositesNull();
+
+        if (rep.getComposites().getClient() == null) {
+            rep.getComposites().setClient(new HashMap<>());
+        }
+
+        if (rep.getComposites().getClient().get(client) == null) {
+            rep.getComposites().getClient().put(client, new LinkedList<>());
+        }
+
+        rep.getComposites().getClient().get(client).add(compositeRole);
+        return this;
+    }
+
+    public RoleRepresentation build() {
+        return rep;
+    }
+
+}

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RolesBuilder.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/RolesBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class RolesBuilder {
+
+    private RolesRepresentation rep;
+
+    public static RolesBuilder create() {
+        return new RolesBuilder();
+    }
+
+    private RolesBuilder() {
+        rep = new RolesRepresentation();
+    }
+
+    public RolesBuilder realmRole(RoleRepresentation role) {
+        if (rep.getRealm() == null) {
+            rep.setRealm(new LinkedList<RoleRepresentation>());
+        }
+
+        rep.getRealm().add(role);
+        return this;
+    }
+
+    public RolesBuilder clientRole(String client, RoleRepresentation role) {
+        if (rep.getClient() == null) {
+            rep.setClient(new HashMap<String, List<RoleRepresentation>>());
+        }
+
+        List<RoleRepresentation> clientList = rep.getClient().get(client);
+        if (clientList == null) {
+            rep.getClient().put(client, new LinkedList<RoleRepresentation>());
+        }
+
+        rep.getClient().get(client).add(role);
+        return this;
+    }
+
+    public RolesRepresentation build() {
+        return rep;
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/UserBuilder.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/UserBuilder.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class UserBuilder {
+
+    private final UserRepresentation rep;
+
+    public static UserBuilder create() {
+        UserRepresentation rep = new UserRepresentation();
+        rep.setEnabled(Boolean.TRUE);
+        return new UserBuilder(rep);
+    }
+
+    public static UserBuilder edit(UserRepresentation rep) {
+        return new UserBuilder(rep);
+    }
+
+    private UserBuilder(UserRepresentation rep) {
+        this.rep = rep;
+    }
+
+    public UserBuilder id(String id) {
+        rep.setId(id);
+        return this;
+    }
+
+    public UserBuilder username(String username) {
+        rep.setUsername(username);
+        return this;
+    }
+
+    public UserBuilder firstName(String firstName) {
+        rep.setFirstName(firstName);
+        return this;
+    }
+
+    public UserBuilder lastName(String lastName) {
+        rep.setLastName(lastName);
+        return this;
+    }
+
+    /**
+     * This method adds additional passwords to the user.
+     */
+    public UserBuilder addPassword(String password) {
+        if (rep.getCredentials() == null) {
+            rep.setCredentials(new LinkedList<>());
+        }
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(password);
+
+        rep.getCredentials().add(credential);
+        return this;
+    }
+
+    public UserBuilder addAttribute(String name, String... values) {
+        if (rep.getAttributes() == null) {
+            rep.setAttributes(new HashMap<>());
+        }
+
+        rep.getAttributes().put(name, Arrays.asList(values));
+        return this;
+    }
+
+    /**
+     * This method makes sure that there is one single password for the user.
+     */
+    public UserBuilder password(String password) {
+        rep.setCredentials(null);
+        return addPassword(password);
+    }
+
+    public UserBuilder email(String email) {
+        rep.setEmail(email);
+        return this;
+    }
+    
+    public UserBuilder emailVerified(boolean emailVerified) {
+        rep.setEmailVerified(emailVerified);
+        return this;
+    }
+
+    public UserBuilder enabled(boolean enabled) {
+        rep.setEnabled(enabled);
+        return this;
+    }
+
+    public UserBuilder addRoles(String... roles) {
+        if (rep.getRealmRoles() == null) {
+            rep.setRealmRoles(new ArrayList<>());
+        }
+        rep.getRealmRoles().addAll(Arrays.asList(roles));
+        return this;
+    }
+
+    public UserBuilder role(String client, String role) {
+        if (rep.getClientRoles() == null) {
+            rep.setClientRoles(new HashMap<>());
+        }
+        if (rep.getClientRoles().get(client) == null) {
+            rep.getClientRoles().put(client, new LinkedList<>());
+        }
+        rep.getClientRoles().get(client).add(role);
+        return this;
+    }
+
+    public UserBuilder requiredAction(String requiredAction) {
+        if (rep.getRequiredActions() == null) {
+            rep.setRequiredActions(new LinkedList<>());
+        }
+        rep.getRequiredActions().add(requiredAction);
+        return this;
+    }
+
+    public UserBuilder serviceAccountId(String serviceAccountId) {
+        rep.setServiceAccountClientId(serviceAccountId);
+        return this;
+    }
+
+    public UserBuilder secret(CredentialRepresentation credential) {
+        if (rep.getCredentials() == null) {
+            rep.setCredentials(new LinkedList<>());
+        }
+
+        rep.getCredentials().add(credential);
+        rep.setTotp(true);
+        return this;
+    }
+
+//    public UserBuilder totpSecret(String totpSecret) {
+//        CredentialRepresentation credential = ModelToRepresentation.toRepresentation(
+//                OTPCredentialModel.createTOTP(totpSecret, 6, 30, HmacOTP.HMAC_SHA1));
+//        return secret(credential);
+//    }
+//
+//    public UserBuilder hotpSecret(String hotpSecret) {
+//        CredentialRepresentation credential = ModelToRepresentation.toRepresentation(
+//                OTPCredentialModel.createHOTP(hotpSecret, 6, 0, HmacOTP.HMAC_SHA1));
+//        return secret(credential);
+//    }
+
+    public UserBuilder otpEnabled() {
+        rep.setTotp(Boolean.TRUE);
+        return this;
+    }
+
+    public UserBuilder addGroups(String... group) {
+        if (rep.getGroups() == null) {
+            rep.setGroups(new ArrayList<>());
+        }
+        rep.getGroups().addAll(Arrays.asList(group));
+        return this;
+    }
+
+    public UserBuilder federatedLink(String identityProvider, String federatedUserId) {
+        if (rep.getFederatedIdentities() == null) {
+            rep.setFederatedIdentities(new LinkedList<>());
+        }
+        FederatedIdentityRepresentation federatedIdentity = new FederatedIdentityRepresentation();
+        federatedIdentity.setUserId(federatedUserId);
+        federatedIdentity.setUserName(rep.getUsername());
+        federatedIdentity.setIdentityProvider(identityProvider);
+
+        rep.getFederatedIdentities().add(federatedIdentity);
+        return this;
+    }
+
+    public UserRepresentation build() {
+        return rep;
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -1,0 +1,28 @@
+package org.keycloak.testsuite.util;
+
+
+import org.jboss.logging.Logger;
+import org.keycloak.client.testsuite.framework.KeycloakClientTestExtension;
+
+/**
+ *
+ * @author Petr Mensik
+ * @author tkyjovsk
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class WaitUtils {
+
+    private static final Logger logger = Logger.getLogger(KeycloakClientTestExtension.class);
+
+    public static void pause(long millis) {
+        if (millis > 0) {
+            logger.infof("Wait: %d ms", millis);
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException ex) {
+                logger.error("Interrupted", ex);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>keycloak-client-testsuite-parent</artifactId>
     <packaging>pom</packaging>
     <modules>
+        <module>providers</module>
         <module>framework</module>
         <module>admin-client-jee-tests</module>
         <module>admin-client-tests</module>

--- a/testsuite/providers/pom.xml
+++ b/testsuite/providers/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-client-testsuite-parent</artifactId>
+        <version>26.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>keycloak-client-testsuite-providers</artifactId>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+        <finalName>keycloak-client-testsuite-providers</finalName>
+    </build>
+</project>

--- a/testsuite/providers/src/main/resources/META-INF/keycloak-scripts.json
+++ b/testsuite/providers/src/main/resources/META-INF/keycloak-scripts.json
@@ -1,0 +1,122 @@
+{
+  "policies": [
+    {
+      "name": "Default Policy",
+      "fileName": "scripts/default-policy.js",
+      "description": "A policy that grants access only for users within this realm"
+    },
+    {
+      "name": "Only Owner Policy",
+      "fileName": "scripts/only-owner-policy.js",
+      "description": "Defines that only the resource owner is allowed to do something"
+    },
+    {
+      "name": "Only From a Specific Client Address",
+      "fileName": "scripts/only-from-specific-address-policy.js",
+      "description": "Defines that only clients from a specific address can do something"
+    },
+    {
+      "name": "Only From @keycloak.org or Admin",
+      "fileName": "scripts/only-from-specific-domain-or-admin-policy.js",
+      "description": "Defines that only users from @keycloak.org"
+    },
+    {
+      "name": "Claim A Policy",
+      "fileName": "scripts/add-claim-a-policy.js"
+    },
+    {
+      "name": "Policy Claim B",
+      "fileName": "scripts/add-claim-b-policy.js"
+    },
+    {
+      "name": "Policy Claim C",
+      "fileName": "scripts/add-claim-c-policy.js"
+    },
+    {
+      "name": "Deny Policy",
+      "fileName": "scripts/always-deny-policy.js"
+    },
+    {
+      "name": "Deny Policy With Claim",
+      "fileName": "scripts/always-deny-with-claim-policy.js"
+    },
+    {
+      "fileName": "scripts/withdraw-limit-policy.js"
+    },
+    {
+      "fileName": "scripts/resource-visibility-attribute-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-group-name-in-role-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-in-group-name-a-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-in-group-path-a-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-in-group-path-b-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-alice-in-group-child-e-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-alice-in-group-path-a-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-alice-in-group-path-a-no-parent-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-alice-in-group-path-e-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-alice-in-group-name-e-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-marta-in-role-a-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-marta-in-role-b-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-trinity-in-client-roles-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-trinity-in-client-role-b-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-child-group-in-role-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-realm-roles-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-client-roles-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-from-groups-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-user-with-attributes.js"
+    },
+    {
+      "fileName": "scripts/allow-resources-with-attributes.js"
+    },
+    {
+      "fileName": "scripts/check-readonly-context-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-group-in-role-policy.js"
+    },
+    {
+      "fileName": "scripts/deny-from-specific-address-policy.js"
+    },
+    {
+      "fileName": "scripts/allow-value-from-request-claim.js"
+    },
+    {
+      "fileName": "scripts/enforce-withdraw-limit-policy.js"
+    }
+  ]
+}

--- a/testsuite/providers/src/main/resources/scripts/add-claim-a-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/add-claim-a-policy.js
@@ -1,0 +1,1 @@
+$evaluation.getPermission().addClaim('claim-a', 'claim-a');$evaluation.getPermission().addClaim('claim-a', 'claim-a1');$evaluation.grant();

--- a/testsuite/providers/src/main/resources/scripts/add-claim-b-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/add-claim-b-policy.js
@@ -1,0 +1,1 @@
+$evaluation.getPermission().addClaim('claim-b', 'claim-b');$evaluation.grant();

--- a/testsuite/providers/src/main/resources/scripts/add-claim-c-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/add-claim-c-policy.js
@@ -1,0 +1,1 @@
+$evaluation.getPermission().addClaim('claim-c', 'claim-c');$evaluation.grant();

--- a/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-child-e-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-child-e-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('alice', '/Group A/Group B/Group E')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-name-e-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-name-e-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('alice', 'Group E')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-a-no-parent-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-a-no-parent-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (!realm.isUserInGroup('alice', '/Group A', false)) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-a-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-a-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('alice', '/Group A')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-e-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-alice-in-group-path-e-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('alice', '/Group E')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-child-group-in-role-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-child-group-in-role-policy.js
@@ -1,0 +1,6 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isGroupInRole('/Group A/Group D', 'role-b')) {
+    $evaluation.grant();
+}
+

--- a/testsuite/providers/src/main/resources/scripts/allow-group-in-role-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-group-in-role-policy.js
@@ -1,0 +1,6 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isGroupInRole('/Group A/Group D', 'role-a')) {
+    $evaluation.grant();
+}
+

--- a/testsuite/providers/src/main/resources/scripts/allow-group-name-in-role-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-group-name-in-role-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('marta', 'Group C')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-marta-in-role-a-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-marta-in-role-a-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInRealmRole('marta', 'role-a')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-marta-in-role-b-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-marta-in-role-b-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInRealmRole('marta', 'role-b')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-resources-with-attributes.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-resources-with-attributes.js
@@ -1,0 +1,9 @@
+var permission = $evaluation.getPermission();
+var resource = permission.getResource();
+var attributes = resource.getAttributes();
+
+if (attributes.size() == 2 && attributes.containsKey('a1') && attributes.containsKey('a2') && attributes.get('a1').size() == 2 && attributes.get('a2').get(0).equals('3') && resource.getAttribute('a1').size() == 2 && resource.getSingleAttribute('a2').equals('3')) {
+    $evaluation.grant();
+}
+
+

--- a/testsuite/providers/src/main/resources/scripts/allow-trinity-in-client-role-b-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-trinity-in-client-role-b-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInRealmRole('trinity', 'client-role-b')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-trinity-in-client-roles-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-trinity-in-client-roles-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInClientRole('trinity', 'role-mapping-client', 'client-role-a')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-client-roles-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-client-roles-policy.js
@@ -1,0 +1,6 @@
+var realm = $evaluation.getRealm();
+var roles = realm.getUserClientRoles('trinity', 'role-mapping-client');
+
+if (roles.size() == 1 && roles.contains('client-role-a')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-from-groups-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-from-groups-policy.js
@@ -1,0 +1,6 @@
+var realm = $evaluation.getRealm();
+var groups = realm.getUserGroups('jdoe');
+
+if (groups.size() == 2 && groups.contains('/Group A/Group B') && groups.contains('/Group A/Group D')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-in-group-name-a-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-in-group-name-a-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('marta', 'Group A')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-in-group-path-a-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-in-group-path-a-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('marta', '/Group A')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-in-group-path-b-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-in-group-path-b-policy.js
@@ -1,0 +1,5 @@
+var realm = $evaluation.getRealm();
+
+if (realm.isUserInGroup('marta', '/Group A/Group B')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-user-realm-roles-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-realm-roles-policy.js
@@ -1,0 +1,7 @@
+var realm = $evaluation.getRealm();
+var roles = realm.getUserRealmRoles('marta');
+
+if (roles.size() == 2 && roles.contains('uma_authorization') && roles.contains('role-a')) {
+    $evaluation.grant();
+}
+

--- a/testsuite/providers/src/main/resources/scripts/allow-user-with-attributes.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-user-with-attributes.js
@@ -1,0 +1,6 @@
+var realm = $evaluation.getRealm();
+var attributes = realm.getUserAttributes('jdoe');
+
+if (attributes.size() == 6 && attributes.containsKey('a1') && attributes.containsKey('a2') && attributes.get('a1').size() == 2 && attributes.get('a2').get(0).equals('3')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/allow-value-from-request-claim.js
+++ b/testsuite/providers/src/main/resources/scripts/allow-value-from-request-claim.js
@@ -1,0 +1,7 @@
+var context = $evaluation.getContext();
+var attributes = context.getAttributes();
+var claim = attributes.getValue('request-claim');
+
+if (claim && claim.asString(0) == 'expected-value') {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/always-deny-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/always-deny-policy.js
@@ -1,0 +1,1 @@
+$evaluation.deny();

--- a/testsuite/providers/src/main/resources/scripts/always-deny-with-claim-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/always-deny-with-claim-policy.js
@@ -1,0 +1,2 @@
+$evaluation.getPermission().addClaim('deny-policy', 'deny-policy');
+$evaluation.deny();

--- a/testsuite/providers/src/main/resources/scripts/check-readonly-context-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/check-readonly-context-policy.js
@@ -1,0 +1,1 @@
+$evaluation.getPermission().getResource().setName('test');

--- a/testsuite/providers/src/main/resources/scripts/default-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/default-policy.js
@@ -1,0 +1,1 @@
+$evaluation.grant();

--- a/testsuite/providers/src/main/resources/scripts/deny-from-specific-address-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/deny-from-specific-address-policy.js
@@ -1,0 +1,5 @@
+var contextAttributes = $evaluation.getContext().getAttributes();
+
+if (contextAttributes.containsValue('kc.client.network.ip_address', '127.3.3.3') || contextAttributes.containsValue('kc.client.network.ip_address', '0:0:0:0:0:ffff:7f03:303')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/enforce-withdraw-limit-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/enforce-withdraw-limit-policy.js
@@ -1,0 +1,7 @@
+var context = $evaluation.getContext();
+var attributes = context.getAttributes();
+var withdrawalAmount = attributes.getValue('withdrawal.amount');
+
+if (withdrawalAmount && withdrawalAmount.asDouble(0) <= 100) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/only-from-specific-address-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/only-from-specific-address-policy.js
@@ -1,0 +1,5 @@
+var contextAttributes = $evaluation.getContext().getAttributes();
+
+if (contextAttributes.containsValue('kc.client.network.ip_address', '127.0.0.1') || contextAttributes.containsValue('kc.client.network.ip_address', '0:0:0:0:0:0:0:1')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/only-from-specific-domain-or-admin-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/only-from-specific-domain-or-admin-policy.js
@@ -1,0 +1,8 @@
+var context = $evaluation.getContext();
+var identity = context.getIdentity();
+var attributes = identity.getAttributes();
+var email = attributes.getValue('email').asString(0);
+
+if (identity.hasRealmRole('admin') || email.endsWith('@keycloak.org')) {
+    $evaluation.grant();
+}

--- a/testsuite/providers/src/main/resources/scripts/only-owner-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/only-owner-policy.js
@@ -1,0 +1,9 @@
+var permission = $evaluation.getPermission();
+var identity = $evaluation.getContext().getIdentity();
+var resource = permission.getResource();
+
+if (resource) {
+    if (resource.getOwner().equals(identity.getId())) {
+        $evaluation.grant();
+    }
+}

--- a/testsuite/providers/src/main/resources/scripts/resource-visibility-attribute-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/resource-visibility-attribute-policy.js
@@ -1,0 +1,13 @@
+var createPermission = $evaluation.getPermission();
+var resource = createPermission.getResource();
+
+if (resource) {
+    var attributes = resource.getAttributes();
+    var visibility = attributes.get('visibility');
+
+    if (visibility && "private".equals(visibility.get(0))) {
+        $evaluation.deny();
+    } else {
+        $evaluation.grant();
+    }
+}

--- a/testsuite/providers/src/main/resources/scripts/withdraw-limit-policy.js
+++ b/testsuite/providers/src/main/resources/scripts/withdraw-limit-policy.js
@@ -1,0 +1,7 @@
+var context = $evaluation.getContext();
+var attributes = context.getAttributes();
+var withdrawValue = attributes.getValue('my.bank.account.withdraw.value');
+
+if (withdrawValue && withdrawValue.asDouble(0) <= 100) {
+    $evaluation.grant();
+}


### PR DESCRIPTION
closes keycloak/keycloak#31980

Moving `PolicyEnforcerTest` from Keycloak repository to keycloak-client repository.

- The test requires some javascript policies deployed on the Keycloak server. So I've created module `providers` in the testsuite for the providers to be deployed to the server and added the javascript policies. For now, I've copy/pasted all the policies from this directory https://github.com/keycloak/keycloak/tree/main/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/src/main/resources/scripts (Hence why so many changed files in this PR together with many enforcer files as mentioned below).

- Also copied all the enforcer configurations from this directory https://github.com/keycloak/keycloak/tree/main/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test (I hope we will be able to remove them from Keycloak main if we move all policy enforcer tests or whole policy enforcer)

- Also copied some utilities, mostly utilities for manipulating representation objects (like `RealmBuilder`, `UserBuilder` etc)

- For make the test passing on Keycloak 24, it is also this change needed in Keycloak main https://github.com/keycloak/keycloak/issues/32117 (Related PR https://github.com/keycloak/keycloak/pull/32118) . So I've also synced files after fix that one locally (Used separate commit for the synced files in this PR).
