### PR TITLE
Move upgrading guide for keycloak-client libraries to the client docu…

### DIFF
--- a/docs/guides/attributes.adoc
+++ b/docs/guides/attributes.adoc
@@ -8,5 +8,7 @@
 :developerguide_name: Server Developer Guide
 :developerguide_name_short: Server Developer
 :developerguide_link: {project_doc_base_url}/server_development/
+:project_product: false
+:project_community: true
 :section: guide
 :sections: guides

--- a/docs/guides/securing-apps/upgrading.adoc
+++ b/docs/guides/securing-apps/upgrading.adoc
@@ -1,0 +1,29 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+[[_upgrade_client_libraries]]
+<@tmpl.guide
+title="Upgrading the {project_name} Client Libraries"
+priority=540
+summary="How to upgrade the {project_name} Client Libraries">
+
+The client libraries are those artifacts:
+
+* Java admin client - Maven artifact `org.keycloak:keycloak-admin-client`
+* Java authorization client - Maven artifact `org.keycloak:keycloak-authz-client`
+* Java policy enforcer - Maven artifact `org.keycloak:keycloak-policy-enforcer`
+* Java common classes used by other client libraries above - Maven artifact `org.keycloak:keycloak-client-common-synced`
+
+ifeval::[{project_community}==true]
+The client libraries are supported with the last supported {project_name} server version.
+endif::[]
+ifeval::[{project_product}==true]
+The client libraries are supported with all the supported {project_name} server versions. The fact that client libraries are supported with more server versions makes the update easier,
+so you may not need to update the server at the same time when you update client libraries of your application.
+endif::[]
+
+It is possible that client libraries may work even with the older releases of the {project_name} server, but it is not guaranteed and officially supported.
+
+It may be needed to consult the javadoc of the client libraries like Java admin-client to see what endpoints and parameters are supported with which {project_name} server version.
+
+</@tmpl.guide>


### PR DESCRIPTION
…mentation

closes #93

Moving this section https://www.keycloak.org/docs/latest/upgrading/index.html#upgrading-the-keycloak-client-libraries from the server documentation to the client repository documentation as it is related to clients.

Once the keycloak-client 26.0.3 is released and this is published on the web, there would be follow-up task for removing this part from the server documentation - https://github.com/keycloak/keycloak/issues/34949
