### PR TITLE
Sync with Keycloak server and send PR

### DIFF
--- a/.github/actions/build-keycloak-client/action.yml
+++ b/.github/actions/build-keycloak-client/action.yml
@@ -1,0 +1,44 @@
+name: Build Keycloak Client
+description: Builds Keycloak client providing Maven repository with all artifacts
+
+inputs:
+  upload-m2-repo:
+    description: Upload Maven repository for org.keycloak artifacts
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - id: setup-java
+      name: Setup Java
+      uses: ./.github/actions/java-setup
+
+    - id: maven-cache
+      name: Maven cache
+      uses: ./.github/actions/maven-cache
+      with:
+        create-cache-if-it-doesnt-exist: true
+
+    - id: build-keycloak-client
+      name: Build Keycloak Client libraries
+      shell: bash
+      run: mvn -B clean install dependency:resolve -Pnightly -DskipTests=true
+
+    - id: compress-keycloak-maven-repository
+      name: Compress Keycloak Maven artifacts
+      if: inputs.upload-m2-repo == 'true'
+      shell: bash
+      run: |
+        tar -C ~/ --use-compress-program zstd -cf m2-keycloak-client.tzts \
+        --exclude '*.tar.gz' \
+        .m2/repository/org/keycloak
+
+    - id: upload-keycloak-maven-repository
+      name: Upload Keycloak Maven artifacts
+      if: inputs.upload-m2-repo == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: m2-keycloak-client.tzts
+        path: m2-keycloak-client.tzts
+        retention-days: 1

--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -1,5 +1,5 @@
-name: Build Keycloak Client
-description: Builds Keycloak client providing Maven repository with all artifacts
+name: Build Keycloak
+description: Builds Keycloak providing Maven repository with all artifacts
 
 inputs:
   upload-m2-repo:
@@ -20,10 +20,18 @@ runs:
       with:
         create-cache-if-it-doesnt-exist: true
 
-    - id: build-keycloak-client
-      name: Build Keycloak Client libraries
+    - id: pnpm-store-cache
+      name: PNPM store cache
+      uses: ./.github/actions/pnpm-store-cache
+
+    - id: build-keycloak
+      name: Build Keycloak
       shell: bash
-      run: mvn -B clean install dependency:resolve -Pnightly -DskipTests=true
+      run: |
+        # Ensure this plugin is built first to avoid warnings in the build
+        ./mvnw install -Pdistribution -am -pl distribution/maven-plugins/licenses-processor
+        # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests
+        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples -DexcludeGroupIds=org.keycloak -Dsilent=true -DcommitProtoLockChanges=true
 
     - id: compress-keycloak-maven-repository
       name: Compress Keycloak Maven artifacts

--- a/.github/actions/pnpm-store-cache/action.yml
+++ b/.github/actions/pnpm-store-cache/action.yml
@@ -1,0 +1,20 @@
+name: Cache PNPM store
+description: Caches the PNPM store to speed up the build.
+
+runs:
+  using: composite
+  steps:
+    - id: weekly-cache-key
+      name: Key for weekly rotation of cache
+      shell: bash
+      run: echo "key=pnpm-store-`date -u "+%Y-%U"`" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      name: Cache PNPM store
+      with:
+        # See: https://pnpm.io/npmrc#store-dir
+        path: |
+          ~/.local/share/pnpm/store
+          ~/AppData/Local/pnpm/store
+          ~/Library/pnpm/store
+        key: ${{ runner.os }}-${{ steps.weekly-cache-key.outputs.key }}

--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -15,7 +15,7 @@ runs:
       name: Download Keycloak Maven artifacts
       uses: actions/download-artifact@v4
       with:
-        name: m2-keycloak.tzts
+        name: m2-keycloak-client.tzts
 
     - id: extract-maven-artifacts
       name: Extract Keycloak Maven artifacts
@@ -24,4 +24,4 @@ runs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           choco install zstandard
         fi
