### PR TITLE
Unnecessary httpclient dependency in keycloak-client-common-synced module

### DIFF
--- a/client-common-synced/pom.xml
+++ b/client-common-synced/pom.xml
@@ -28,11 +28,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
Removing `httpclient` dependency

Closes #105