### PR TITLE
Policy enforcer do not handle suppressed server resources

### DIFF
--- a/authz-client/src/main/java/org/keycloak/authorization/client/ResourceNotFoundException.java
+++ b/authz-client/src/main/java/org/keycloak/authorization/client/ResourceNotFoundException.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2016 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.authorization.client;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/authz-client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
+++ b/authz-client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
@@ -19,6 +19,7 @@ package org.keycloak.authorization.client.util;
 import java.util.concurrent.Callable;
 
 import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.ResourceNotFoundException;
 import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
 
 /**
@@ -85,6 +86,8 @@ public final class Throwables {
                 }
 
                 throw handleWrapException(message, cause);
+            } else if (httpe.getStatusCode() == 400 && new String(httpe.getBytes()).contains("invalid_resource_id")) {
+                throw new ResourceNotFoundException(message, cause);
             }
         }
 


### PR DESCRIPTION
closes #137 

In some scenarios, a resource may have been removed of the KC server but still exists in the path cache of the policy enforcer. Consequently, the policy enforcer cannot obtain a permission token from the KC server for these deleted resources and throw a runtime error. The policy enforcer should evict/update resources from the cache.