-        tar -C ~/ --use-compress-program="zstd -d" -xf m2-keycloak.tzts
+        tar -C ~/ --use-compress-program="zstd -d" -xf m2-keycloak-client.tzts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Keycloak Client Libs
-        uses: ./.github/actions/build-keycloak
+        uses: ./.github/actions/build-keycloak-client
 
   client-tests:
     name: Client tests (Jakarta, JEE)

--- a/.github/workflows/sync-and-send-pr.yml
+++ b/.github/workflows/sync-and-send-pr.yml
@@ -1,0 +1,73 @@
+name: Sync with Keycloak Server and send PR with changes
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      REPO_HEAD: "keycloak"
+      KEYCLOAK_CLIENT_BRANCH: "main"
+
+    steps:
+      - name: Find latest Keycloak release branch
+        id: latest_release
+        run: |
+          LATEST_RELEASE=$(git ls-remote --heads https://github.com/keycloak/keycloak.git 'release/*' | awk -F'/' '{print $NF}' | sort -V | tail -n1)
+          echo "KEYCLOAK_RELEASE_BRANCH_NAME=release/$LATEST_RELEASE" >> $GITHUB_ENV
+
+      - name: Checkout Keycloak latest release
+        uses: actions/checkout@v4
+        with:
+          repository: keycloak/keycloak
+          ref: ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }}
+
+      - name: Build Keycloak
+        uses: ./.github/actions/build-keycloak
+
+      - name: Checkout Keycloak Client
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.REPO_HEAD }}/keycloak-client
+          ref: ${{ env.KEYCLOAK_CLIENT_BRANCH }}
+
+      - name: Build Keycloak Client
+        uses: ./.github/actions/build-keycloak-client
+
+      - name: Sync Keycloak sources
+        run: ./.github/scripts/sync-keycloak-sources.sh
+
+      - name: Config git and GitHub CLI
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check for changes in client-common-synced
+        id: changes_check
+        run: |
+          if [ -z "$(git status --porcelain client-common-synced)" ]; then
+            echo "No changes detected in client-common-synced, stopping the workflow."
+            echo "CHANGES_CHECK=false" >> $GITHUB_ENV
+          else
+            echo "CHANGES_CHECK=true" >> $GITHUB_ENV
+          fi
+
+      - name: Create and push new branch
+        if: env.CHANGES_CHECK == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH_NAME="sync-with-keycloak-server-${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }}"
+          git checkout -b $BRANCH_NAME
+          git add client-common-synced
+          git commit -m "Sync with Keycloak server release branch ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }}" --author="${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+          git push --set-upstream origin $BRANCH_NAME
+
+      - name: Create pull request with gh CLI
+        if: env.CHANGES_CHECK == 'true'
+        run: |
+          PR_TITLE="Sync with Keycloak server ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }} branch"
+          PR_BODY="This PR syncs keycloak-client with the latest Keycloak release branch ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }}"
+          gh pr create --base main --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"


### PR DESCRIPTION
Closes #101

Created a workflow that follows these steps:

- Finds the latest release/* branch in the Keycloak repository.
- Checks out Keycloak with the release branch.
- Build Keycloak.
- Checks out keycloak-client with the main branch.
- Build keycloak-client.
- Synchronizes with Keycloak using the `sync-keycloak-sources.sh` script.
- Exits the workflow if no changes are detected in `client-common-synced`.
- Creates and pushes a new branch named `sync-with-keycloak-server-${release/*}` on the Keycloak repository with the detected changes.
- Creates a pull request from the `sync-with-keycloak-server-${release/*}` branch to main.

I tested the workflow on my fork by modifying the branch in the workflow dispatch:
```yaml
workflow_dispatch:
push:
  branches:
    - issue-101
```

and setting the following environment variables:
- `REPO_HEAD`: "graziang"
- `KEYCLOAK_CLIENT_BRANCH`: "issue-101"

With the current configuration, the branch is created directly on keycloak/keycloak-client, and the PR is sent by the GitHub Action bot. An alternative approach could be to create the branch on the fork of the user who triggers the workflow, allowing the user to submit the PR themselves.