### PR TITLE
Aling quarkus deps to 3.13.x as keycloak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,14 +40,14 @@
         <freemarker.version>2.3.32</freemarker.version>
 
         <!-- Quarkus aligned versions -->
-        <resteasy.version>6.2.7.Final</resteasy.version>
-        <com.fasterxml.jackson.version>2.17.0</com.fasterxml.jackson.version>
+        <resteasy.version>6.2.9.Final</resteasy.version>
+        <com.fasterxml.jackson.version>2.17.2</com.fasterxml.jackson.version>
         <microprofile-openapi-api.version>3.1.1</microprofile-openapi-api.version>
-        <jboss-logging.version>3.5.3.Final</jboss-logging.version>
+        <jboss-logging.version>3.6.0.Final</jboss-logging.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <httpclient.version>4.5.14</httpclient.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
-        <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>
+        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
 
         <jboss.repo.nexusUrl>https://s01.oss.sonatype.org/</jboss.repo.nexusUrl>
         <jboss.releases.repo.id>ossrh</jboss.releases.repo.id>


### PR DESCRIPTION
Closes #39

Just updating the quarkus dependencies to be the same versions used in keycloak project.