### PR TITLE
Setup CI nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Keycloak Client CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,8 +1,6 @@
 name: Keycloak Client Nightly Release
 
 on:
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -1,0 +1,24 @@
+name: Scheduled nightly workflows
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  run-ci:
+    name: Run nightly workflows
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-client'
+
+    strategy:
+      matrix:
+        workflow:
+          - ci.yml
+          - release-nightly.yml
+
+    steps:
+      - run: gh workflow run -R ${{ github.repository }} ${{ matrix.workflow }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
closes #92

The nightly scheduled is updated to schedule both release and CI.

NOTE: Tests failing because of https://github.com/keycloak/keycloak-client/issues/94