### PR TITLE
Move RegexPolicyTest, RolePolicyTest, Uma* and UserManaged* tests to keycloak-client

### DIFF
--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractResourceServerTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/AbstractResourceServerTest.java
@@ -31,6 +31,7 @@ import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.resource.ProtectionResource;
+import org.keycloak.client.testsuite.events.EventType;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.authorization.AuthorizationRequest;
 import org.keycloak.representations.idm.authorization.AuthorizationRequest.Metadata;
@@ -56,6 +57,7 @@ public abstract class AbstractResourceServerTest extends AbstractAuthzTest {
     public List<RealmRepresentation> getRealmsForImport() {
         List<RealmRepresentation> testRealms = new ArrayList<>();
         testRealms.add(RealmBuilder.create().name(REALM_NAME)
+                .events(EventType.PERMISSION_TOKEN_ERROR, EventType.PERMISSION_TOKEN)
                 .roles(RolesBuilder.create()
                         .realmRole(RoleBuilder.create().name("uma_authorization").build())
                         .realmRole(RoleBuilder.create().name("uma_protection").build())

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/RegexPolicyTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/RegexPolicyTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.*;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
+ */
+public class RegexPolicyTest extends AbstractAuthzTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        Map<String, String> claims = new HashMap<>();
+
+        claims.put("user.attribute", "foo");
+        claims.put("claim.name", "foo");
+        ProtocolMapperRepresentation userAttrFooProtocolMapper = addClaimMapper("userAttrFoo", claims);
+
+        claims.put("user.attribute", "bar");
+        claims.put("claim.name", "bar");
+        ProtocolMapperRepresentation userAttrBarProtocolMapper = addClaimMapper("userAttrBar", claims);
+
+        claims.put("user.attribute", "json-simple");
+        claims.put("claim.name", "userinfo");
+        ProtocolMapperRepresentation userAttrJsonProtocolMapper = addClaimMapper("userAttrJsonSimple", claims);
+
+        claims.put("user.attribute", "json-complex");
+        claims.put("claim.name", "json-complex");
+        ProtocolMapperRepresentation userAttrJsonComplexProtocolMapper = addClaimMapper("userAttrJsonComplex", claims);
+
+        ProtocolMapperRepresentation userAttributesProtocolMapper = new ProtocolMapperRepresentation();
+        userAttributesProtocolMapper.setName("canWriteItems");
+        userAttributesProtocolMapper.setProtocol("openid-connect");
+        userAttributesProtocolMapper.setProtocolMapper("oidc-usermodel-attribute-mapper");
+        Map<String, String> PMUserConfig = new HashMap<>();
+        PMUserConfig.put("claim.name","customPermissions.canCreateItems");
+        PMUserConfig.put("access.token.claim","true");
+        PMUserConfig.put("id.token.claim","true");
+        PMUserConfig.put("userinfo.token.claim","true");
+        PMUserConfig.put("user.attribute","canCreateItems");
+        PMUserConfig.put("aggregate.attrs","false");
+        PMUserConfig.put("multivalued","false");
+        userAttributesProtocolMapper.setConfig(PMUserConfig);
+
+        ProtocolMapperRepresentation groupAttributesProtocolMapper = new ProtocolMapperRepresentation();
+        groupAttributesProtocolMapper.setName("Group_Mapper");
+        groupAttributesProtocolMapper.setProtocol("openid-connect");
+        groupAttributesProtocolMapper.setProtocolMapper("oidc-usermodel-attribute-mapper");
+        Map<String, String> PMgroupConfig = new HashMap<>();
+        PMgroupConfig.put("claim.name","attributes.values");
+        PMgroupConfig.put("access.token.claim","true");
+        PMgroupConfig.put("id.token.claim","true");
+        PMgroupConfig.put("userinfo.token.claim","true");
+        PMgroupConfig.put("user.attribute","attribute");
+        PMgroupConfig.put("aggregate.attrs","false");
+        PMgroupConfig.put("multivalued","false");
+        groupAttributesProtocolMapper.setConfig(PMgroupConfig);
+
+        //        For JSON-based claims, you can use dot notation for nesting and square brackets to access array fields by index. For example, contact.address[0].country.
+
+        testRealms.add(RealmBuilder.create().name("authz-test")
+            .user(UserBuilder.create().username("marta").password("password").addAttribute("foo", "foo").addAttribute("bar",
+                "barbar").addAttribute("json-simple", "{\"tenant\": \"abc\"}")
+                    .addAttribute("json-complex", "{\"userinfo\": {\"tenant\": \"abc\"}, \"some-array\": [\"foo\",\"bar\"]}"))
+            .user(UserBuilder.create().username("taro").password("password").addAttribute("foo", "faa").addAttribute("bar",
+                "bbarbar"))
+            .user(UserBuilder.create().username("my-user").password("password").addAttribute("canCreateItems","true"))
+            .user(UserBuilder.create().username("my-user2").password("password").addAttribute("canCreateItems","false"))
+            .user(UserBuilder.create().username("my-user3").password("password").addAttribute("otherClaim","something"))
+            .user(UserBuilder.create().username("context-user").password("password").addAttribute("custom", "foo"))
+            .group(GroupBuilder.create().name("ADMIN").singleAttribute("attribute","example").build())
+            .user(UserBuilder.create().username("admin").password("password").addGroups("ADMIN"))
+
+
+            .client(ClientBuilder.create().clientId("resource-server-test").secret("secret").authorizationServicesEnabled(true)
+                .redirectUris("http://localhost/resource-server-test").directAccessGrants()
+                .protocolMapper(userAttrFooProtocolMapper, userAttrBarProtocolMapper, userAttrJsonProtocolMapper, userAttrJsonComplexProtocolMapper,userAttributesProtocolMapper,groupAttributesProtocolMapper))
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        createResource("Resource A");
+        createResource("Resource B");
+        createResource("Resource C");
+        createResource("Resource D");
+        createResource("Resource E");
+        createResource("Resource ITEM");
+        createResource("Resource CONTEXT");
+        ScopeRepresentation scopeRead = new ScopeRepresentation();
+        scopeRead.setName("read");
+        ScopeRepresentation scopeDelete = new ScopeRepresentation();
+        scopeDelete.setName("delete");
+        getClient().authorization().scopes().scopes().add(scopeRead);
+        getClient().authorization().scopes().scopes().add(scopeDelete);
+
+        createResourceWithScopes("service", Collections.singleton(scopeRead));
+
+        createRegexPolicy("Regex foo Policy", "foo", "foo");
+        createRegexPolicy("Regex bar Policy", "bar", "^bar.+$");
+        createRegexPolicy("Regex json-simple Policy", "userinfo.tenant", "^abc$");
+        createRegexPolicy("Regex json-complex Policy", "json-complex.userinfo.tenant", "^abc$");
+        createRegexPolicy("Regex json-array Policy", "json-complex.some-array[1]", "bar");
+        createRegexPolicy("Regex user attribute to json-Complex Policy", "customPermissions.canCreateItems", "true");
+        createRegexPolicyExtended("attribute-policy","attributes.values","^example$",Logic.POSITIVE);
+        createRegexPolicy("Regex context policy", "custom", "^foo$", true);
+
+        createResourcePermission("Resource A Permission", "Resource A", "Regex foo Policy");
+        createResourcePermission("Resource B Permission", "Resource B", "Regex bar Policy");
+        createResourcePermission("Resource C Permission", "Resource C", "Regex json-simple Policy");
+        createResourcePermission("Resource D Permission", "Resource D", "Regex json-complex Policy");
+        createResourcePermission("Resource E Permission", "Resource E", "Regex json-array Policy");
+
+        createResourcePermission("Resource ITEM Permission", "Resource ITEM", "Regex user attribute to json-Complex Policy");
+        createResourceScopesPermissionExtended("read-permission","service",DecisionStrategy.UNANIMOUS,"read","attribute-policy");
+
+        createResourcePermission("Resource CONTEXT Permission", "Resource CONTEXT", "Regex context policy");
+    }
+
+    private void createResource(String name) {
+        AuthorizationResource authorization = getClient().authorization();
+        ResourceRepresentation resource = new ResourceRepresentation(name);
+
+        authorization.resources().create(resource).close();
+    }
+
+    private void createResourceWithScopes(String name, Set<ScopeRepresentation> scopes) {
+        AuthorizationResource authorization = getClient().authorization();
+        ResourceRepresentation resource = new ResourceRepresentation(name);
+        resource.setScopes(scopes);
+        authorization.resources().create(resource).close();
+    }
+
+
+    private void createRegexPolicy(String name, String targetClaim, String pattern) {
+        createRegexPolicy(name, targetClaim, pattern, false);
+    }
+
+    private void createRegexPolicy(String name, String targetClaim, String pattern, Boolean targetContextAttributes) {
+        RegexPolicyRepresentation policy = new RegexPolicyRepresentation();
+
+        policy.setName(name);
+        policy.setTargetClaim(targetClaim);
+        policy.setPattern(pattern);
+        policy.setTargetContextAttributes(targetContextAttributes);
+
+        getClient().authorization().policies().regex().create(policy).close();
+    }
+
+    private void createRegexPolicyExtended(String name, String targetClaim, String pattern,Logic logic) {
+        RegexPolicyRepresentation policy = new RegexPolicyRepresentation();
+
+        policy.setName(name);
+        policy.setTargetClaim(targetClaim);
+        policy.setPattern(pattern);
+        policy.setLogic(logic);
+        getClient().authorization().policies().regex().create(policy).close();
+    }
+
+    private void createResourcePermission(String name, String resource, String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(name);
+        permission.addResource(resource);
+        permission.addPolicy(policies);
+
+        getClient().authorization().permissions().resource().create(permission).close();
+    }
+    private void createResourceScopesPermissionExtended(String name, String resource, DecisionStrategy strategy,String scope,String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        permission.setName(name);
+        permission.addResource(resource);
+        permission.addPolicy(policies);
+        permission.addScope(scope);
+        permission.setDecisionStrategy(strategy);
+        getClient().authorization().permissions().resource().create(permission).close();
+    }
+
+    private ClientResource getClient() {
+        return getClient(getRealm());
+    }
+
+    private ClientResource getClient(RealmResource realm) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId("resource-server-test").stream()
+            .map(representation -> clients.get(representation.getId())).findFirst()
+            .orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+
+    private RealmResource getRealm() {
+        return adminClient.realm("authz-test");
+    }
+
+    @Test
+    public void testWithExpectedUserAttribute() {
+        // Access Resource A with marta.
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization("marta", "password")
+            .authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+
+        // Access Resource B with marta.
+        request = new PermissionRequest("Resource B");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+
+        request = new PermissionRequest("Resource C");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+
+        request = new PermissionRequest("Resource D");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+
+        request = new PermissionRequest("Resource E");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testWithExpectedUserAttributeValueMappedToComplexJsonClaim() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource ITEM");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationRequest theRequest = new AuthorizationRequest(ticket);
+        AuthorizationResponse response = authzClient.authorization("my-user", "password").authorize(theRequest);
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testWithExpectedUserAttributeValueMappedToComplexJsonClaimPermissions() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("service","read");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationRequest theRequest = new AuthorizationRequest(ticket);
+        AuthorizationRequest.Metadata metadata = new AuthorizationRequest.Metadata();
+        metadata.setResponseMode("permissions");
+        metadata.setIncludeResourceName(true);
+        metadata.setPermissionResourceFormat("uri");
+        theRequest.setMetadata(metadata);
+        List<Permission> permissions = authzClient.authorization("admin", "password").getPermissions(theRequest);
+        Assertions.assertNotNull(permissions);
+        Assertions.assertTrue(permissions.get(0).getResourceName().equals("service"));
+        Assertions.assertTrue(permissions.get(0).getScopes().contains("read"));
+    }
+
+    @Test
+    public void testWithNotExpectedUserAttributeValueMappedToComplexJsonClaim() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource ITEM");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("my-user2", "password").authorize(new AuthorizationRequest(ticket)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testWithAbsentUserAttributeThusNotMappedToComplexJsonClaim() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource ITEM");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("my-user3", "password").authorize(new AuthorizationRequest(ticket)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testWithoutExpectedUserAttribute() {
+        // Access Resource A with taro.
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+        String ticket1 = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("taro", "password").authorize(new AuthorizationRequest(ticket1)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        // Access Resource B with taro.
+        request = new PermissionRequest("Resource B");
+        String ticket2 = authzClient.protection().permission().create(request).getTicket();
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("taro", "password").authorize(new AuthorizationRequest(ticket2)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        // Access Resource C with taro.
+        request = new PermissionRequest("Resource C");
+        String ticket3 = authzClient.protection().permission().create(request).getTicket();
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("taro", "password").authorize(new AuthorizationRequest(ticket3)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        // Access Resource D with taro.
+        request = new PermissionRequest("Resource D");
+        authzClient.protection().permission().create(request);
+
+        String ticket4 = authzClient.protection().permission().create(request).getTicket();
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("taro", "password").authorize(new AuthorizationRequest(ticket4)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testWithExpectedContextAttribute() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource CONTEXT");
+        request.setClaim("custom", "foo");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationRequest theRequest = new AuthorizationRequest(ticket);
+        AuthorizationResponse response = authzClient.authorization("my-user", "password").authorize(theRequest);
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testWithExpectedContextAttributeAsUserAttribute() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource CONTEXT");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("context-user", "password").authorize(new AuthorizationRequest(ticket)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testWithoutExpectedContextAttribute() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource CONTEXT");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("my-user", "password").authorize(new AuthorizationRequest(ticket)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    private AuthzClient getAuthzClient() {
+        return getAuthzClient("/authorization-test/default-keycloak.json");
+    }
+
+    private ProtocolMapperRepresentation addClaimMapper(String name, Map<String, String> claims) {
+        ProtocolMapperRepresentation userAttrBarProtocolMapper = new ProtocolMapperRepresentation();
+        userAttrBarProtocolMapper.setName(name);
+        userAttrBarProtocolMapper.setProtocolMapper("oidc-usermodel-attribute-mapper");
+        userAttrBarProtocolMapper.setProtocol("openid-connect");
+        Map<String, String> configBar = new HashMap<>(claims);
+        configBar.put("access.token.claim", "true");
+        configBar.put("id.token.claim", "true");
+        configBar.put("jsonType.label", "String");
+        userAttrBarProtocolMapper.setConfig(configBar);
+        return userAttrBarProtocolMapper;
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/RolePolicyTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/RolePolicyTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientScopeResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.client.testsuite.framework.KeycloakVersion;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.testsuite.util.ApiUtil;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class RolePolicyTest extends AbstractAuthzTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        testRealms.add(RealmBuilder.create().name("authz-test")
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                        .realmRole(RoleBuilder.create().name("Role A").build())
+                        .realmRole(RoleBuilder.create().name("Role B").build())
+                        .realmRole(RoleBuilder.create().name("Role C").build())
+                )
+                .group(GroupBuilder.create().name("Group A").realmRoles(Arrays.asList("Role A")).build())
+                .group(GroupBuilder.create().name("Group B").realmRoles(Arrays.asList("Role C")).build())
+                .user(UserBuilder.create().username("marta").password("password").addRoles("uma_authorization", "Role A"))
+                .user(UserBuilder.create().username("kolo").password("password").addRoles("uma_authorization", "Role B"))
+                .user(UserBuilder.create().username("alice").password("password").addRoles("uma_authorization").addGroups("Group B"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .redirectUris("http://localhost/resource-server-test")
+                    .defaultRoles("uma_protection")
+                    .directAccessGrants())
+                .build());
+        return testRealms;
+    }
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        createResource("Resource A");
+        createResource("Resource B");
+        createResource("Resource C");
+
+        createRealmRolePolicy("Role A Policy", "Role A");
+        createRealmRolePolicy("Role B Policy", "Role B");
+        createRealmRolePolicy("Role C Policy", "Role C");
+
+        createResourcePermission("Resource A Permission", "Resource A", "Role A Policy");
+        createResourcePermission("Resource B Permission", "Resource B", "Role B Policy");
+        createResourcePermission("Resource C Permission", "Resource C", "Role C Policy");
+    }
+
+    @Test
+    public void testUserWithExpectedRole() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationResponse response = authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
+
+        Assertions.assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testUserWithoutExpectedRole() {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest("Resource A");
+        String ticket1 = authzClient.protection().permission().create(request).getTicket();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket1)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        request.setResourceId("Resource B");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        Assertions.assertNotNull(authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket)));
+
+        UserRepresentation user = getRealm().users().search("kolo").get(0);
+        RoleRepresentation roleA = getRealm().roles().get("Role A").toRepresentation();
+        getRealm().users().get(user.getId()).roles().realmLevel().add(Arrays.asList(roleA));
+
+        request.setResourceId("Resource A");
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        Assertions.assertNotNull(authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket)));
+    }
+
+    @Test
+    public void testUserWithGroupRole() throws InterruptedException {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest();
+
+        request.setResourceId("Resource C");
+
+        String ticket1 = authzClient.protection().permission().create(request).getTicket();
+        Assertions.assertNotNull(authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket1)));
+
+        UserRepresentation user = getRealm().users().search("alice").get(0);
+        GroupRepresentation groupB = getRealm().groups().groups().stream().filter(representation -> "Group B".equals(representation.getName())).findFirst().get();
+        getRealm().users().get(user.getId()).leaveGroup(groupB.getId());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket1)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        request.setResourceId("Resource A");
+        String ticket2 = authzClient.protection().permission().create(request).getTicket();
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket2)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        GroupRepresentation groupA = getRealm().groups().groups().stream().filter(representation -> "Group A".equals(representation.getName())).findFirst().get();
+        getRealm().users().get(user.getId()).joinGroup(groupA.getId());
+
+        Assertions.assertNotNull(authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket2)));
+    }
+
+    @Test
+    @KeycloakVersion(min = "25.0.0") // fetchRoles added in 25
+    public void testFetchRoles() {
+        AuthzClient authzClient = getAuthzClient();
+        RealmResource realm = getRealm();
+        ClientsResource clients = realm.clients();
+        ClientRepresentation client = clients.findByClientId(authzClient.getConfiguration().getResource()).get(0);
+        ClientScopeRepresentation rolesScope = ApiUtil.findClientScopeByName(realm, "roles").toRepresentation();
+        ClientResource clientResource = clients.get(client.getId());
+        clientResource.removeDefaultClientScope(rolesScope.getId());
+        PermissionRequest request = new PermissionRequest("Resource B");
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket)));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        RolePolicyRepresentation roleRep = clientResource.authorization().policies().role().findByName("Role B Policy");
+        roleRep.setFetchRoles(true);
+        clientResource.authorization().policies().role().findById(roleRep.getId()).update(roleRep);
+        Assertions.assertNotNull(authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket)));
+
+        clientResource.addDefaultClientScope(rolesScope.getId());
+    }
+
+    @Test
+    @KeycloakVersion(min = "25.0.0") // fetchRoles added in 25
+    public void testFetchRolesUsingServiceAccount() {
+        AuthzClient authzClient = getAuthzClient();
+        RealmResource realm = getRealm();
+        ClientsResource clients = realm.clients();
+        ClientRepresentation client = clients.findByClientId(authzClient.getConfiguration().getResource()).get(0);
+        ClientScopeResource rolesScopeRes = ApiUtil.findClientScopeByName(realm, "roles");
+        ClientScopeRepresentation rolesScope = rolesScopeRes.toRepresentation();
+        ClientResource clientResource = clients.get(client.getId());
+        clientResource.removeDefaultClientScope(rolesScope.getId());
+        UserRepresentation serviceAccountUser = clientResource.getServiceAccountUser();
+        RoleRepresentation roleB = realm.roles().get("Role B").toRepresentation();
+        realm.users().get(serviceAccountUser.getId()).roles().realmLevel().add(Collections.singletonList(roleB));
+        RolePolicyRepresentation roleRep = clientResource.authorization().policies().role().findByName("Role B Policy");
+        roleRep.setFetchRoles(true);
+        clientResource.authorization().policies().role().findById(roleRep.getId()).update(roleRep);
+        Assertions.assertNotNull(authzClient.authorization().authorize(new AuthorizationRequest()));
+
+        clientResource.addDefaultClientScope(rolesScope.getId());
+        roleRep.setFetchRoles(false);
+        clientResource.authorization().policies().role().findById(roleRep.getId()).update(roleRep);
+    }
+
+    private void createRealmRolePolicy(String name, String... roles) {
+        RolePolicyRepresentation policy = new RolePolicyRepresentation();
+
+        policy.setName(name);
+
+        for (String role : roles) {
+            policy.addRole(role);
+        }
+
+        getClient().authorization().policies().role().create(policy).close();
+    }
+
+    private void createResourcePermission(String name, String resource, String... policies) {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(name);
+        permission.addResource(resource);
+        permission.addPolicy(policies);
+
+        getClient().authorization().permissions().resource().create(permission).close();
+    }
+
+    private void createResource(String name) {
+        AuthorizationResource authorization = getClient().authorization();
+        ResourceRepresentation resource = new ResourceRepresentation(name);
+
+        authorization.resources().create(resource).close();
+    }
+
+    private RealmResource getRealm() {
+        try {
+            return adminClient.realm("authz-test");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create admin client");
+        }
+    }
+
+    private ClientResource getClient(RealmResource realm) {
+        ClientsResource clients = realm.clients();
+        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+    }
+
+    private AuthzClient getAuthzClient() {
+        return getAuthzClient("/authorization-test/default-keycloak.json");
+    }
+
+    private ClientResource getClient() {
+        return getClient(getRealm());
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaGrantTypeTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaGrantTypeTest.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
+import org.keycloak.client.testsuite.common.OAuthClient;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.testsuite.util.KeycloakModelUtils;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.util.BasicAuthHelper;
+import org.keycloak.util.JsonSerialization;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class UmaGrantTypeTest extends AbstractResourceServerTest {
+
+    private ResourceRepresentation resourceA;
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+        policy.setName("Default Policy");
+        policy.setType("script-scripts/default-policy.js");
+
+        authorization.policies().js().create(policy).close();
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resourceA = addResource("Resource A", null, Collections.singleton("/resource"), false, "ScopeA", "ScopeB", "ScopeC");
+
+        permission.setName(resourceA.getName() + " Permission");
+        permission.addResource(resourceA.getName());
+        permission.addPolicy(policy.getName());
+
+        authorization.permissions().resource().create(permission).close();
+
+        policy = new JSPolicyRepresentation();
+
+        policy.setName("Deny Policy");
+        policy.setType("script-scripts/always-deny-policy.js");
+
+        authorization.policies().js().create(policy).close();
+    }
+
+    @Test
+    public void testObtainRptWithClientAdditionalScopes() throws Exception {
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"}, new String[] {"ScopeC"});
+        AccessToken accessToken = toAccessToken(response.getToken());
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB", "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithUpgrade() throws Exception {
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        response = authorize("marta", "password", "Resource A", new String[] {"ScopeC"}, rpt);
+        Assertions.assertTrue(response.isUpgraded());
+
+        authorization = toAccessToken(response.getToken()).getAuthorization();
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB", "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithUpgradeOnlyScopes() throws Exception {
+        AuthorizationResponse response = authorize("marta", "password", null, new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        response = authorize("marta", "password", "Resource A", new String[] {"ScopeC"}, rpt);
+
+        authorization = toAccessToken(response.getToken()).getAuthorization();
+        permissions = authorization.getPermissions();
+
+        Assertions.assertTrue(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB", "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithUpgradeWithUnauthorizedResource() throws Exception {
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        ResourceRepresentation resourceB = addResource("Resource B", "ScopeA", "ScopeB", "ScopeC");
+
+        permission.setName(resourceB.getName() + " Permission");
+        permission.addResource(resourceB.getName());
+        permission.addPolicy("Deny Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+            () -> authorize("marta", "password", "Resource B", new String[]{"ScopeC"}, rpt));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testObtainRptWithUpgradeWithUnauthorizedResourceFromRpt() throws Exception {
+        ResourcePermissionRepresentation permissionA = new ResourcePermissionRepresentation();
+        ResourceRepresentation resourceA = addResource(KeycloakModelUtils.generateId(), "ScopeA", "ScopeB", "ScopeC");
+
+        permissionA.setName(resourceA.getName() + " Permission");
+        permissionA.addResource(resourceA.getName());
+        permissionA.addPolicy("Default Policy");
+
+        AuthorizationResource authzResource = getClient(getRealm()).authorization();
+
+        authzResource.permissions().resource().create(permissionA).close();
+        AuthorizationResponse response = authorize("marta", "password", resourceA.getId(), new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        ResourceRepresentation resourceB = addResource(KeycloakModelUtils.generateId(), "ScopeA", "ScopeB", "ScopeC");
+        ResourcePermissionRepresentation permissionB = new ResourcePermissionRepresentation();
+
+        permissionB.setName(resourceB.getName() + " Permission");
+        permissionB.addResource(resourceB.getName());
+        permissionB.addPolicy("Default Policy");
+
+        authzResource.permissions().resource().create(permissionB).close();
+        response = authorize("marta", "password", resourceB.getId(), new String[] {"ScopeC"}, rpt);
+        rpt = response.getToken();
+        authorization = toAccessToken(rpt).getAuthorization();
+        permissions = authorization.getPermissions();
+
+        Assertions.assertTrue(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "ScopeA", "ScopeB");
+        assertPermissions(permissions, resourceB.getName(), "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        permissionB = authzResource.permissions().resource().findByName(permissionB.getName());
+        permissionB.removePolicy("Default Policy");
+        permissionB.addPolicy("Deny Policy");
+
+        authzResource.permissions().resource().findById(permissionB.getId()).update(permissionB);
+
+        response = authorize("marta", "password", resourceA.getId(), new String[] {"ScopeC"}, rpt);
+        rpt = response.getToken();
+        authorization = toAccessToken(rpt).getAuthorization();
+        permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "ScopeA", "ScopeB", "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptOnlyAuthorizedScopes() throws Exception {
+        ResourceRepresentation resourceA = addResource(KeycloakModelUtils.generateId(), "READ", "WRITE");
+        ScopePermissionRepresentation permissionA = new ScopePermissionRepresentation();
+
+        permissionA.setName(KeycloakModelUtils.generateId());
+        permissionA.addScope("READ");
+        permissionA.addPolicy("Default Policy");
+
+        AuthorizationResource authzResource = getClient(getRealm()).authorization();
+
+        authzResource.permissions().scope().create(permissionA).close();
+
+        ScopePermissionRepresentation permissionB = new ScopePermissionRepresentation();
+
+        permissionB.setName(KeycloakModelUtils.generateId());
+        permissionB.addScope("WRITE");
+        permissionB.addPolicy("Deny Policy");
+
+        authzResource.permissions().scope().create(permissionB).close();
+
+        AuthorizationResponse response = authorize("marta", "password", resourceA.getName(), new String[] {"READ"});
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "READ");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        response = authorize("marta", "password", resourceA.getName(), new String[] {"READ", "WRITE"});
+        rpt = response.getToken();
+        authorization = toAccessToken(rpt).getAuthorization();
+        permissions = authorization.getPermissions();
+
+        Assertions.assertFalse(response.isUpgraded());
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "READ");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithOwnerManagedResource() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        ResourceRepresentation resourceA = addResource("Resource Marta", "marta", true, "ScopeA", "ScopeB", "ScopeC");
+
+        permission.setName(resourceA.getName() + " Permission");
+        permission.addResource(resourceA.getId());
+        permission.addPolicy("Default Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        ResourceRepresentation resourceB = addResource("Resource B", "marta", "ScopeA", "ScopeB", "ScopeC");
+
+        permission.setName(resourceB.getName() + " Permission");
+        permission.addResource(resourceB.getId());
+        permission.addPolicy("Default Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password",
+                new PermissionRequest(resourceA.getName(), "ScopeA", "ScopeB"),
+                new PermissionRequest(resourceB.getName(), "ScopeC"));
+        String rpt = response.getToken();
+        AccessToken.Authorization authorization = toAccessToken(rpt).getAuthorization();
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resourceA.getName(), "ScopeA", "ScopeB");
+        assertPermissions(permissions, resourceB.getName(), "ScopeC");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithClientCredentials() throws Exception {
+        AuthorizationResponse response = authorize("Resource A", new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptUsingAccessToken() throws Exception {
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+        AuthorizationResponse response = authorize(null, null, null, null, accessTokenResponse.getToken(), null, null, new PermissionRequest("Resource A", "ScopeA", "ScopeB"));
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainDecisionUsingAccessToken() throws Exception {
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+
+        // use "rsid" as "uri"
+        // uri and scopes exist
+        AuthorizationResponse response = authorizeDecision(accessTokenResponse.getToken(), null,
+            new PermissionRequest("/resource", "ScopeA", "ScopeB"));
+        Assertions.assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // uri and scopes are empty
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+            () -> authorizeDecision(accessTokenResponse.getToken(), null, new PermissionRequest(null)));
+        MatcherAssert.assertThat(re.getMessage(), Matchers.containsString("Bad Request"));
+
+        // uri is empty but scopes exist
+        response = authorizeDecision(accessTokenResponse.getToken(), null, new PermissionRequest(null, "ScopeA", "ScopeB"));
+        Assertions.assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // test wild card
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        ResourceRepresentation resourceB = addResource("Resource B", null, Collections.singleton("/rs/*"), false, "ScopeD",
+            "ScopeE");
+
+        permission.setName(resourceB.getName() + " Permission");
+        permission.addResource(resourceB.getName());
+        permission.addPolicy("Default Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        // matchingUri is null, then result error
+        re = Assertions.assertThrows(RuntimeException.class,
+            () -> authorizeDecision(accessTokenResponse.getToken(), null, new PermissionRequest("/rs/data", "ScopeD", "ScopeE")));
+        MatcherAssert.assertThat(re.getMessage(), Matchers.containsString("Bad Request"));
+
+        // matchingUri is true, then result true
+        response = authorizeDecision(accessTokenResponse.getToken(), true,
+            new PermissionRequest("/rs/data", "ScopeD", "ScopeE"));
+        Assertions.assertTrue((Boolean) response.getOtherClaims().getOrDefault("result", "false"));
+
+        // matchingUri is false, then result error
+        re = Assertions.assertThrows(RuntimeException.class,
+            () -> authorizeDecision(accessTokenResponse.getToken(), false, new PermissionRequest("/rs/data", "ScopeD", "ScopeE")));
+        MatcherAssert.assertThat(re.getMessage(), Matchers.containsString("Bad Request"));
+    }
+
+    @Test
+    public void testCORSHeadersInFailedRptRequest() throws Exception {
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+
+        UserRepresentation userRepresentation = getRealm().users().search("marta").get(0);
+        UserRepresentation updatedUser = UserBuilder.edit(userRepresentation).enabled(false).build();
+        getRealm().users().get(userRepresentation.getId()).update(updatedUser);
+
+        PermissionRequest permissions = new PermissionRequest("Resource A", "ScopeA", "ScopeB");
+        String ticket = getAuthzClient().protection().permission().create(Arrays.asList(permissions)).getTicket();
+
+        String tokenEndpoint = getAuthzClient().getServerConfiguration().getTokenEndpoint();
+        HttpPost post = new HttpPost(tokenEndpoint);
+        post.addHeader("Origin", "http://localhost");
+        post.addHeader("Authorization", "Bearer " + accessTokenResponse.getToken());
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.UMA_GRANT_TYPE));
+        parameters.add(new BasicNameValuePair("ticket", ticket));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        post.setEntity(formEntity);
+
+        CloseableHttpResponse response = httpClient.execute(post);
+        Assertions.assertEquals(401, response.getStatusLine().getStatusCode());
+        Assertions.assertEquals("http://localhost", response.getFirstHeader("Access-Control-Allow-Origin").getValue());
+    }
+
+    @Test
+    public void testRefreshRpt() throws Exception {
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+        AuthorizationResponse response = authorize(null, null, null, null, accessTokenResponse.getToken(), null, null, new PermissionRequest("Resource A", "ScopeA", "ScopeB"));
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        String refreshToken = response.getRefreshToken();
+
+        Assertions.assertNotNull(refreshToken);
+
+        AccessToken refreshTokenToken = toAccessToken(refreshToken);
+
+        Assertions.assertNotNull(refreshTokenToken.getAuthorization());
+
+        HttpPost post = new HttpPost(getAuthzClient().getServerConfiguration().getTokenEndpoint());
+        post.addHeader("Origin", "http://localhost");
+        post.addHeader("Authorization", BasicAuthHelper.createHeader("resource-server-test", "secret"));
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constants.REFRESH_TOKEN));
+        parameters.add(new BasicNameValuePair(OAuth2Constants.REFRESH_TOKEN, refreshToken));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        post.setEntity(formEntity);
+
+        AccessTokenResponse refreshTokenResponse;
+        try (CloseableHttpResponse res = httpClient.execute(post)) {
+            Assertions.assertEquals(200, res.getStatusLine().getStatusCode());
+            refreshTokenResponse = JsonSerialization.readValue(res.getEntity().getContent(), AccessTokenResponse.class);
+        }
+
+        Assertions.assertNotNull(refreshTokenResponse.getToken());
+        refreshToken = refreshTokenResponse.getRefreshToken();
+        refreshTokenToken = toAccessToken(refreshToken);
+
+        Assertions.assertNotNull(refreshTokenToken.getAuthorization());
+
+        AccessToken refreshedToken = toAccessToken(rpt);
+        authorization = refreshedToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        try (CloseableHttpResponse res = httpClient.execute(post)) {
+            Assertions.assertEquals(200, res.getStatusLine().getStatusCode());
+            refreshTokenResponse = JsonSerialization.readValue(res.getEntity().getContent(), AccessTokenResponse.class);
+        }
+
+        Assertions.assertNotNull(refreshTokenResponse.getToken());
+        refreshToken = refreshTokenResponse.getRefreshToken();
+        refreshTokenToken = toAccessToken(refreshToken);
+
+        Assertions.assertNotNull(refreshTokenToken.getAuthorization());
+
+        refreshedToken = toAccessToken(rpt);
+        authorization = refreshedToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testObtainRptWithIDToken() throws Exception {
+        String idToken = getIdToken("marta", "password");
+        AuthorizationResponse response = authorize("Resource A", new String[] {"ScopeA", "ScopeB"}, idToken, "http://openid.net/specs/openid-connect-core-1_0.html#IDToken");
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testTokenIntrospect() throws Exception {
+        AuthzClient authzClient = getAuthzClient();
+        AccessTokenResponse accessTokenResponse = authzClient.obtainAccessToken("marta", "password");
+        AuthorizationResponse response = authorize(null, null, null, null, accessTokenResponse.getToken(), null, null, new PermissionRequest("Resource A", "ScopeA", "ScopeB"));
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        TokenIntrospectionResponse introspectionResponse = authzClient.protection().introspectRequestingPartyToken(rpt);
+
+        Assertions.assertNotNull(introspectionResponse);
+        Assertions.assertNotNull(introspectionResponse.getPermissions());
+
+        oauth.realm("authz-test");
+        String introspectHttpResponse = oauth.introspectTokenWithClientCredential("authz-test", "resource-server-test", "secret", "requesting_party_token", rpt);
+
+        Map jsonNode = JsonSerialization.readValue(introspectHttpResponse, Map.class);
+
+        Assertions.assertEquals(Boolean.TRUE, jsonNode.get("active"));
+
+        Collection permissionClaims = (Collection) jsonNode.get("permissions");
+
+        Assertions.assertNotNull(permissionClaims);
+        Assertions.assertEquals(1, permissionClaims.size());
+
+        Map<String, Object> claim = (Map<String, Object>) permissionClaims.iterator().next();
+
+        MatcherAssert.assertThat(claim.keySet(), Matchers.containsInAnyOrder("resource_id", "rsname", "resource_scopes", "scopes", "rsid"));
+        MatcherAssert.assertThat(claim.get("rsname"), Matchers.equalTo("Resource A"));
+
+        ResourceRepresentation resourceRep = authzClient.protection().resource().findByName("Resource A");
+        MatcherAssert.assertThat(claim.get("rsid"), Matchers.equalTo(resourceRep.getId()));
+        MatcherAssert.assertThat(claim.get("resource_id"), Matchers.equalTo(resourceRep.getId()));
+
+        MatcherAssert.assertThat((Collection<?>) claim.get("resource_scopes"), Matchers.containsInAnyOrder("ScopeA", "ScopeB"));
+        MatcherAssert.assertThat((Collection<?>) claim.get("scopes"), Matchers.containsInAnyOrder("ScopeA", "ScopeB"));
+    }
+
+    @Test
+    public void testNoRefreshToken() {
+        ClientResource client = getClient(getRealm());
+        ClientRepresentation clientRepresentation = client.toRepresentation();
+        clientRepresentation.getAttributes().put("use.refresh.tokens", "false");
+        client.update(clientRepresentation);
+
+        AccessTokenResponse accessTokenResponse = getAuthzClient().obtainAccessToken("marta", "password");
+        AuthorizationResponse response = authorize(null, null, null, null, accessTokenResponse.getToken(), null, null,
+            new PermissionRequest("Resource A", "ScopeA", "ScopeB"));
+        String rpt = response.getToken();
+        String refreshToken = response.getRefreshToken();
+        Assertions.assertNotNull(rpt);
+        Assertions.assertNull(refreshToken);
+
+        clientRepresentation.getAttributes().put("use.refresh.tokens", "true");
+        client.update(clientRepresentation);
+    }
+
+    private String getIdToken(String username, String password) throws IOException {
+        oauth.realm(REALM_NAME);
+        oauth.clientId("test-app");
+        oauth.scope("openid");
+        oauth.redirectUri("https://localhost:8543/auth/realms/master/app/auth");
+        OAuthClient.AuthorizationEndpointResponse res = oauth.doLogin(username, password);
+        OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(res.getCode(), null);
+        return response.getIdToken();
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.PermissionResponse;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class UmaPermissionTicketPushedClaimsTest extends AbstractResourceServerTest {
+
+    @Test
+    public void testEvaluatePermissionsWithPushedClaims() throws Exception {
+        ResourceRepresentation resource = addResource("Bank Account", "withdraw");
+        JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+        policy.setName("Withdraw Limit Policy");
+        policy.setType("script-scripts/withdraw-limit-policy.js");
+
+        AuthorizationResource authorization = getClient(getRealm()).authorization();
+
+        authorization.policies().js().create(policy).close();
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+
+        representation.setName("Withdraw Permission");
+        representation.addScope("withdraw");
+        representation.addPolicy(policy.getName());
+
+        authorization.permissions().scope().create(representation).close();
+
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest permissionRequest = new PermissionRequest(resource.getId());
+
+        permissionRequest.addScope("withdraw");
+        permissionRequest.setClaim("my.bank.account.withdraw.value", "50.5");
+
+        PermissionResponse response = authzClient.protection("marta", "password").permission().create(permissionRequest);
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.setTicket(response.getTicket());
+        request.setClaimToken(authzClient.obtainAccessToken("marta", "password").getToken());
+
+        AuthorizationResponse authorizationResponse = authzClient.authorization().authorize(request);
+
+        Assertions.assertNotNull(authorizationResponse);
+        Assertions.assertNotNull(authorizationResponse.getToken());
+
+        AccessToken token = toAccessToken(authorizationResponse.getToken());
+        Collection<Permission> permissions = token.getAuthorization().getPermissions();
+
+        Assertions.assertEquals(1, permissions.size());
+
+        Permission permission = permissions.iterator().next();
+        Map<String, Set<String>> claims = permission.getClaims();
+
+        Assertions.assertNotNull(claims);
+
+        MatcherAssert.assertThat(claims.get("my.bank.account.withdraw.value"), Matchers.containsInAnyOrder("50.5"));
+
+        permissionRequest.setClaim("my.bank.account.withdraw.value", "100.5");
+
+        response = authzClient.protection("marta", "password").permission().create(permissionRequest);
+        AuthorizationRequest request2 = new AuthorizationRequest();
+
+        request2.setTicket(response.getTicket());
+        request2.setClaimToken(authzClient.obtainAccessToken("marta", "password").getToken());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authzClient.authorization().authorize(request2));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaRepresentationTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UmaRepresentationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.client.testsuite.authz;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.client.resource.PermissionResource;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.DecisionEffect;
+import org.keycloak.representations.idm.authorization.PermissionTicketRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationRequest;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationResponse;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+
+
+public class UmaRepresentationTest extends AbstractResourceServerTest {
+    private ResourceRepresentation resource;
+    private PermissionResource permission;
+
+    private void createPermissionTicket() {
+        PermissionTicketRepresentation ticket = new PermissionTicketRepresentation();
+        ticket.setOwner(resource.getOwner().getId());
+        ticket.setResource(resource.getId());
+        ticket.setRequesterName("kolo");
+        ticket.setScopeName("ScopeA");
+        ticket.setGranted(true);
+        permission.create(ticket);
+    }
+
+    @Test
+    public void testCanRepresentPermissionTicketWithNamesOfResourceOwnedByUser() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA");
+        permission = getAuthzClient().protection("marta", "password").permission();
+        createPermissionTicket();
+
+        List<PermissionTicketRepresentation> permissionTickets = permission.find(resource.getId(), null, null, null, null, true, null, null);
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        PermissionTicketRepresentation ticket = permissionTickets.get(0);
+        Assertions.assertEquals("marta", ticket.getOwnerName());
+        Assertions.assertEquals("kolo", ticket.getRequesterName());
+        Assertions.assertEquals("Resource A", ticket.getResourceName());
+        Assertions.assertEquals("ScopeA", ticket.getScopeName());
+        Assertions.assertTrue(ticket.isGranted());
+    }
+
+    @Test
+    public void testCanRepresentPermissionTicketWithNamesOfResourceOwnedByClient() throws Exception {
+        resource = addResource("Resource A", getClient(getRealm()).toRepresentation().getId(), true, "ScopeA");
+        permission = getAuthzClient().protection().permission();
+        createPermissionTicket();
+
+        List<PermissionTicketRepresentation> permissionTickets = permission.find(resource.getId(), null, null, null, null, true, null, null);
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        PermissionTicketRepresentation ticket = permissionTickets.get(0);
+        Assertions.assertEquals("resource-server-test", ticket.getOwnerName());
+        Assertions.assertEquals("kolo", ticket.getRequesterName());
+        Assertions.assertEquals("Resource A", ticket.getResourceName());
+        Assertions.assertEquals("ScopeA", ticket.getScopeName());
+        Assertions.assertTrue(ticket.isGranted());
+    }
+
+    @Test
+    public void testCanRepresentPolicyResultGrantOfResourceOwnedByUser() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA");
+        permission = getAuthzClient().protection("marta", "password").permission();
+        createPermissionTicket();
+
+        RealmResource realm = getRealm();
+        String resourceServerId = getClient(realm).toRepresentation().getId();
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource("Resource A", "ScopeA");
+        PolicyEvaluationResponse result = getClient(realm).authorization().policies().evaluate(request);
+        Assertions.assertEquals(result.getStatus(), DecisionEffect.PERMIT);
+
+        List<PolicyEvaluationResponse.EvaluationResultRepresentation> evaluations = result.getResults();
+        Assertions.assertFalse(evaluations.isEmpty());
+        Assertions.assertEquals(1, evaluations.size());
+
+        List<PolicyEvaluationResponse.PolicyResultRepresentation> policies = evaluations.get(0).getPolicies();
+        Assertions.assertFalse(evaluations.isEmpty());
+        Assertions.assertEquals(1, evaluations.size());
+
+        String description = policies.get(0).getPolicy().getDescription();
+        Assertions.assertTrue(description.startsWith("Resource owner (marta) grants access"));
+    }
+
+    @Test
+    public void testCanRepresentPolicyResultGrantOfResourceOwnedByClient() throws Exception {
+        resource = addResource("Resource A", getClient(getRealm()).toRepresentation().getId(), true, "ScopeA");
+        permission = getAuthzClient().protection().permission();
+        createPermissionTicket();
+
+        RealmResource realm = getRealm();
+        String resourceServerId = getClient(realm).toRepresentation().getId();
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource("Resource A", "ScopeA");
+        PolicyEvaluationResponse result = getClient(realm).authorization().policies().evaluate(request);
+        Assertions.assertEquals(result.getStatus(), DecisionEffect.PERMIT);
+
+        List<PolicyEvaluationResponse.EvaluationResultRepresentation> evaluations = result.getResults();
+        Assertions.assertFalse(evaluations.isEmpty());
+        Assertions.assertEquals(1, evaluations.size());
+
+        List<PolicyEvaluationResponse.PolicyResultRepresentation> policies = evaluations.get(0).getPolicies();
+        Assertions.assertFalse(evaluations.isEmpty());
+        Assertions.assertEquals(1, evaluations.size());
+
+        String description = policies.get(0).getPolicy().getDescription();
+        Assertions.assertTrue(description.startsWith("Resource owner (resource-server-test) grants access"));
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedAccessTest.java
@@ -1,0 +1,669 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.resource.PermissionResource;
+import org.keycloak.authorization.client.resource.ProtectionResource;
+import org.keycloak.authorization.client.util.HttpResponseException;
+import org.keycloak.client.testsuite.events.EventType;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionTicketRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyEnforcementMode;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class UserManagedAccessTest extends AbstractResourceServerTest {
+
+    private ResourceRepresentation resource;
+
+    @BeforeEach
+    public void configureAuthorization() throws Exception {
+        ClientResource client = getClient(getRealm());
+        AuthorizationResource authorization = client.authorization();
+
+        JSPolicyRepresentation policy = new JSPolicyRepresentation();
+
+        policy.setName("Only Owner Policy");
+        policy.setType("script-scripts/only-owner-policy.js");
+
+        authorization.policies().js().create(policy).close();
+    }
+
+    @Test
+    public void testOnlyOwnerCanAccess() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", resource.getName(), new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[]{"ScopeA", "ScopeB"}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testOnlyOwnerCanAccessPermissionsToScope() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+        ScopePermissionRepresentation permission = new ScopePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Scope A Permission");
+        permission.addScope("ScopeA");
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().scope().create(permission).close();
+
+        permission = new ScopePermissionRepresentation();
+
+        permission.setName(resource.getName() + " Scope B Permission");
+        permission.addScope("ScopeB");
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().scope().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", resource.getName(), new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        List<PermissionTicketRepresentation> tickets = getAuthzClient().protection().permission().find(resource.getId(), null, null, null, null, null, null, null);
+
+        for (PermissionTicketRepresentation ticket : tickets) {
+            ticket.setGranted(true);
+            getAuthzClient().protection().permission().update(ticket);
+        }
+
+        response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
+
+        rpt = response.getToken();
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+        permissions = authorization.getPermissions();
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        response = authorize("marta", "password", resource.getId(), new String[] {"ScopeB"});
+
+        rpt = response.getToken();
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+        permissions = authorization.getPermissions();
+        assertPermissions(permissions, resource.getName(), "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    /**
+     * Makes sure permissions granted to a typed resource instance does not grant access to resource instances with the same type.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOnlyOwnerCanAccessResourceWithType() throws Exception {
+        ResourceRepresentation typedResource = addResource("Typed Resource", getClient(getRealm()).toRepresentation().getId(), false, "ScopeA", "ScopeB");
+
+        typedResource.setType("my:resource");
+
+        getClient(getRealm()).authorization().resources().resource(typedResource.getId()).update(typedResource);
+
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+
+        resource.setType(typedResource.getType());
+
+        getClient(getRealm()).authorization().resources().resource(resource.getId()).update(resource);
+
+        ResourceRepresentation resourceB = addResource("Resource B", "marta", true, "ScopeA", "ScopeB");
+
+        resourceB.setType(typedResource.getType());
+
+        getClient(getRealm()).authorization().resources().resource(resourceB.getId()).update(resourceB);
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+
+        permission.setName(resource.getType() + " Permission");
+        permission.setResourceType(resource.getType());
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", resource.getName(), new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        List<PermissionTicketRepresentation> tickets = getAuthzClient().protection().permission().find(resource.getId(), null, null, null, null, null, null, null);
+
+        for (PermissionTicketRepresentation ticket : tickets) {
+            ticket.setGranted(true);
+            getAuthzClient().protection().permission().update(ticket);
+        }
+
+        authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        for (PermissionTicketRepresentation ticket : tickets) {
+            getAuthzClient().protection().permission().delete(ticket.getId());
+        }
+
+        tickets = getAuthzClient().protection().permission().find(resource.getId(), null, null, null, null, null, null, null);
+
+        Assertions.assertEquals(0, tickets.size());
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testUserGrantsAccessToResource() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+
+        ClientResource client = getClient(getRealm());
+
+        client.authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"});
+
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        getRealm().clearEvents();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        List<EventRepresentation> events = getRealm()
+                .getEvents(Arrays.asList(EventType.PERMISSION_TOKEN_ERROR.name()), null, null, null, null, null, null, null);
+        Assertions.assertEquals(1, events.size());
+        EventRepresentation event = events.iterator().next();
+        final String clientId = client.toRepresentation().getClientId();
+        final String koloId = getRealm().users().search("kolo", true).get(0).getId();
+        Assertions.assertEquals(clientId, event.getClientId());
+        Assertions.assertEquals(koloId, event.getUserId());
+        Assertions.assertEquals("access_denied", event.getError());
+        Assertions.assertEquals("request_submitted", event.getDetails().get("reason"));
+
+        PermissionResource permissionResource = getAuthzClient().protection().permission();
+        List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(2, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertFalse(ticket.isGranted());
+
+            ticket.setGranted(true);
+
+            permissionResource.update(ticket);
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(2, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertTrue(ticket.isGranted());
+        }
+
+        getRealm().clearEvents();
+
+        response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
+        rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        events = getRealm().getEvents(Arrays.asList(EventType.PERMISSION_TOKEN.name()), null, null, null, null, null, null, null);
+        Assertions.assertEquals(1, events.size());
+        event = events.iterator().next();
+        Assertions.assertEquals(clientId, event.getClientId());
+        Assertions.assertEquals(koloId, event.getUserId());
+    }
+
+    @Test
+    public void testUserGrantedAccessConsideredWhenRequestingAuthorizationByResourceName() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        PermissionResource permissionResource = getAuthzClient().protection().permission();
+        List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(2, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertFalse(ticket.isGranted());
+
+            ticket.setGranted(true);
+
+            permissionResource.update(ticket);
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(2, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertTrue(ticket.isGranted());
+        }
+
+        AuthorizationRequest request1 = new AuthorizationRequest();
+        // No resource id used in request, only name
+        request1.addPermission("Resource A", "ScopeA", "ScopeB");
+
+        List<Permission> permissions = authorize("kolo", "password", request1);
+
+        Assertions.assertEquals(1, permissions.size());
+        Permission koloPermission = permissions.get(0);
+        Assertions.assertEquals("Resource A", koloPermission.getResourceName());
+        Assertions.assertTrue(koloPermission.getScopes().containsAll(Arrays.asList("ScopeA", "ScopeB")));
+
+        ResourceRepresentation resourceRep = getAuthzClient().protection().resource().findById(resource.getId());
+
+        resourceRep.setName("Resource A Changed");
+
+        getAuthzClient().protection().resource().update(resourceRep);
+
+        AuthorizationRequest request2 = new AuthorizationRequest();
+        // Try to use the old name
+        request2.addPermission("Resource A", "ScopeA", "ScopeB");
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> authorize("kolo", "password", request2));
+        Assertions.assertNotNull(re.getCause());
+        MatcherAssert.assertThat(re.getCause().toString(), Matchers.containsString("invalid_resource"));
+
+        AuthorizationRequest request3 = new AuthorizationRequest();
+        request3.addPermission(resourceRep.getName(), "ScopeA", "ScopeB");
+
+        permissions = authorize("kolo", "password", request3);
+
+        Assertions.assertEquals(1, permissions.size());
+        koloPermission = permissions.get(0);
+        Assertions.assertEquals(resourceRep.getName(), koloPermission.getResourceName());
+        Assertions.assertTrue(koloPermission.getScopes().containsAll(Arrays.asList("ScopeA", "ScopeB")));
+    }
+
+    @Test
+    public void testUserGrantsAccessToResourceWithoutScopes() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resource = addResource("Resource A", "marta", true);
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        PermissionResource permissionResource = getAuthzClient().protection().permission();
+        List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertFalse(ticket.isGranted());
+
+            ticket.setGranted(true);
+
+            permissionResource.update(ticket);
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertTrue(ticket.isGranted());
+        }
+
+        response = authorize("kolo", "password", resource.getId(), new String[] {});
+        rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName());
+        Assertions.assertTrue(permissions.isEmpty());
+
+        response = authorize("kolo", "password", resource.getId(), new String[] {});
+        rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName());
+        Assertions.assertTrue(permissions.isEmpty());
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            Assertions.assertTrue(ticket.isGranted());
+        }
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            permissionResource.delete(ticket.getId());
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertEquals(0, permissionTickets.size());
+    }
+
+    @Test
+    public void testScopePermissionsToScopeOnly() throws Exception {
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        resource = addResource("Resource A", "marta", true, "ScopeA", "ScopeB");
+
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"});
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorize("kolo", "password", resource.getId(), new String[] {"ScopeA"}));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        PermissionResource permissionResource = getAuthzClient().protection().permission();
+        List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        Assertions.assertEquals(1, permissionTickets.size());
+
+        PermissionTicketRepresentation ticket = permissionTickets.get(0);
+        Assertions.assertFalse(ticket.isGranted());
+
+        ticket.setGranted(true);
+
+        permissionResource.update(ticket);
+
+        response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
+        rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        accessToken = toAccessToken(rpt);
+        authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, resource.getName(), "ScopeA");
+        Assertions.assertTrue(permissions.isEmpty());
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertFalse(permissionTickets.isEmpty());
+        // must have two permission tickets, one persisted during the first authorize call for ScopeA and another for the second call to authorize for ScopeB
+        Assertions.assertEquals(2, permissionTickets.size());
+
+        for (PermissionTicketRepresentation representation : new ArrayList<>(permissionTickets)) {
+            if (representation.isGranted()) {
+                permissionResource.delete(representation.getId());
+            }
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        Assertions.assertEquals(1, permissionTickets.size());
+    }
+
+    @Test
+    public void testPermissiveModePermissions() throws Exception {
+        resource = addResource("Resource A");
+
+        try {
+            authorize("kolo", "password", resource.getId(), null);
+            Assertions.fail("Access should be denied, server in enforcing mode");
+        } catch (AuthorizationDeniedException ade) {
+
+        }
+
+        AuthorizationResource authorizationResource = getClient(getRealm()).authorization();
+        ResourceServerRepresentation settings = authorizationResource.getSettings();
+
+        settings.setPolicyEnforcementMode(PolicyEnforcementMode.PERMISSIVE);
+
+        authorizationResource.update(settings);
+
+        AuthorizationResponse response = authorize("marta", "password", "Resource A", null);
+        String rpt = response.getToken();
+
+        Assertions.assertNotNull(rpt);
+        Assertions.assertFalse(response.isUpgraded());
+
+        AccessToken accessToken = toAccessToken(rpt);
+        AccessToken.Authorization authorization = accessToken.getAuthorization();
+
+        Assertions.assertNotNull(authorization);
+
+        Collection<Permission> permissions = authorization.getPermissions();
+
+        Assertions.assertNotNull(permissions);
+        assertPermissions(permissions, "Resource A");
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testResourceIsUserManagedCheck() throws Exception {
+        resource = addResource("Resource A", null, false, "ScopeA");
+
+        PermissionTicketRepresentation ticket = new PermissionTicketRepresentation();
+        ticket.setResource(resource.getId());
+        ticket.setRequesterName("marta");
+        ticket.setScopeName("ScopeA");
+        ticket.setGranted(true);
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> protection.permission().create(ticket));
+        MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
+        Assertions.assertEquals(400, HttpResponseException.class.cast(re.getCause()).getStatusCode());
+        HttpResponseException hre = HttpResponseException.class.cast(re.getCause());
+        MatcherAssert.assertThat(hre.toString(), Matchers.containsString("invalid_permission"));
+        MatcherAssert.assertThat(hre.toString(), Matchers.containsString("permission can only be created for resources with user-managed access enabled"));
+    }
+
+    private List<Permission> authorize(String userName, String password, AuthorizationRequest request) {
+        AuthorizationResponse response = getAuthzClient().authorization(userName, password).authorize(request);
+        AccessToken token = toAccessToken(response.getToken());
+        AccessToken.Authorization authorization = token.getAuthorization();
+        return new ArrayList<>(authorization.getPermissions());
+    }
+}

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -1,0 +1,866 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.client.testsuite.authz;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.resource.AuthorizationResource;
+import org.keycloak.authorization.client.resource.PolicyResource;
+import org.keycloak.authorization.client.resource.ProtectionResource;
+import org.keycloak.authorization.client.util.HttpResponseException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.keycloak.representations.idm.authorization.PermissionResponse;
+import org.keycloak.representations.idm.authorization.PermissionTicketRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.UmaPermissionRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.GroupBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.testsuite.util.RolesBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
+import org.testcontainers.shaded.org.hamcrest.Matchers;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class UserManagedPermissionServiceTest extends AbstractResourceServerTest {
+
+    @Override
+    public List<RealmRepresentation> getRealmsForImport() {
+        List<RealmRepresentation> testRealms = new ArrayList<>();
+        testRealms.add(RealmBuilder.create().name(REALM_NAME)
+                .roles(RolesBuilder.create()
+                        .realmRole(RoleBuilder.create().name("uma_authorization").build())
+                        .realmRole(RoleBuilder.create().name("uma_protection").build())
+                        .realmRole(RoleBuilder.create().name("role_a").build())
+                        .realmRole(RoleBuilder.create().name("role_b").build())
+                        .realmRole(RoleBuilder.create().name("role_c").build())
+                        .realmRole(RoleBuilder.create().name("role_d").build())
+                )
+                .group(GroupBuilder.create().name("group_a")
+                        .subGroups(Arrays.asList(GroupBuilder.create().name("group_b").build()))
+                        .build())
+                .group(GroupBuilder.create().name("group_c").build())
+                .group(GroupBuilder.create().name("group_remove").build())
+                .user(UserBuilder.create().username("marta").password("password")
+                        .addRoles("uma_authorization", "uma_protection")
+                        .role("resource-server-test", "uma_protection"))
+                .user(UserBuilder.create().username("alice").password("password")
+                        .addRoles("uma_authorization", "uma_protection")
+                        .role("resource-server-test", "uma_protection"))
+                .user(UserBuilder.create().username("kolo").password("password")
+                        .addRoles("role_a")
+                        .addGroups("group_a"))
+                .client(ClientBuilder.create().clientId("resource-server-test")
+                        .secret("secret")
+                        .authorizationServicesEnabled(true)
+                        .redirectUris("http://localhost/resource-server-test")
+                        .defaultRoles("uma_protection")
+                        .directAccessGrants()
+                        .serviceAccountsEnabled(true))
+                .client(ClientBuilder.create().clientId("client-a")
+                        .redirectUris("http://localhost/resource-server-test")
+                        .publicClient())
+                .client(ClientBuilder.create().clientId("client-remove")
+                        .redirectUris("http://localhost/resource-server-test")
+                        .publicClient())
+                .build());
+        return testRealms;
+    }
+
+    private void testCreate() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        UmaPermissionRepresentation newPermission = new UmaPermissionRepresentation();
+
+        newPermission.setName("Custom User-Managed Permission");
+        newPermission.setDescription("Users from specific roles are allowed to access");
+        newPermission.addScope("Scope A", "Scope B", "Scope C");
+        newPermission.addRole("role_a", "role_b", "role_c", "role_d");
+        newPermission.addGroup("/group_a", "/group_a/group_b", "/group_c");
+        newPermission.addClient("client-a", "resource-server-test");
+
+        newPermission.setCondition("script-scripts/default-policy.js");
+
+        newPermission.addUser("kolo");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        UmaPermissionRepresentation permission = protection.policy(resource.getId()).create(newPermission);
+
+        Assertions.assertEquals(newPermission.getName(), permission.getName());
+        Assertions.assertEquals(newPermission.getDescription(), permission.getDescription());
+        Assertions.assertNotNull(permission.getScopes());
+        Assertions.assertTrue(permission.getScopes().containsAll(newPermission.getScopes()));
+        Assertions.assertNotNull(permission.getRoles());
+        Assertions.assertTrue(permission.getRoles().containsAll(newPermission.getRoles()));
+        Assertions.assertNotNull(permission.getGroups());
+        Assertions.assertTrue(permission.getGroups().containsAll(newPermission.getGroups()));
+        Assertions.assertNotNull(permission.getClients());
+        Assertions.assertTrue(permission.getClients().containsAll(newPermission.getClients()));
+        Assertions.assertEquals(newPermission.getCondition(), permission.getCondition());
+        Assertions.assertNotNull(permission.getUsers());
+        Assertions.assertTrue(permission.getUsers().containsAll(newPermission.getUsers()));
+    }
+
+    @Test
+    public void testCreateDeprecatedFeaturesEnabled() {
+        testCreate();
+    }
+
+    @Test
+    public void testCreateDeprecatedFeaturesDisabled() {
+        testCreate();
+    }
+
+    private void testUpdate() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        UmaPermissionRepresentation permissionTmp = new UmaPermissionRepresentation();
+
+        permissionTmp.setName("Custom User-Managed Permission");
+        permissionTmp.setDescription("Users from specific roles are allowed to access");
+        permissionTmp.addScope("Scope A");
+        permissionTmp.addRole("role_a");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        final UmaPermissionRepresentation permission = protection.policy(resource.getId()).create(permissionTmp);
+
+        Assertions.assertEquals(1, getAssociatedPolicies(permission).size());
+
+        permission.setName("Changed");
+        permission.setDescription("Changed");
+
+        protection.policy(resource.getId()).update(permission);
+
+        UmaPermissionRepresentation updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getName(), updated.getName());
+        Assertions.assertEquals(permission.getDescription(), updated.getDescription());
+
+        permission.removeRole("role_a");
+        permission.addRole("role_b", "role_c");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(1, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getRoles().containsAll(updated.getRoles()));
+
+        permission.addRole("role_d");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(1, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getRoles().containsAll(updated.getRoles()));
+
+        permission.addGroup("/group_a/group_b");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(2, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getGroups().containsAll(updated.getGroups()));
+
+        permission.addGroup("/group_a");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(2, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getGroups().containsAll(updated.getGroups()));
+
+        permission.removeGroup("/group_a/group_b");
+        permission.addGroup("/group_c");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(2, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getGroups().containsAll(updated.getGroups()));
+
+        permission.addClient("client-a");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(3, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getClients().containsAll(updated.getClients()));
+
+        permission.addClient("resource-server-test");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(3, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getClients().containsAll(updated.getClients()));
+
+        permission.removeClient("client-a");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(3, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertTrue(permission.getClients().containsAll(updated.getClients()));
+
+        permission.setCondition("script-scripts/default-policy.js");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(4, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getCondition(), updated.getCondition());
+
+        permission.addUser("alice");
+
+        protection.policy(resource.getId()).update(permission);
+
+        int expectedPolicies = 5;
+
+        Assertions.assertEquals(expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+        Assertions.assertEquals(1, updated.getUsers().size());
+        Assertions.assertEquals(permission.getUsers(), updated.getUsers());
+
+        permission.addUser("kolo");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+        Assertions.assertEquals(2, updated.getUsers().size());
+        Assertions.assertEquals(permission.getUsers(), updated.getUsers());
+
+        permission.removeUser("alice");
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+        Assertions.assertEquals(1, updated.getUsers().size());
+        Assertions.assertEquals(permission.getUsers(), updated.getUsers());
+
+        permission.setUsers(null);
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(--expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getUsers(), updated.getUsers());
+
+        permission.setCondition(null);
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(--expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getCondition(), updated.getCondition());
+
+        permission.setRoles(null);
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(--expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getRoles(), updated.getRoles());
+
+        permission.setClients(null);
+
+        protection.policy(resource.getId()).update(permission);
+        Assertions.assertEquals(--expectedPolicies, getAssociatedPolicies(permission).size());
+        updated = protection.policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertEquals(permission.getClients(), updated.getClients());
+
+        permission.setGroups(null);
+
+        protection.policy(resource.getId()).update(permission);
+
+        NotFoundException nfe = Assertions.assertThrows(NotFoundException.class, () -> getAssociatedPolicies(permission));
+        Assertions.assertEquals(404, nfe.getResponse().getStatus());
+    }
+
+    @Test
+    public void testUpdatePermission() {
+        testUpdate();
+    }
+
+    @Test
+    public void testUploadScriptDisabled() {
+        ResourceRepresentation resourceTmp = new ResourceRepresentation();
+
+        resourceTmp.setName("Resource A");
+        resourceTmp.setOwnerManagedAccess(true);
+        resourceTmp.setOwner("marta");
+        resourceTmp.addScope("Scope A", "Scope B", "Scope C");
+
+        final ResourceRepresentation resource = getAuthzClient().protection().resource().create(resourceTmp);
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        UmaPermissionRepresentation newPermission = new UmaPermissionRepresentation();
+        newPermission.setName("Custom User-Managed Permission");
+        newPermission.setDescription("Users from specific roles are allowed to access");
+        newPermission.setCondition("$evaluation.grant()");
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> protection.policy(resource.getId()).create(newPermission));
+        MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
+    }
+
+    @Test
+    public void testUserManagedPermission() {
+        ResourceRepresentation resourceTmp = new ResourceRepresentation();
+
+        resourceTmp.setName("Resource A");
+        resourceTmp.setOwnerManagedAccess(true);
+        resourceTmp.setOwner("marta");
+        resourceTmp.addScope("Scope A", "Scope B", "Scope C");
+
+        final ResourceRepresentation resource = getAuthzClient().protection().resource().create(resourceTmp);
+
+        UmaPermissionRepresentation permissionTmp = new UmaPermissionRepresentation();
+
+        permissionTmp.setName("Custom User-Managed Permission");
+        permissionTmp.setDescription("Users from specific roles are allowed to access");
+        permissionTmp.addScope("Scope A");
+        permissionTmp.addRole("role_a");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        final UmaPermissionRepresentation permission = protection.policy(resource.getId()).create(permissionTmp);
+
+        AuthorizationResource authorization = getAuthzClient().authorization("kolo", "password");
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(resource.getId(), "Scope A");
+
+        AuthorizationResponse authzResponse = authorization.authorize(request);
+
+        Assertions.assertNotNull(authzResponse);
+
+        permission.removeRole("role_a");
+        permission.addRole("role_b");
+
+        protection.policy(resource.getId()).update(permission);
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorization.authorize(request));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("alice", "password").authorize(request));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        permission.addRole("role_a");
+
+        protection.policy(resource.getId()).update(permission);
+
+        authzResponse = authorization.authorize(request);
+
+        Assertions.assertNotNull(authzResponse);
+
+        protection.policy(resource.getId()).delete(permission.getId());
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorization.authorize(request));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> getAuthzClient().protection("marta", "password").policy(resource.getId()).findById(permission.getId()));
+        MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
+        Assertions.assertEquals(404, HttpResponseException.class.cast(re.getCause()).getStatusCode());
+
+        // create a user based permission, where only selected users are allowed access to the resource.
+        final UmaPermissionRepresentation permission2 = new UmaPermissionRepresentation();
+        permission2.setName("Custom User-Managed Permission");
+        permission2.setDescription("Specific users are allowed access to the resource");
+        permission2.addScope("Scope A");
+        permission2.addUser("alice");
+        protection.policy(resource.getId()).create(permission2);
+
+        // alice should be able to access the resource with the updated permission.
+        authzResponse = getAuthzClient().authorization("alice", "password").authorize(request);
+        Assertions.assertNotNull(authzResponse);
+
+        // kolo shouldn't be able to access the resource with the updated permission.
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> authorization.authorize(request));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testRemovePolicyWhenOwnerDeleted() {
+        final ClientResource client = getClient(getRealm());
+
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+        permission.setName("Custom User-Managed Permission");
+        permission.addUser("kolo");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        permission = protection.policy(resource.getId()).create(permission);
+        PolicyRepresentation policy = client.authorization().policies().policy(permission.getId()).toRepresentation();
+
+        AuthorizationResource authorization = getAuthzClient().authorization("kolo", "password");
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(resource.getId(), "Scope A");
+
+        AuthorizationResponse authzResponse = authorization.authorize(request);
+
+        Assertions.assertNotNull(authzResponse);
+
+        UsersResource users = adminClient.realm(REALM_NAME).users();
+        UserRepresentation marta = users.search("marta").get(0);
+
+        users.delete(marta.getId());
+
+        NotFoundException nfe = Assertions.assertThrows(NotFoundException.class,
+                () -> client.authorization().policies().policy(policy.getId()).toRepresentation());
+        Assertions.assertEquals(404, nfe.getResponse().getStatus());
+    }
+
+    @Test
+    public void testPermissionInAdditionToUserGrantedPermission() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        PermissionResponse ticketResponse = getAuthzClient().protection().permission().create(new PermissionRequest(resource.getId(), "Scope A"));
+
+        AuthorizationRequest request1 = new AuthorizationRequest();
+
+        request1.setTicket(ticketResponse.getTicket());
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request1));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("request_submitted"));
+
+        List<PermissionTicketRepresentation> tickets = getAuthzClient().protection().permission().findByResource(resource.getId());
+
+        Assertions.assertEquals(1, tickets.size());
+
+        PermissionTicketRepresentation ticket = tickets.get(0);
+
+        ticket.setGranted(true);
+
+        getAuthzClient().protection().permission().update(ticket);
+
+        AuthorizationResponse authzResponse = getAuthzClient().authorization("kolo", "password").authorize(request1);
+
+        Assertions.assertNotNull(authzResponse);
+
+        UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+        permission.setName("Custom User-Managed Permission");
+        permission.addScope("Scope A");
+        permission.addRole("role_a");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        permission = protection.policy(resource.getId()).create(permission);
+
+        getAuthzClient().authorization("kolo", "password").authorize(request1);
+
+        ticket.setGranted(false);
+
+        getAuthzClient().protection().permission().update(ticket);
+
+        getAuthzClient().authorization("kolo", "password").authorize(request1);
+
+        permission = getAuthzClient().protection("marta", "password").policy(resource.getId()).findById(permission.getId());
+
+        Assertions.assertNotNull(permission);
+
+        permission.removeRole("role_a");
+        permission.addRole("role_b");
+
+        getAuthzClient().protection("marta", "password").policy(resource.getId()).update(permission);
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request1));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        AuthorizationRequest request2 = new AuthorizationRequest();
+
+        request2.addPermission(resource.getId());
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request2));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        getAuthzClient().protection("marta", "password").policy(resource.getId()).delete(permission.getId());
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request2));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testPermissionWithoutScopes() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName(UUID.randomUUID().toString());
+        resource.setOwner("marta");
+        resource.setOwnerManagedAccess(true);
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        resource = protection.resource().create(resource);
+
+        UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+        permission.setName("Custom User-Managed Policy");
+        permission.addRole("role_a");
+
+        PolicyResource policy = getAuthzClient().protection("marta", "password").policy(resource.getId());
+
+        permission = policy.create(permission);
+
+        Assertions.assertEquals(3, permission.getScopes().size());
+        Assertions.assertTrue(Arrays.asList("Scope A", "Scope B", "Scope C").containsAll(permission.getScopes()));
+
+        permission = policy.findById(permission.getId());
+
+        Assertions.assertTrue(Arrays.asList("Scope A", "Scope B", "Scope C").containsAll(permission.getScopes()));
+        Assertions.assertEquals(3, permission.getScopes().size());
+
+        permission.removeScope("Scope B");
+
+        policy.update(permission);
+        permission = policy.findById(permission.getId());
+
+        Assertions.assertEquals(2, permission.getScopes().size());
+        Assertions.assertTrue(Arrays.asList("Scope A", "Scope C").containsAll(permission.getScopes()));
+    }
+
+    @Test
+    public void testOnlyResourceOwnerCanManagePolicies() {
+        ResourceRepresentation resourceTmp = new ResourceRepresentation();
+
+        resourceTmp.setName(UUID.randomUUID().toString());
+        resourceTmp.setOwner("marta");
+        resourceTmp.addScope("Scope A", "Scope B", "Scope C");
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        final ResourceRepresentation resource = protection.resource().create(resourceTmp);
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> getAuthzClient().protection("alice", "password").policy(resource.getId()).create(new UmaPermissionRepresentation()));
+        MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
+        Assertions.assertEquals(400, HttpResponseException.class.cast(re.getCause()).getStatusCode());
+        MatcherAssert.assertThat(HttpResponseException.class.cast(re.getCause()).toString(),
+                Matchers.containsString("Only resource owner can access policies for resource"));
+    }
+
+    @Test
+    public void testOnlyResourcesWithOwnerManagedAccess() {
+        ResourceRepresentation resourceTmp = new ResourceRepresentation();
+
+        resourceTmp.setName(UUID.randomUUID().toString());
+        resourceTmp.setOwner("marta");
+        resourceTmp.addScope("Scope A", "Scope B", "Scope C");
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        final ResourceRepresentation resource = protection.resource().create(resourceTmp);
+
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class,
+                () -> getAuthzClient().protection("marta", "password").policy(resource.getId()).create(new UmaPermissionRepresentation()));
+        MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
+        Assertions.assertEquals(400, HttpResponseException.class.cast(re.getCause()).getStatusCode());
+        MatcherAssert.assertThat(HttpResponseException.class.cast(re.getCause()).toString(),
+        Matchers.containsString("Only resources with owner managed accessed can have policies"));
+    }
+
+    @Test
+    public void testOwnerAccess() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName(UUID.randomUUID().toString());
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+        resource.setOwnerManagedAccess(true);
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        resource = protection.resource().create(resource);
+
+        UmaPermissionRepresentation rep = new UmaPermissionRepresentation();
+        rep.setName("test");
+        rep.addRole("role_b");
+
+        rep = getAuthzClient().protection("marta", "password").policy(resource.getId()).create(rep);
+
+        AuthorizationResource authorization = getAuthzClient().authorization("marta", "password");
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(resource.getId(), "Scope A");
+
+        AuthorizationResponse authorize = authorization.authorize(request);
+
+        Assertions.assertNotNull(authorize);
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        rep.addRole("role_a");
+
+        getAuthzClient().protection("marta", "password").policy(resource.getId()).update(rep);
+
+        authorization = getAuthzClient().authorization("kolo", "password");
+
+        Assertions.assertNotNull(authorization.authorize(request));
+    }
+
+    @Test
+    public void testFindPermission() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName(UUID.randomUUID().toString());
+        resource.setOwner("marta");
+        resource.setOwnerManagedAccess(true);
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        ProtectionResource protection = getAuthzClient().protection();
+
+        resource = protection.resource().create(resource);
+
+        PolicyResource policy = getAuthzClient().protection("marta", "password").policy(resource.getId());
+
+        for (int i = 0; i < 10; i++) {
+            UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+            permission.setName("Custom User-Managed Policy " + i);
+            permission.addRole("role_a");
+
+            policy.create(permission);
+        }
+
+        Assertions.assertEquals(10, policy.find(null, null, null, null).size());
+
+        List<UmaPermissionRepresentation> byId = policy.find("Custom User-Managed Policy 8", null, null, null);
+
+        Assertions.assertEquals(1, byId.size());
+        Assertions.assertEquals(byId.get(0).getId(), policy.findById(byId.get(0).getId()).getId());
+        Assertions.assertEquals(10, policy.find(null, "Scope A", null, null).size());
+        Assertions.assertEquals(5, policy.find(null, null, -1, 5).size());
+        Assertions.assertEquals(2, policy.find(null, null, -1, 2).size());
+    }
+
+    @Test
+    public void testGrantRequestedScopesOnly() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName(UUID.randomUUID().toString());
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("view", "delete");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        resource = protection.resource().create(resource);
+
+        UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+        permission.setName("Custom User-Managed Permission");
+        permission.addScope("view");
+        permission.addUser("kolo");
+
+        protection.policy(resource.getId()).create(permission);
+
+        AuthorizationRequest request1 = new AuthorizationRequest();
+
+        request1.addPermission(resource.getId(), "view");
+
+        AuthorizationResponse response = getAuthzClient().authorization("kolo", "password").authorize(request1);
+        AccessToken rpt = toAccessToken(response.getToken());
+        Collection<Permission> permissions = rpt.getAuthorization().getPermissions();
+
+        assertPermissions(permissions, resource.getId(), "view");
+
+        Assertions.assertTrue(permissions.isEmpty());
+
+        AuthorizationRequest request2 = new AuthorizationRequest();
+
+        request2.addPermission(resource.getId(), "delete");
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request2));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        AuthorizationRequest request3 = new AuthorizationRequest();
+
+        request3.addPermission(resource.getId(), "delete");
+
+        ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize(request3));
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+
+        AuthorizationRequest request4 = new AuthorizationRequest();
+
+        request4.addPermission(resource.getId());
+
+        response = getAuthzClient().authorization("kolo", "password").authorize(request4);
+        rpt = toAccessToken(response.getToken());
+        permissions = rpt.getAuthorization().getPermissions();
+
+        assertPermissions(permissions, resource.getId(), "view");
+
+        Assertions.assertTrue(permissions.isEmpty());
+    }
+
+    @Test
+    public void testDoNotGrantPermissionWhenObtainAllEntitlements() {
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
+
+        permission.setName("Custom User-Managed Permission");
+        permission.addScope("Scope A", "Scope B");
+        permission.addUser("kolo");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        protection.policy(resource.getId()).create(permission);
+
+        AuthorizationResource authorization = getAuthzClient().authorization("kolo", "password");
+
+        AuthorizationRequest request = new AuthorizationRequest();
+
+        request.addPermission(resource.getId(), "Scope A", "Scope B");
+
+        AuthorizationResponse authzResponse = authorization.authorize(request);
+        Assertions.assertNotNull(authzResponse);
+
+        AccessToken token = toAccessToken(authzResponse.getToken());
+        Assertions.assertNotNull(token.getAuthorization());
+
+        Collection<Permission> permissions = token.getAuthorization().getPermissions();
+        Assertions.assertEquals(1, permissions.size());
+
+        Assertions.assertTrue(permissions
+                .iterator().next().getScopes().containsAll(Arrays.asList("Scope A", "Scope B")));
+
+        AuthorizationDeniedException ade = Assertions.assertThrows(AuthorizationDeniedException.class,
+                () -> getAuthzClient().authorization("kolo", "password").authorize());
+        MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
+    }
+
+    @Test
+    public void testRemovePoliciesOnResourceDelete() {
+        final ClientResource client = getClient(getRealm());
+
+        ResourceRepresentation resource = new ResourceRepresentation();
+
+        resource.setName("Resource A");
+        resource.setOwnerManagedAccess(true);
+        resource.setOwner("marta");
+        resource.addScope("Scope A", "Scope B", "Scope C");
+
+        resource = getAuthzClient().protection().resource().create(resource);
+
+        UmaPermissionRepresentation newPermission = new UmaPermissionRepresentation();
+
+        newPermission.setName("Custom User-Managed Permission");
+        newPermission.setDescription("Users from specific roles are allowed to access");
+        newPermission.addScope("Scope A", "Scope B", "Scope C");
+        newPermission.addRole("role_a", "role_b", "role_c", "role_d");
+        newPermission.addGroup("/group_a", "/group_a/group_b", "/group_c");
+        newPermission.addClient("client-a", "resource-server-test");
+
+        newPermission.setCondition("script-scripts/default-policy.js");
+
+        newPermission.addUser("kolo");
+
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+
+        newPermission = protection.policy(resource.getId()).create(newPermission);
+        PolicyRepresentation policy = client.authorization().policies().policy(newPermission.getId()).toRepresentation();
+
+        client.authorization().resources().resource(resource.getId()).remove();
+
+        NotFoundException nfe = Assertions.assertThrows(NotFoundException.class,
+                () -> client.authorization().policies().policy(policy.getId()).toRepresentation());
+        Assertions.assertEquals(404, nfe.getResponse().getStatus());
+    }
+
+    private List<PolicyRepresentation> getAssociatedPolicies(UmaPermissionRepresentation permission) {
+        return getClient(getRealm()).authorization().policies().policy(permission.getId()).associatedPolicies();
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
@@ -315,6 +315,33 @@ public class OAuthClient {
         }
     }
 
