### PR TITLE
Move Group*, PermissionClaimTest and PermissionEqualsTest to keycloak-client

### DIFF
--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupNamePolicyTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupNamePolicyTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class GroupNamePolicyTest extends AbstractAuthzTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        ProtocolMapperRepresentation groupProtocolMapper = new ProtocolMapperRepresentation();
+
+        groupProtocolMapper.setName("groups");
+        groupProtocolMapper.setProtocolMapper("oidc-group-membership-mapper");
+        groupProtocolMapper.setProtocol("openid-connect");
+        Map<String, String> config = new HashMap<>();
+        config.put("claim.name", "groups");
+        config.put("access.token.claim", "true");
+        config.put("id.token.claim", "true");
+        groupProtocolMapper.setConfig(config);
+
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                )
+                .group(GroupBuilder.create().name("Group A")
+                    .subGroups(Arrays.asList("Group B", "Group D").stream().map(name -> {
+                        if ("Group B".equals(name)) {
+                            return GroupBuilder.create().name(name).subGroups(Arrays.asList("Group C", "Group E").stream().map((String name1)
+                                    -> GroupBuilder.create().name(name1).build()).collect(Collectors.toList())).build();
+                        }
+                        return GroupBuilder.create().name(name).build();
+                    }).collect(Collectors.toList())).build())
+                .group(GroupBuilder.create().name("Group E").build())
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization").addGroups("Group A"))
+                .user(UserBuilder.create().username("alice").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password").addRoles("uma_authorization"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants()
+                    .protocolMapper(groupProtocolMapper)
+                    .serviceAccountsEnabled(true))
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        createResource("Resource A");
+        createResource("Resource B");
+        createResource("Resource C");
+
+        createGroupPolicy("Only Group A Policy", "/Group A", true);
+        createGroupPolicy("Only Group B Policy", "/Group A/Group B", false);
+        createGroupPolicy("Only Group C Policy", "/Group A/Group B/Group C", false);
+
+        createResourcePermission("Resource A Permission", "Resource A", "Only Group A Policy");
+        createResourcePermission("Resource B Permission", "Resource B", "Only Group B Policy");
+        createResourcePermission("Resource C Permission", "Resource C", "Only Group C Policy");
+
+        RealmResource realm = getRealm();
+        GroupRepresentation group = getGroup("/Group A/Group B/Group C");
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        realm.users().get(user.getId()).joinGroup(group.getId());
+
+        group = getGroup("/Group A/Group B");
+        user = realm.users().search("alice").get(0);
+
+        realm.users().get(user.getId()).joinGroup(group.getId());
+    }
+
+    @Test
+    public void testExactNameMatch() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+
+        try {
+            authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected group");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+
+        try {
+            authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected group");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+
+        try {
+            authzClient.authorization(authzClient.obtainAccessToken().getToken()).authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because service account is not granted with expected group");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+    }
+
+    @Test
+    public void testOnlyChildrenPolicy() throws Exception {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource B");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        try {
+            authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected group");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+
+        AuthorizationResponse response = authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+
+        try {
+            authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected role");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+
+        request = new PermissionRequest("Resource C");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    private void createGroupPolicy(String name, String groupPath, boolean extendChildren) {
+        GroupPolicyRepresentation policy = new GroupPolicyRepresentation();
+
+        policy.setName(name);
+        policy.setGroupsClaim("groups");
+        policy.addGroupPath(groupPath, extendChildren);
+
+        getClient().authorization().policies().group().create(policy).close();
+    }
+
+    private void createResourcePermission(String name, String resource, String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(name);
+        permission.addResource(resource);
+        permission.addPolicy(policies);
+
+        getClient().authorization().permissions().resource().create(permission).close();
+    }
+
+    private void createResource(String name) {
+        AuthorizationResource authorization = getClient().authorization();
+        ResourceRepresentation resource = new ResourceRepresentation(name);
+
+        authorization.resources().create(resource).close();
+    }
+
+    private RealmResource getRealm() {
+        try {
+            return adminClient.realm("authz-test");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create admin client");
+        }
+    }
+
+    private ClientResource getClient(RealmResource realm) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+
+    private AuthzClient getAuthzClient() {
+        return getAuthzClient("/authorization-test/default-keycloak.json");
+    }
+
+    private ClientResource getClient() {
+        return getClient(getRealm());
+    }
+
+    private GroupRepresentation getGroup(String path) {
+        String[] parts = path.split("/");
+        RealmResource realm = getRealm();
+        GroupRepresentation parent = null;
+
+        for (String part : parts) {
+            if ("".equals(part)) {
+                continue;
+            }
+            if (parent == null) {
+                parent = realm.groups().groups().stream().filter((GroupRepresentation groupRepresentation)
+                        -> part.equals(groupRepresentation.getName())).findFirst().get();
+                continue;
+            }
+
+            GroupRepresentation group = getGroup(part, realm.groups().group(parent.getId()).getSubGroups(0, 10, true));
+
+            if (path.endsWith(group.getName())) {
+                return group;
+            }
+
+            parent = group;
+        }
+
+        return null;
+    }
+
+    private GroupRepresentation getGroup(String name, List<GroupRepresentation> groups) {
+        RealmResource realm = getRealm();
+        for (GroupRepresentation group : groups) {
+            if (name.equals(group.getName())) {
+                return group;
+            }
+
+            GroupRepresentation child = getGroup(name, realm.groups().group(group.getId()).getSubGroups(0, 10, true));
+
+            if (child != null && name.equals(child.getName())) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupPathPolicyTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupPathPolicyTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class GroupPathPolicyTest extends AbstractAuthzTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        ProtocolMapperRepresentation groupProtocolMapper = new ProtocolMapperRepresentation();
+
+        groupProtocolMapper.setName("groups");
+        groupProtocolMapper.setProtocolMapper("oidc-group-membership-mapper");
+        groupProtocolMapper.setProtocol("openid-connect");
+        Map<String, String> config = new HashMap<>();
+        config.put("claim.name", "groups");
+        config.put("access.token.claim", "true");
+        config.put("id.token.claim", "true");
+        config.put("full.path", "true");
+        groupProtocolMapper.setConfig(config);
+
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                )
+                .group(GroupBuilder.create().name("Group A")
+                    .subGroups(Arrays.asList("Group B", "Group D").stream().map(name -> {
+                        if ("Group B".equals(name)) {
+                            return GroupBuilder.create().name(name).subGroups(Arrays.asList("Group C", "Group E").stream().map((String name1)
+                                    -> GroupBuilder.create().name(name1).build()).collect(Collectors.toList())).build();
+                        }
+                        return GroupBuilder.create().name(name).build();
+                    }).collect(Collectors.toList())).build())
+                .group(GroupBuilder.create().name("Group E").build())
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization").addGroups("Group A"))
+                .user(UserBuilder.create().username("alice").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password").addRoles("uma_authorization"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants()
+                    .protocolMapper(groupProtocolMapper))
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        createResource("Resource A");
+        createResource("Resource B");
+
+        createGroupPolicy("Parent And Children Policy", "/Group A", true);
+        createGroupPolicy("Only Children Policy", "/Group A/Group B/Group C", false);
+
+        createResourcePermission("Resource A Permission", "Resource A", "Parent And Children Policy");
+        createResourcePermission("Resource B Permission", "Resource B", "Only Children Policy");
+    }
+
+    @Test
+    public void testAllowParentAndChildren() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+
+        RealmResource realm = getRealm();
+        GroupRepresentation group = getGroup("/Group A/Group B/Group C");
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        realm.users().get(user.getId()).joinGroup(group.getId());
+
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testOnlyChildrenPolicy() throws Exception {
+        RealmResource realm = getRealm();
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource B");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        try {
+            authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected role");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+
+        GroupRepresentation group = getGroup("/Group A/Group B/Group C");
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        realm.users().get(user.getId()).joinGroup(group.getId());
+
+        AuthorizationResponse response = authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+
+        try {
+            authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+            Assertions.fail("Should fail because user is not granted with expected role");
+        } catch (AuthorizationDeniedException ignore) {
+
+        }
+    }
+
+    private void createGroupPolicy(String name, String groupPath, boolean extendChildren) {
+        GroupPolicyRepresentation policy = new GroupPolicyRepresentation();
+
+        policy.setName(name);
+        policy.setGroupsClaim("groups");
+        policy.addGroupPath(groupPath, extendChildren);
+
+        getClient().authorization().policies().group().create(policy).close();
+    }
+
+    private void createResourcePermission(String name, String resource, String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(name);
+        permission.addResource(resource);
+        permission.addPolicy(policies);
+
+        getClient().authorization().permissions().resource().create(permission).close();
+    }
+
+    private void createResource(String name) {
+        AuthorizationResource authorization = getClient().authorization();
+        ResourceRepresentation resource = new ResourceRepresentation(name);
+
+        authorization.resources().create(resource).close();
+    }
+
+    private RealmResource getRealm() {
+        try {
+            return adminClient.realm("authz-test");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create admin client");
+        }
+    }
+
+    private ClientResource getClient(RealmResource realm) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+
+    private AuthzClient getAuthzClient() {
+        return getAuthzClient("/authorization-test/default-keycloak.json");
+    }
+
+    private ClientResource getClient() {
+        return getClient(getRealm());
+    }
+
+    private GroupRepresentation getGroup(String path) {
+        String[] parts = path.split("/");
+        RealmResource realm = getRealm();
+        GroupRepresentation parent = null;
+
+        for (String part : parts) {
+            if ("".equals(part)) {
+                continue;
+            }
+            if (parent == null) {
+                parent = realm.groups().groups().stream().filter((GroupRepresentation groupRepresentation)
+                        -> part.equals(groupRepresentation.getName())).findFirst().get();
+                continue;
+            }
+
+            GroupRepresentation group = getGroup(part, realm.groups().group(parent.getId()).getSubGroups(0, 10, true));
+
+            if (path.endsWith(group.getName())) {
+                return group;
+            }
+
+            parent = group;
+        }
+
+        return null;
+    }
+
+    private GroupRepresentation getGroup(String name, List<GroupRepresentation> groups) {
+        RealmResource realm = getRealm();
+        for (GroupRepresentation group : groups) {
+            if (name.equals(group.getName())) {
+                return group;
+            }
+
+            GroupRepresentation child = getGroup(name, realm.groups().group(group.getId()).getSubGroups(0, 10, true));
+
+            if (child != null && name.equals(child.getName())) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupPathWithoutGroupClaimPolicyTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/GroupPathWithoutGroupClaimPolicyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class GroupPathWithoutGroupClaimPolicyTest extends GroupPathPolicyTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        ProtocolMapperRepresentation groupProtocolMapper = new ProtocolMapperRepresentation();
+
+        groupProtocolMapper.setName("groups");
+        groupProtocolMapper.setProtocolMapper("oidc-group-membership-mapper");
+        groupProtocolMapper.setProtocol("openid-connect");
+        Map<String, String> config = new HashMap<>();
+        config.put("claim.name", "groups");
+        config.put("access.token.claim", "true");
+        config.put("id.token.claim", "true");
+        groupProtocolMapper.setConfig(config);
+
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                )
+                .group(GroupBuilder.create().name("Group A")
+                    .subGroups(Arrays.asList("Group B", "Group D").stream().map(name -> {
+                        if ("Group B".equals(name)) {
+                            return GroupBuilder.create().name(name).subGroups(Arrays.asList("Group C", "Group E").stream()
+                                    .map((String name1) -> GroupBuilder.create().name(name1).build())
+                                    .collect(Collectors.toList())).build();
+                        }
+                        return GroupBuilder.create().name(name).build();
+                    }).collect(Collectors.toList())).build())
+                .group(GroupBuilder.create().name("Group E").build())
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization").addGroups("Group A"))
+                .user(UserBuilder.create().username("alice").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password").addRoles("uma_authorization"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants())
+                .build());
+        return testRealms;
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/PermissionClaimTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/PermissionClaimTest.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.ResourcesResource;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.util.HttpResponseException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessToken.Authorization;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.KeycloakModelUtils;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionClaimTest extends AbstractAuthzTest {
+
+    private JSPolicyRepresentation claimAPolicy;
+    private JSPolicyRepresentation claimBPolicy;
+    private JSPolicyRepresentation claimCPolicy;
+    private JSPolicyRepresentation denyPolicy;
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create().realmRole(RoleBuilder.create().name("uma_authorization").build()))
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization"))
+                .user(UserBuilder.create().username("kolo").password("password"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants())
+                .client(ClientBuilder.create().clientId("test-client")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/test-client")
+                    .directAccessGrants())
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        claimAPolicy = new JSPolicyRepresentation();
+
+        claimAPolicy.setName("Claim A Policy");
+        claimAPolicy.setType("script-scripts/add-claim-a-policy.js");
+
+        authorization.policies().js().create(claimAPolicy).close();
+
+        claimBPolicy = new JSPolicyRepresentation();
+
+        claimBPolicy.setName("Policy Claim B");
+        claimBPolicy.setType("script-scripts/add-claim-b-policy.js");
+
+        authorization.policies().js().create(claimBPolicy).close();
+
+        claimCPolicy = new JSPolicyRepresentation();
+
+        claimCPolicy.setName("Policy Claim C");
+        claimCPolicy.setType("script-scripts/add-claim-c-policy.js");
+
+        authorization.policies().js().create(claimCPolicy).close();
+
+        denyPolicy = new JSPolicyRepresentation();
+
+        denyPolicy.setName("Deny Policy");
+        denyPolicy.setType("script-scripts/always-deny-with-claim-policy.js");
+
+        authorization.policies().js().create(denyPolicy).close();
+    }
+
+    @AfterEach
+    public void removeAuthorization() throws Exception {
+        ClientResource client = getClient(getRealm());
+        ClientRepresentation representation = client.toRepresentation();
+
+        representation.setAuthorizationServicesEnabled(false);
+
+        client.update(representation);
+
+        representation.setAuthorizationServicesEnabled(true);
+
+        client.update(representation);
+
+        ResourcesResource resources = client.authorization().resources();
+        List<ResourceRepresentation> defaultResource = resources.findByName("Default Resource");
+
+        resources.resource(defaultResource.get(0).getId()).remove();
+    }
+
+    @Test
+    public void testPermissionWithClaims() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+        ResourceRepresentation resource = new ResourceRepresentation("Resource A");
+
+        authorization.resources().create(resource).close();
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy(claimAPolicy.getName());
+
+        authorization.permissions().resource().create(permission).close();
+
+        PermissionRequest request = new PermissionRequest();
+
+        request.setResourceId(resource.getName());
+
+        String accessToken = oauth.realm("authz-test").clientId("test-client").doGrantAccessTokenRequest("secret", "marta", "password").getAccessToken();
+        AuthzClient authzClient = getAuthzClient("/authorization-test/default-keycloak.json");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization(accessToken).authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+        AccessToken rpt = toAccessToken(response.getToken());
+        Authorization authorizationClaim = rpt.getAuthorization();
+        List<Permission> permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(1, permissions.size());
+
+        Assertions.assertTrue(permissions.get(0).getClaims().get("claim-a").containsAll(Arrays.asList("claim-a", "claim-a1")));
+    }
+
+    @Test
+    public void testPermissionWithClaimsDifferentPolicies() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        ResourceRepresentation resource = new ResourceRepresentation("Resource B");
+
+        authorization.resources().create(resource).close();
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getName());
+        permission.addPolicy(claimAPolicy.getName(), claimBPolicy.getName());
+
+        authorization.permissions().resource().create(permission).close();
+
+        PermissionRequest request = new PermissionRequest();
+
+        request.setResourceId(resource.getName());
+
+        String accessToken = oauth.realm("authz-test").clientId("test-client").doGrantAccessTokenRequest("secret", "marta", "password").getAccessToken();
+        AuthzClient authzClient = getAuthzClient("/authorization-test/default-keycloak.json");
+        String ticket = authzClient.protection().permission().forResource(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization(accessToken).authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+        AccessToken rpt = toAccessToken(response.getToken());
+        Authorization authorizationClaim = rpt.getAuthorization();
+        List<Permission> permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(1, permissions.size());
+
+        Map<String, Set<String>> claims = permissions.get(0).getClaims();
+
+        Assertions.assertTrue(claims.containsKey("claim-a"));
+        Assertions.assertTrue(claims.containsKey("claim-b"));
+    }
+
+    @Test
+    public void testClaimsFromDifferentScopePermissions() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        ResourceRepresentation resourceA = new ResourceRepresentation(KeycloakModelUtils.generateId(), "create", "update");
+
+        authorization.resources().create(resourceA).close();
+
+        ResourceRepresentation resourceB = new ResourceRepresentation(KeycloakModelUtils.generateId(), "create", "update");
+
+        authorization.resources().create(resourceB).close();
+
+        ScopePermissionRepresentation allScopesPermission = new ScopePermissionRepresentation();
+
+        allScopesPermission.setName(KeycloakModelUtils.generateId());
+        allScopesPermission.addScope("create", "update");
+        allScopesPermission.addPolicy(claimAPolicy.getName(), claimBPolicy.getName());
+
+        authorization.permissions().scope().create(allScopesPermission).close();
+
+        ScopePermissionRepresentation updatePermission = new ScopePermissionRepresentation();
+
+        updatePermission.setName(KeycloakModelUtils.generateId());
+        updatePermission.addScope("update");
+        updatePermission.addPolicy(claimCPolicy.getName());
+
+        try (Response response = authorization.permissions().scope().create(updatePermission)) {
+            updatePermission = response.readEntity(ScopePermissionRepresentation.class);
+        }
+
+        AuthzClient authzClient = getAuthzClient("/authorization-test/default-keycloak.json");
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(null, "create", "update");
+
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(request);
+        Assertions.assertNotNull(response.getToken());
+        AccessToken rpt = toAccessToken(response.getToken());
+        Authorization authorizationClaim = rpt.getAuthorization();
+        List<Permission> permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(2, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+        }
+
+        updatePermission.addPolicy(denyPolicy.getName());
+        authorization.permissions().scope().findById(updatePermission.getId()).update(updatePermission);
+
+        response = authzClient.authorization("marta", "password").authorize(request);
+        Assertions.assertNotNull(response.getToken());
+        rpt = toAccessToken(response.getToken());
+        authorizationClaim = rpt.getAuthorization();
+        permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(2, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+            MatcherAssert.assertThat(claims.get("deny-policy"), Matchers.containsInAnyOrder("deny-policy"));
+        }
+    }
+
+    @Test
+    public void testClaimsFromDifferentResourcePermissions() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        ResourceRepresentation resourceA = new ResourceRepresentation(KeycloakModelUtils.generateId());
+
+        resourceA.setType("typed-resource");
+
+        authorization.resources().create(resourceA).close();
+
+        ResourcePermissionRepresentation allScopesPermission = new ResourcePermissionRepresentation();
+
+        allScopesPermission.setName(KeycloakModelUtils.generateId());
+        allScopesPermission.addResource(resourceA.getName());
+        allScopesPermission.addPolicy(claimAPolicy.getName(), claimBPolicy.getName());
+
+        authorization.permissions().resource().create(allScopesPermission).close();
+
+        ResourcePermissionRepresentation updatePermission = new ResourcePermissionRepresentation();
+
+        updatePermission.setName(KeycloakModelUtils.generateId());
+        updatePermission.addResource(resourceA.getName());
+        updatePermission.addPolicy(claimCPolicy.getName());
+
+        try (Response response = authorization.permissions().resource().create(updatePermission)) {
+            updatePermission = response.readEntity(ResourcePermissionRepresentation.class);
+        }
+
+        AuthzClient authzClient = getAuthzClient("/authorization-test/default-keycloak.json");
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize();
+        Assertions.assertNotNull(response.getToken());
+        AccessToken rpt = toAccessToken(response.getToken());
+        Authorization authorizationClaim = rpt.getAuthorization();
+        List<Permission> permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(1, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+        }
+
+        updatePermission.addPolicy(denyPolicy.getName());
+        authorization.permissions().resource().findById(updatePermission.getId()).update(updatePermission);
+
+        try {
+            authzClient.authorization("marta", "password").authorize();
+            Assertions.fail("can not access resource");
+        } catch (RuntimeException expected) {
+            Assertions.assertEquals(403, HttpResponseException.class.cast(expected.getCause()).getStatusCode());
+            Assertions.assertTrue(HttpResponseException.class.cast(expected.getCause()).toString().contains("access_denied"));
+        }
+
+        ResourceRepresentation resourceInstance = new ResourceRepresentation(KeycloakModelUtils.generateId(), "create", "update");
+
+        resourceInstance.setType(resourceA.getType());
+        resourceInstance.setOwner("marta");
+
+        try (Response response1 = authorization.resources().create(resourceInstance)) {
+            resourceInstance = response1.readEntity(ResourceRepresentation.class);
+        }
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(null, "create", "update");
+
+        try {
+            authzClient.authorization("marta", "password").authorize(request);
+            Assertions.fail("can not access resource");
+        } catch (RuntimeException expected) {
+            Assertions.assertEquals(403, HttpResponseException.class.cast(expected.getCause()).getStatusCode());
+            Assertions.assertTrue(HttpResponseException.class.cast(expected.getCause()).toString().contains("access_denied"));
+        }
+
+        ResourcePermissionRepresentation resourceInstancePermission = new ResourcePermissionRepresentation();
+
+        resourceInstancePermission.setName(KeycloakModelUtils.generateId());
+        resourceInstancePermission.addResource(resourceInstance.getId());
+        resourceInstancePermission.addPolicy(claimCPolicy.getName());
+
+        try (Response response1 = authorization.permissions().resource().create(resourceInstancePermission)) {
+            response1.readEntity(ResourcePermissionRepresentation.class);
+        }
+
+        response = authzClient.authorization("marta", "password").authorize(request);
+        Assertions.assertNotNull(response.getToken());
+        rpt = toAccessToken(response.getToken());
+        authorizationClaim = rpt.getAuthorization();
+        permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(1, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+            MatcherAssert.assertThat(claims.get("deny-policy"), Matchers.containsInAnyOrder("deny-policy"));
+        }
+
+        response = authzClient.authorization("marta", "password").authorize();
+        Assertions.assertNotNull(response.getToken());
+        rpt = toAccessToken(response.getToken());
+        authorizationClaim = rpt.getAuthorization();
+        permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(1, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+            MatcherAssert.assertThat(claims.get("deny-policy"), Matchers.containsInAnyOrder("deny-policy"));
+            MatcherAssert.assertThat(permission.getScopes(), Matchers.containsInAnyOrder("create", "update"));
+        }
+
+        updatePermission.setPolicies(new HashSet<>());
+        updatePermission.addPolicy(claimCPolicy.getName());
+        authorization.permissions().resource().findById(updatePermission.getId()).update(updatePermission);
+
+        response = authzClient.authorization("marta", "password").authorize();
+        Assertions.assertNotNull(response.getToken());
+        rpt = toAccessToken(response.getToken());
+        authorizationClaim = rpt.getAuthorization();
+        permissions = new ArrayList<>(authorizationClaim.getPermissions());
+
+        Assertions.assertEquals(2, permissions.size());
+
+        for (Permission permission : permissions) {
+            Map<String, Set<String>> claims = permission.getClaims();
+
+            Assertions.assertNotNull(claims);
+
+            MatcherAssert.assertThat(claims.get("claim-a"), Matchers.containsInAnyOrder("claim-a", "claim-a1"));
+            MatcherAssert.assertThat(claims.get("claim-b"), Matchers.containsInAnyOrder("claim-b"));
+            MatcherAssert.assertThat(claims.get("claim-c"), Matchers.containsInAnyOrder("claim-c"));
+        }
+    }
+
+    private RealmResource getRealm() throws Exception {
+        return adminClient.realm("authz-test");
+    }
+
+    private ClientResource getClient(RealmResource realm) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/PermissionEqualsTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/PermissionEqualsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.client.testsuite.authz;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.authorization.Permission;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class PermissionEqualsTest {
+
+    @Test
+    public void testEquals() {
+        Assertions.assertTrue(new Permission("1", null, Collections.emptySet(), Collections.emptyMap()).equals(
+                new Permission("1", null, Collections.emptySet(), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission("1", null, Collections.emptySet(), Collections.emptyMap()).equals(
+                new Permission("2", null, Collections.emptySet(), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission("1", null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap()).equals(
+                new Permission("1", null, Collections.emptySet(), Collections.emptyMap())
+        ));
+        Assertions.assertTrue(new Permission("1", null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap()).equals(
+                new Permission("1", null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap())
+        ));
+        Assertions.assertTrue(new Permission("1", null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap()).equals(
+                new Permission("1", null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission("1", null, new HashSet<>(Arrays.asList("read")), Collections.emptyMap()).equals(
+                new Permission("1", null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission(null, null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap()).equals(
+                new Permission("1", null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission("1", null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap()).equals(
+                new Permission(null, null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap())
+        ));
+        Assertions.assertTrue(new Permission(null, null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap()).equals(
+                new Permission(null, null, new HashSet<>(Arrays.asList("write")), Collections.emptyMap())
+        ));
+        Assertions.assertTrue(new Permission(null, null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap()).equals(
+                new Permission(null, null, new HashSet<>(Arrays.asList("read")), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission(null, null, new HashSet<>(Arrays.asList("read", "write")), Collections.emptyMap()).equals(
+                new Permission(null, null, new HashSet<>(Arrays.asList("update")), Collections.emptyMap())
+        ));
+        Assertions.assertFalse(new Permission(null, null, Collections.emptySet(), Collections.emptyMap()).equals(
+                new Permission(null, null, new HashSet<>(Arrays.asList("read")), Collections.emptyMap())
+        ));
+    }
+}


### PR DESCRIPTION
Closes #62

More tests. No issues this time. The `GroupBuilder` helper class is added for the group tests.