### PR TITLE
Add event listener providers

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -24,6 +24,7 @@
         <quarkus.version>3.8.5</quarkus.version>
         <smallrye.config.version>3.5.4</smallrye.config.version>
         <undertow.version>2.3.2.Final</undertow.version>
+        <keycloak.server.version>26.0.5</keycloak.server.version><!-- Used just for testsuite "providers" -->
     </properties>
 
     <build>

--- a/testsuite/providers/pom.xml
+++ b/testsuite/providers/pom.xml
@@ -13,6 +13,21 @@
     <artifactId>keycloak-client-testsuite-providers</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>${keycloak.server.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${keycloak.server.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${keycloak.server.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProvider.java
+++ b/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.events;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.keycloak.events.Event;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * <p>Just an extension of TestEventsListenerProvider that includes the realm and
+ * client passed in the session context as details in the event.</p>
+ *
+ * @author rmartinc
+ */
+public class TestEventsListenerContextDetailsProvider extends TestEventsListenerProvider {
+
+    private final KeycloakSession session;
+
+    public TestEventsListenerContextDetailsProvider(KeycloakSession session) {
+        super(session);
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        event = event.clone();
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            details = new HashMap<>();
+            event.setDetails(details);
+        }
+        if (session.getContext().getRealm() != null) {
+            details.put(TestEventsListenerContextDetailsProviderFactory.CONTEXT_REALM_DETAIL, session.getContext().getRealm().getName());
+        }
+        if (session.getContext().getClient() != null) {
+            details.put(TestEventsListenerContextDetailsProviderFactory.CONTEXT_CLIENT_DETAIL, session.getContext().getClient().getClientId());
+        }
+        super.onEvent(event);
+    }
+}

--- a/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProviderFactory.java
+++ b/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerContextDetailsProviderFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.events;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * <p>Same events provider factory than <em>TestEventsListenerProviderFactory</em> but
+ * the implementation saves realm name and clientId  from the session context as details in
+ * the event. This way we can ensure that session context is correctly
+ * propagated to the event listener.</p>
+ *
+ * @author rmartinc
+ */
+public class TestEventsListenerContextDetailsProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "event-queue-context-details";
+    public static final String CONTEXT_REALM_DETAIL = "context.realmName";
+    public static final String CONTEXT_CLIENT_DETAIL = "context.clientId";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new TestEventsListenerContextDetailsProvider(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProvider.java
+++ b/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.events;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerTransaction;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public class TestEventsListenerProvider implements EventListenerProvider {
+
+    private static final BlockingQueue<Event> events = new LinkedBlockingQueue<Event>();
+    private static final BlockingQueue<AdminEvent> adminEvents = new LinkedBlockingQueue<>();
+    private final EventListenerTransaction tx = new EventListenerTransaction((event, includeRepre) -> adminEvents.add(event), events::add);
+
+    public TestEventsListenerProvider(KeycloakSession session) {
+        session.getTransactionManager().enlistAfterCompletion(tx);
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        tx.addEvent(event);
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        tx.addAdminEvent(event, includeRepresentation);
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    public static Event poll() {
+        return events.poll();
+    }
+
+    public static AdminEvent pollAdminEvent() {
+        return adminEvents.poll();
+    }
+
+    public static void clear() {
+        events.clear();
+    }
+
+    public static void clearAdminEvents() {
+        adminEvents.clear();
+    }
+}

--- a/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProviderFactory.java
+++ b/testsuite/providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProviderFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.events;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
+ */
+public class TestEventsListenerProviderFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "event-queue";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new TestEventsListenerProvider(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/testsuite/providers/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/testsuite/providers/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,36 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.testsuite.events.TestEventsListenerContextDetailsProviderFactory
+org.keycloak.testsuite.events.TestEventsListenerProviderFactory


### PR DESCRIPTION
closes #109

PR deploys some testsuite providers, so they are available for the server in the testsuite. The provider, which is referenced in the test, caused the test failure.

The keycloak-client should not have any dependency on the Keycloak-server, but it is probably fine to have dependency on the server in the testsuite? Could it be any issue (like productization or something else) why adding dependency on keycloak server artifacts in `testsuite/providers` can cause issues?

