### PR TITLE
ProviderTest failing with latest nightly build

### DIFF
--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/authentication/ProvidersTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/authentication/ProvidersTest.java
@@ -232,9 +232,13 @@ public class ProvidersTest extends AbstractAuthenticationTest {
     }
 
     private void compareProviders(List<Map<String, Object>> expected, List<Map<String, Object>> actual) {
-        assertEquals(expected.size(), actual.size(), "Providers count");
-        // compare ignoring list and map impl types
-        assertEquals(normalizeResults(actual), normalizeResults(expected));
+        List<Map<String, Object>> actualNormalizedList = normalizeResults(actual);
+        List<Map<String, Object>> expectedNormalizedList = normalizeResults(expected);
+
+        // compare that returned actual results contains all expected providers (Actual might include some more)
+        for (Map<String, Object> expectedItem : expectedNormalizedList) {
+            Assert.assertTrue(actualNormalizedList.contains(expectedItem), () -> "Item " + expectedItem + " not present in the actual list");
+        }
     }
 
     private List<Map<String, Object>> normalizeResults(List<Map<String, Object>> list) {


### PR DESCRIPTION
closes #115

The `ProvidersTest` might fail quite often as it will always fail with keycloak-server nightly release whenever any new provider is added. Could we be less strict in the client testsuite and just check that all "expected" items are present in the providers, which are returned from server? This means that providers from server can contain some more providers.

This means that `ProviderTest` won't fail always whenever new provider is implemented on the Keycloak server side.