### PR TITLE
Update snapshot version to 999.0.0-SNAPSHOT similarly like Keycloak has

### DIFF
--- a/admin-client/pom.xml
+++ b/admin-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-client-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authz-client/pom.xml
+++ b/authz-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/guides/pom.xml
+++ b/docs/guides/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-docs-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-docs-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/policy-enforcer/pom.xml
+++ b/policy-enforcer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </description>
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-client-parent</artifactId>
-    <version>26.0.0-SNAPSHOT</version>
+    <version>999.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -460,5 +460,6 @@
                 </plugins>
             </build>
         </profile>
+
    </profiles>
 </project>

--- a/set-version.sh
+++ b/set-version.sh
@@ -3,6 +3,6 @@
 NEW_VERSION=$1
 
 # Maven
-mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
+mvn versions:set -Pdocs -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
 echo "New Mvn Version: $NEW_VERSION" >&2

--- a/testsuite/admin-client-tests/pom.xml
+++ b/testsuite/admin-client-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-testsuite-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/authz-tests/pom.xml
+++ b/testsuite/authz-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-testsuite-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/framework/pom.xml
+++ b/testsuite/framework/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-testsuite-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/providers/pom.xml
+++ b/testsuite/providers/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-client-testsuite-parent</artifactId>
-        <version>26.0.0-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
closes #15

Since we have alpha release already, it's possibly good time to make snapshot versions aligned with the same versions as used by Keycloak codebase.