### PR TITLE
Move AuthorizationAPITest and AuthorizationTest to keycloak-client

### DIFF
--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractAuthzTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractAuthzTest.java
@@ -3,15 +3,26 @@ package org.keycloak.client.testsuite.authz;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmsResource;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
 import org.keycloak.client.testsuite.common.OAuthClient;
 import org.keycloak.client.testsuite.framework.Inject;
 import org.keycloak.client.testsuite.common.RealmImporter;
 import org.keycloak.client.testsuite.common.RealmRepsSupplier;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.util.AuthzTestUtils;
+import org.keycloak.testsuite.util.KeycloakModelUtils;
 import org.keycloak.util.JsonSerialization;
 
 /**
@@ -27,6 +38,9 @@ public abstract class AbstractAuthzTest implements RealmRepsSupplier {
 
     @Inject
     protected OAuthClient oauth;
+
+    @Inject
+    protected CloseableHttpClient httpClient;
 
     @BeforeEach
     public void importRealms() {
@@ -49,5 +63,37 @@ public abstract class AbstractAuthzTest implements RealmRepsSupplier {
 
     public RealmsResource realmsResource() {
         return adminClient.realms();
+    }
+
+    protected AccessToken toAccessToken(String rpt) {
+        try {
+            return new JWSInput(rpt).readJsonContent(AccessToken.class);
+        } catch (JWSInputException cause) {
+            throw new RuntimeException("Failed to deserialize RPT", cause);
+        }
+    }
+
+    protected AuthzClient getAuthzClient(String filePath) {
+        try {
+            Configuration config = JsonSerialization.readValue(AuthzTestUtils.httpsAwareConfigurationStream(
+                    getClass().getResourceAsStream(filePath)), Configuration.class);
+            config.setHttpClient(httpClient);
+            return AuthzClient.create(config);
+        } catch (IOException cause) {
+            throw new RuntimeException("Failed to create authz client", cause);
+        }
+    }
+
+    protected ProtocolMapperRepresentation createPairwiseMapper(String sectorIdentifierUri) {
+        Map<String, String> config;
+        ProtocolMapperRepresentation pairwise = new ProtocolMapperRepresentation();
+        pairwise.setName("pairwise subject identifier");
+        pairwise.setProtocolMapper("oidc-sha256-pairwise-sub-mapper");
+        pairwise.setProtocol("openid-connect");
+        config = new HashMap<>();
+        config.put("sectorIdentifierUri", sectorIdentifierUri);
+        config.put("pairwiseSubAlgorithmSalt", KeycloakModelUtils.generateId());
+        pairwise.setConfig(config);
+        return pairwise;
     }
 }

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AuthorizationAPITest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AuthorizationAPITest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.client.testsuite.framework.PairwiseHttpServerExtension;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@ExtendWith(PairwiseHttpServerExtension.class)
+public class AuthorizationAPITest extends AbstractAuthzTest {
+
+    private static final String RESOURCE_SERVER_TEST = "resource-server-test";
+    private static final String TEST_CLIENT = "test-client";
+    private static final String AUTHZ_CLIENT_CONFIG = "/authorization-test/default-keycloak.json";
+    private static final String PAIRWISE_RESOURCE_SERVER_TEST = "pairwise-resource-server-test";
+    private static final String PAIRWISE_TEST_CLIENT = "test-client-pairwise";
+    private static final String PAIRWISE_AUTHZ_CLIENT_CONFIG = "/authorization-test/default-keycloak-pairwise.json";
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create().realmRole(RoleBuilder.create().name("uma_authorization").build()))
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password"))
+                .client(ClientBuilder.create().clientId(RESOURCE_SERVER_TEST)
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants())
+                .client(ClientBuilder.create().clientId(PAIRWISE_RESOURCE_SERVER_TEST)
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants()
+                    .protocolMapper(createPairwiseMapper(PairwiseHttpServerExtension.HTTP_URL)))
+                .client(ClientBuilder.create().clientId(TEST_CLIENT)
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/test-client")
+                    .directAccessGrants())
+                .client(ClientBuilder.create().clientId(PAIRWISE_TEST_CLIENT)
+                        .secret("secret")
+                        .authorizationServicesEnabled(true)
+                        .redirectUris("http://localhost/test-client")
+                        .directAccessGrants())
+                .build());
+
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        configureAuthorization(RESOURCE_SERVER_TEST);
+        configureAuthorization(PAIRWISE_RESOURCE_SERVER_TEST);
+    }
+
+    private void configureAuthorization(String clientId) throws Exception {
+        ClientResource client = getClient(getRealm(), clientId);
+        AuthorizationResource authorization = client.authorization();
+        ResourceRepresentation resource = new ResourceRepresentation("Resource A");
+
+        Response response = authorization.resources().create(resource);
+        response.close();
+
+        JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+        policy.setName("Default Policy");
+        policy.setType("script-scripts/default-policy.js");
+
+        response = authorization.policies().js().create(policy);
+        response.close();
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy(policy.getName());
+
+        response = authorization.permissions().resource().create(permission);
+        response.close();
+    }
+
+    @Test
+    public void testAccessTokenWithUmaAuthorization() {
+        testAccessTokenWithUmaAuthorization(AUTHZ_CLIENT_CONFIG);
+    }
+
+    @Test
+    public void testAccessTokenWithUmaAuthorizationPairwise() {
+        testAccessTokenWithUmaAuthorization(PAIRWISE_AUTHZ_CLIENT_CONFIG);
+    }
+
+    public void testAccessTokenWithUmaAuthorization(String authzConfigFile) {
+        AuthzClient authzClient = getAuthzClient(authzConfigFile);
+        PermissionRequest request = new PermissionRequest("Resource A");
+
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testResourceServerAsAudience() throws Exception {
+        testResourceServerAsAudience(
+                TEST_CLIENT,
+                RESOURCE_SERVER_TEST,
+                AUTHZ_CLIENT_CONFIG);
+    }
+
+    @Test
+    public void testResourceServerAsAudienceWithPairwiseClient() throws Exception {
+        testResourceServerAsAudience(
+                PAIRWISE_TEST_CLIENT,
+                RESOURCE_SERVER_TEST,
+                AUTHZ_CLIENT_CONFIG);
+    }
+
+    @Test
+    public void testPairwiseResourceServerAsAudience() throws Exception {
+        testResourceServerAsAudience(
+                TEST_CLIENT,
+                PAIRWISE_RESOURCE_SERVER_TEST,
+                PAIRWISE_AUTHZ_CLIENT_CONFIG);
+    }
+
+    @Test
+    public void testPairwiseResourceServerAsAudienceWithPairwiseClient() throws Exception {
+        testResourceServerAsAudience(
+                PAIRWISE_TEST_CLIENT,
+                PAIRWISE_RESOURCE_SERVER_TEST,
+                PAIRWISE_AUTHZ_CLIENT_CONFIG);
+    }
+
+    @Test
+    public void testResponseMode() {
+        AuthzClient authzClient = getAuthzClient(AUTHZ_CLIENT_CONFIG);
+        PermissionRequest permission = new PermissionRequest("Resource A");
+
+        String ticket = authzClient.protection().permission().create(permission).getTicket();
+        AuthorizationRequest request = new AuthorizationRequest(ticket);
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(request);
+        Assertions.assertNotNull(response.getToken());
+
+        request.setMetadata(new AuthorizationRequest.Metadata());
+        request.getMetadata().setResponseMode("decision");
+        response = authzClient.authorization("marta", "password").authorize(request);
+        Assertions.assertNull(response.getToken());
+        Assertions.assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        List<Permission> permissions = authzClient.authorization("marta", "password").getPermissions(request);
+        Assertions.assertFalse(permissions.isEmpty());
+        Assertions.assertTrue(permissions.get(0) instanceof Permission);
+    }
+
+    public void testResourceServerAsAudience(String clientId, String resourceServerClientId, String authzConfigFile) throws Exception {
+        AuthzClient authzClient = getAuthzClient(authzConfigFile);
+        PermissionRequest request = new PermissionRequest();
+
+        request.setResourceId("Resource A");
+
+        String accessToken = oauth.realm("authz-test").clientId(clientId).doGrantAccessTokenRequest("secret", "marta", "password").getAccessToken();
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        // Ticket is opaque to client or resourceServer. The audience should be just an authorization server itself
+        JsonWebToken ticketDecoded = JsonSerialization.readValue(new JWSInput(ticket).getContent(), JsonWebToken.class);
+        Assertions.assertFalse(ticketDecoded.hasAudience(clientId));
+        Assertions.assertFalse(ticketDecoded.hasAudience(resourceServerClientId));
+
+        AuthorizationResponse response = authzClient.authorization(accessToken).authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+        AccessToken rpt = toAccessToken(response.getToken());
+        Assertions.assertEquals(resourceServerClientId, rpt.getAudience()[0]);
+    }
+
+    private RealmResource getRealm() {
+        return adminClient.realm("authz-test");
+    }
+
+    private ClientResource getClient(RealmResource realm, String clientId) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId(clientId).stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AuthorizationTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AuthorizationTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.ResourcesResource;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessToken.Authorization;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.ResourceOwnerRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class AuthorizationTest extends AbstractAuthzTest {
+
+    private AuthzClient authzClient;
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create().realmRole(RoleBuilder.create().name("uma_authorization").build()))
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants())
+                .client(ClientBuilder.create().clientId("test-client")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/test-client")
+                    .directAccessGrants())
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        ClientResource client = getClient();
+        AuthorizationResource authorization = client.authorization();
+
+        JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+        policy.setName("Grant Policy");
+        policy.setType("script-scripts/default-policy.js");
+
+        authorization.policies().js().create(policy).close();
+
+        policy = new JSPolicyRepresentation();
+
+        policy.setName("Deny Policy");
+        policy.setType("script-scripts/always-deny-policy.js");
+    }
+
+    @AfterEach
+    public void onAfter() {
+        ResourcesResource resources = getClient().authorization().resources();
+        List<ResourceRepresentation> existingResources = resources.resources();
+
+        for (ResourceRepresentation resource : existingResources) {
+            resources.resource(resource.getId()).remove();
+        }
+    }
+
+    @Test
+    public void testResourceWithSameNameDifferentOwner() throws JWSInputException {
+        ResourceRepresentation koloResource = createResource("Resource A", "kolo", "Scope A", "Scope B");
+
+        createResourcePermission(koloResource, "Grant Policy");
+
+        ResourceRepresentation martaResource = createResource("Resource A", "marta", "Scope A", "Scope B");
+
+        createResourcePermission(martaResource, "Grant Policy");
+
+        Assertions.assertNotEquals(koloResource.getId(), martaResource.getId());
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission("Resource A");
+
+        List<Permission> permissions = authorize("kolo", "password", request);
+
+        Assertions.assertEquals(1, permissions.size());
+
+        Permission permission = permissions.get(0);
+        Assertions.assertTrue(permission.getScopes().containsAll(Arrays.asList("Scope A", "Scope B")));
+
+        Assertions.assertEquals(koloResource.getId(), permission.getResourceId());
+
+        permissions = authorize("marta", "password", request);
+
+        Assertions.assertEquals(1, permissions.size());
+
+        permission = permissions.get(0);
+
+        Assertions.assertEquals(martaResource.getId(), permission.getResourceId());
+        Assertions.assertTrue(permission.getScopes().containsAll(Arrays.asList("Scope A", "Scope B")));
+    }
+
+    @Test
+    public void testResourceServerWithSameNameDifferentOwner() {
+        ResourceRepresentation koloResource = createResource("Resource A", "kolo", "Scope A", "Scope B");
+
+        createResourcePermission(koloResource, "Grant Policy");
+
+        ResourceRepresentation serverResource = createResource("Resource A", null, "Scope A", "Scope B");
+
+        createResourcePermission(serverResource, "Grant Policy");
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission("Resource A");
+
+        List<Permission> permissions = authorize("kolo", "password", request);
+
+        Assertions.assertEquals(2, permissions.size());
+
+        for (Permission permission : permissions) {
+            Assertions.assertTrue(permission.getResourceId().equals(koloResource.getId()) || permission.getResourceId().equals(serverResource.getId()));
+            Assertions.assertEquals("Resource A", permission.getResourceName());
+        }
+    }
+
+    private List<Permission> authorize(String userName, String password, AuthorizationRequest request) {
+        AuthorizationResponse response = getAuthzClient().authorization(userName, password).authorize(request);
+        AccessToken token = toAccessToken(response.getToken());
+        Authorization authorization = token.getAuthorization();
+        return new ArrayList<>(authorization.getPermissions());
+    }
+
+    private void createResourcePermission(ResourceRepresentation resource, String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + UUID.randomUUID().toString());
+        permission.addResource(resource.getId());
+        permission.addPolicy(policies);
+
+        try (Response response = getClient().authorization().permissions().resource().create(permission)) {
+            Assertions.assertEquals(201, response.getStatus());
+        }
+    }
+
+    private ResourceRepresentation createResource(String name, String owner, String... scopes) {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName(name);
+        resource.setOwner(owner != null ? new ResourceOwnerRepresentation(owner) : null);
+        resource.addScope(scopes);
+
+        ResourceRepresentation stored;
+        try (Response response = getClient().authorization().resources().create(resource)) {
+            stored = response.readEntity(ResourceRepresentation.class);
+        }
+
+        resource.setId(stored.getId());
+
+        return resource;
+    }
+
+    private RealmResource getRealm() {
+        return adminClient.realm("authz-test");
+    }
+
+    private ClientResource getClient() {
+        ClientsResource clients = getRealm().clients();
+        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+
+    private AuthzClient getAuthzClient() {
+        if (authzClient == null) {
+            return getAuthzClient("/authorization-test/default-keycloak.json");
+        }
+
+        return authzClient;
+    }
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/default-keycloak-pairwise.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/default-keycloak-pairwise.json
@@ -1,0 +1,8 @@
+{
+    "realm": "authz-test",
+    "auth-server-url" : "http://localhost:8180",
+    "resource" : "pairwise-resource-server-test",
+    "credentials": {
+        "secret": "secret"
+    }
+}

--- a/testsuite/authz-tests/src/test/resources/authorization-test/default-keycloak.json
+++ b/testsuite/authz-tests/src/test/resources/authorization-test/default-keycloak.json
@@ -1,0 +1,8 @@
+{
+    "realm": "authz-test",
+    "auth-server-url" : "http://localhost:8180",
+    "resource" : "resource-server-test",
+    "credentials": {
+        "secret": "secret"
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/framework/PairwiseHttpServerExtension.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/framework/PairwiseHttpServerExtension.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.framework;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.Testcontainers;
+
+/**
+ * <p>Simple extension to start a HTTP server for pairwise redirect URIs responses.
+ * It runs in port 8280 and fixes the response. The sectorIdentifierUri in the
+ * pairwise mapper should be <em>http://host.testcontainers.internal:8280</em>.
+ * </p>
+ *
+ * @author rmartinc
+ */
+public class PairwiseHttpServerExtension implements AfterAllCallback, BeforeAllCallback {
+
+    public static final int HTTP_PORT = 8280;
+    public static final String PAIRWISE_RESPONSE = "[\"http://localhost/resource-server-test\"]";
+    public static final String HTTP_URL = "http://host.testcontainers.internal:" + HTTP_PORT;
+
+    private HttpServer server;
+
+    private class MyHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            // just return the same data received, headers inclusive
+            if ("GET".equals(exchange.getRequestMethod())) {
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                byte[] data = PAIRWISE_RESPONSE.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, data.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(data);
+                }
+            } else {
+                exchange.sendResponseHeaders(400, 0);
+            }
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext ec) throws Exception {
+        server.stop(0);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext ec) throws Exception {
+        server = HttpServer.create(new InetSocketAddress(HTTP_PORT), 0);
+        server.createContext("/", new MyHandler());
+        server.setExecutor(null); // creates a default executor
+        server.start();
+        Testcontainers.exposeHostPorts(HTTP_PORT);
+    }
+
+}


### PR DESCRIPTION
Closes #46

Just the two first authz classes moved from keycloak to keycloak-client. These two have no issues at all. Only that the API one uses a pairwise mapper that needs an HTTP server to download the redirect URIs. I have just added a simple extension with fixed data. I tyhin this will be re-used in other tests that use pairwise.