+    public String introspectTokenWithClientCredential(String realm, String clientId, String clientSecret, String tokenType, String tokenToIntrospect) {
+        HttpPost post = new HttpPost(getTokenIntrospectionUrl(realm));
+
+        String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
+        post.setHeader("Authorization", authorization);
+
+        List<NameValuePair> parameters = new LinkedList<>();
+
+        parameters.add(new BasicNameValuePair("token", tokenToIntrospect));
+        parameters.add(new BasicNameValuePair("token_type_hint", tokenType));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        post.setEntity(formEntity);
+
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to retrieve access token", e);
+        }
+    }
+
+    private String getTokenIntrospectionUrl(String realmName) {
+        return KeycloakUriBuilder.fromUri(ServerURLs.AUTH_SERVER_URL + "/realms/{realmName}/protocol/openid-connect/token/introspect")
+                .build(realmName)
+                .toString();
+    }
+
     private String getLoginUrlForCode() {
         KeycloakUriBuilder b = KeycloakUriBuilder.fromUri(ServerURLs.AUTH_SERVER_URL + "/realms/{realmName}/protocol/openid-connect/auth");
         b.queryParam(OAuth2Constants.RESPONSE_TYPE, "code");


### PR DESCRIPTION
More tests for the authz. With this bunch all the `org.keycloak.testsuite.authz` package is finished. No issues except that `UserManagedPermissionServiceTest` needed some refactoring.

Closes #73