### PR TITLE
Create draft PR to trigger the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: Keycloak Client CI
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/sync-and-send-pr.yml
+++ b/.github/workflows/sync-and-send-pr.yml
@@ -74,4 +74,4 @@ jobs:
         run: |
           PR_TITLE="Sync with Keycloak server ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }} branch"
           PR_BODY="This PR syncs keycloak-client with the latest Keycloak release branch ${{ env.KEYCLOAK_RELEASE_BRANCH_NAME }}"
-          gh pr create --base main --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
+          gh pr create --draft --base main --head "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"


### PR DESCRIPTION
Closes #132

**Pull requests created by a GH action using the default `GITHUB_TOKEN` cannot trigger other workflows like the `ci` workflow.** 

The workaround introduced by this pr is the following: 

- Create draft pull requests, and configure the ci workflow to trigger on: `ready_for_review`. The workflow will run when users manually click the "Ready for review" button on the draft pull requests.

Another approach could have been using a Personal Access Token (PAT) to create the pull request, which is the standard workaround recommended by GitHub. However, it was discarded to avoid introducing PAT management. 

A final test to confirm everything is working correctly can be performed after this PR is merged.