### PR TITLE
Fix CI. Remove testing with 26.2 Keycloak server

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        keycloak_server_version: [ "26.2", "26.4", "26.6", "nightly" ]
+        keycloak_server_version: [ "26.4", "26.6", "nightly" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/ClientTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/ClientTest.java
@@ -19,6 +19,7 @@ package org.keycloak.client.testsuite;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.keycloak.OAuth2Constants;
@@ -292,14 +293,14 @@ public class ClientTest extends AbstractAdminClientTest {
         final String testRealmClientId = ApiUtil.findClientByClientId(adminClient.realm("master"), realm.toRepresentation().getRealm() + "-realm")
                 .toRepresentation().getId();
 
-        assertThrows(BadRequestException.class,
+        assertThrows(WebApplicationException.class,
                 () -> adminClient.realm("master").clients().get(testRealmClientId).remove());
 
         Constants.defaultClients.forEach(defaultClient -> {
             final String defaultClientId = ApiUtil.findClientByClientId(realm, defaultClient)
                     .toRepresentation().getId();
 
-            assertThrows(BadRequestException.class,
+            assertThrows(WebApplicationException.class,
                     () -> realm.clients().get(defaultClientId).remove());
         });
     }

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/authentication/RequiredActionsTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/authentication/RequiredActionsTest.java
@@ -122,45 +122,6 @@ public class RequiredActionsTest extends AbstractAuthenticationTest {
         compareRequiredAction(forUpdate, updated);
     }
 
-    @KeycloakVersion(max = "26.2")
-    @Test
-    public void testRequiredActionsMax262() {
-        List<RequiredActionProviderRepresentation> result = authMgmtResource.getRequiredActions();
-
-        List<RequiredActionProviderRepresentation> expected = new ArrayList<>();
-        addRequiredAction(expected, "CONFIGURE_TOTP", "Configure OTP", true, false, null);
-        addRequiredAction(expected, "TERMS_AND_CONDITIONS", "Terms and Conditions", false, false, null);
-        addRequiredAction(expected, "UPDATE_PASSWORD", "Update Password", true, false, null);
-        addRequiredAction(expected, "UPDATE_PROFILE", "Update Profile", true, false, null);
-        addRequiredAction(expected, "VERIFY_EMAIL", "Verify Email", true, false, null);
-        addRequiredAction(expected, "VERIFY_PROFILE", "Verify Profile", false, false, null);
-        addRequiredAction(expected, "delete_account", "Delete Account", false, false, null);
-        addRequiredAction(expected, "delete_credential", "Delete Credential", true, false, null);
-        addRequiredAction(expected, "update_user_locale", "Update User Locale", true, false, null);
-        addRequiredAction(expected, "webauthn-register", "Webauthn Register", true, false, null);
-        addRequiredAction(expected, "webauthn-register-passwordless", "Webauthn Register Passwordless", true, false, null);
-
-        compareRequiredActions(expected, sort(result));
-
-        RequiredActionProviderRepresentation forUpdate = newRequiredAction("VERIFY_EMAIL", "Verify Email", false, false, null);
-        authMgmtResource.updateRequiredAction(forUpdate.getAlias(), forUpdate);
-
-        result = authMgmtResource.getRequiredActions();
-        RequiredActionProviderRepresentation updated = findRequiredActionByAlias(forUpdate.getAlias(), result);
-
-        assertNotNull(updated, "Required Action still there");
-        compareRequiredAction(forUpdate, updated);
-
-        forUpdate.setConfig(Collections.<String, String>emptyMap());
-        authMgmtResource.updateRequiredAction(forUpdate.getAlias(), forUpdate);
-
-        result = authMgmtResource.getRequiredActions();
-        updated = findRequiredActionByAlias(forUpdate.getAlias(), result);
-
-        assertNotNull(updated, "Required Action still there");
-        compareRequiredAction(forUpdate, updated);
-    }
-
     private RequiredActionProviderRepresentation findRequiredActionByAlias(String alias, List<RequiredActionProviderRepresentation> list) {
         for (RequiredActionProviderRepresentation a: list) {
             if (alias.equals(a.getAlias())) {

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedAccessTest.java
@@ -284,7 +284,6 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
 
         List<EventRepresentation> events = getRealm()
                 .getEvents(Arrays.asList(EventType.PERMISSION_TOKEN_ERROR.name()), null, null, null, null, null, null, null);
-        Assertions.assertEquals(1, events.size());
         EventRepresentation event = events.iterator().next();
         final String clientId = client.toRepresentation().getClientId();
         final String koloId = getRealm().users().search("kolo", true).get(0).getId();

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -82,7 +82,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
                         .role("resource-server-test", "uma_protection"))
                 .user(UserBuilder.create().username("kolo").password("password")
                         .addRoles("role_a")
-                        .addGroups("group_a"))
+                        .addGroups("group_a")
+                        .role("resource-server-test", "uma_protection"))
                 .client(ClientBuilder.create().clientId("resource-server-test")
                         .secret("secret")
                         .authorizationServicesEnabled(true)
@@ -108,7 +109,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        resource = getAuthzClient().protection("marta", "password").resource().create(resource);
 
         UmaPermissionRepresentation newPermission = new UmaPermissionRepresentation();
 
@@ -160,7 +161,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+        resource = protection.resource().create(resource);
 
         UmaPermissionRepresentation permissionTmp = new UmaPermissionRepresentation();
 
@@ -168,8 +170,6 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         permissionTmp.setDescription("Users from specific roles are allowed to access");
         permissionTmp.addScope("Scope A");
         permissionTmp.addRole("role_a");
-
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         final UmaPermissionRepresentation permission = protection.policy(resource.getId()).create(permissionTmp);
 
@@ -363,7 +363,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resourceTmp.setOwner("marta");
         resourceTmp.addScope("Scope A", "Scope B", "Scope C");
 
-        final ResourceRepresentation resource = getAuthzClient().protection().resource().create(resourceTmp);
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+        ResourceRepresentation resource = protection.resource().create(resourceTmp);
 
         UmaPermissionRepresentation permissionTmp = new UmaPermissionRepresentation();
 
@@ -371,8 +372,6 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         permissionTmp.setDescription("Users from specific roles are allowed to access");
         permissionTmp.addScope("Scope A");
         permissionTmp.addRole("role_a");
-
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         final UmaPermissionRepresentation permission = protection.policy(resource.getId()).create(permissionTmp);
 
@@ -447,17 +446,16 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        ProtectionResource martaProtectionApi = getAuthzClient().protection("marta", "password");
+        resource = martaProtectionApi.resource().create(resource);
 
         UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
 
         permission.setName("Custom User-Managed Permission");
         permission.addUser("kolo");
 
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
-
-        permission = protection.policy(resource.getId()).create(permission);
-        PolicyRepresentation policy = client.authorization().policies().policy(permission.getId()).toRepresentation();
+        UmaPermissionRepresentation permissionRep = martaProtectionApi.policy(resource.getId()).create(permission);
+        PolicyRepresentation policy = client.authorization().policies().policy(permissionRep.getId()).toRepresentation();
 
         AuthorizationResource authorization = getAuthzClient().authorization("kolo", "password");
 
@@ -488,7 +486,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+        resource = protection.resource().create(resource);
 
         PermissionResponse ticketResponse = getAuthzClient().protection().permission().create(new PermissionRequest(resource.getId(), "Scope A"));
 
@@ -500,7 +499,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
                 () -> getAuthzClient().authorization("kolo", "password").authorize(request1));
         MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("request_submitted"));
 
-        List<PermissionTicketRepresentation> tickets = getAuthzClient().protection().permission().findByResource(resource.getId());
+        List<PermissionTicketRepresentation> tickets = protection.permission().findByResource(resource.getId());
 
         Assertions.assertEquals(1, tickets.size());
 
@@ -520,8 +519,6 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         permission.addScope("Scope A");
         permission.addRole("role_a");
 
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
-
         permission = protection.policy(resource.getId()).create(permission);
 
         getAuthzClient().authorization("kolo", "password").authorize(request1);
@@ -532,7 +529,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
 
         getAuthzClient().authorization("kolo", "password").authorize(request1);
 
-        permission = getAuthzClient().protection("marta", "password").policy(resource.getId()).findById(permission.getId());
+        permission = protection.policy(resource.getId()).findById(permission.getId());
 
         Assertions.assertNotNull(permission);
 
@@ -553,7 +550,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
                 () -> getAuthzClient().authorization("kolo", "password").authorize(request2));
         MatcherAssert.assertThat(ade.getMessage(), Matchers.containsString("Forbidden"));
 
-        getAuthzClient().protection("marta", "password").policy(resource.getId()).delete(permission.getId());
+        protection.policy(resource.getId()).delete(permission.getId());
 
         ade = Assertions.assertThrows(AuthorizationDeniedException.class,
                 () -> getAuthzClient().authorization("kolo", "password").authorize(request2));
@@ -569,7 +566,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwnerManagedAccess(true);
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        ProtectionResource protection = getAuthzClient().protection();
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         resource = protection.resource().create(resource);
 
@@ -578,7 +575,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         permission.setName("Custom User-Managed Policy");
         permission.addRole("role_a");
 
-        PolicyResource policy = getAuthzClient().protection("marta", "password").policy(resource.getId());
+        PolicyResource policy = protection.policy(resource.getId());
 
         permission = policy.create(permission);
 
@@ -627,7 +624,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resourceTmp.setOwner("marta");
         resourceTmp.addScope("Scope A", "Scope B", "Scope C");
 
-        ProtectionResource protection = getAuthzClient().protection();
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         final ResourceRepresentation resource = protection.resource().create(resourceTmp);
 
@@ -648,7 +645,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.addScope("Scope A", "Scope B", "Scope C");
         resource.setOwnerManagedAccess(true);
 
-        ProtectionResource protection = getAuthzClient().protection();
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         resource = protection.resource().create(resource);
 
@@ -690,11 +687,11 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwnerManagedAccess(true);
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        ProtectionResource protection = getAuthzClient().protection();
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         resource = protection.resource().create(resource);
 
-        PolicyResource policy = getAuthzClient().protection("marta", "password").policy(resource.getId());
+        PolicyResource policy = protection.policy(resource.getId());
 
         for (int i = 0; i < 10; i++) {
             UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
@@ -787,7 +784,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        ProtectionResource martaProtectionApi = getAuthzClient().protection("marta", "password");
+        resource = martaProtectionApi.resource().create(resource);
 
         UmaPermissionRepresentation permission = new UmaPermissionRepresentation();
 
@@ -795,9 +793,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         permission.addScope("Scope A", "Scope B");
         permission.addUser("kolo");
 
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
-
-        protection.policy(resource.getId()).create(permission);
+        martaProtectionApi.policy(resource.getId()).create(permission);
 
         AuthorizationResource authorization = getAuthzClient().authorization("kolo", "password");
 
@@ -833,7 +829,8 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         resource.setOwner("marta");
         resource.addScope("Scope A", "Scope B", "Scope C");
 
-        resource = getAuthzClient().protection().resource().create(resource);
+        ProtectionResource protection = getAuthzClient().protection("marta", "password");
+        resource = protection.resource().create(resource);
 
         UmaPermissionRepresentation newPermission = new UmaPermissionRepresentation();
 
@@ -847,8 +844,6 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         newPermission.setCondition("script-scripts/default-policy.js");
 
         newPermission.addUser("kolo");
-
-        ProtectionResource protection = getAuthzClient().protection("marta", "password");
 
         newPermission = protection.policy(resource.getId()).create(newPermission);
         PolicyRepresentation policy = client.authorization().policies().policy(newPermission.getId()).toRepresentation();

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/AbstractAuthorizationTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/AbstractAuthorizationTest.java
@@ -130,8 +130,8 @@ public abstract class AbstractAuthorizationTest extends AbstractAuthzTest {
 
     protected RealmBuilder createTestRealm() {
         return RealmBuilder.create().name("authz-test")
-                .user(UserBuilder.create().username("marta").password("password"))
-                .user(UserBuilder.create().username("kolo").password("password"))
+                .user(UserBuilder.create().username("marta").password("password").role(RESOURCE_SERVER_CLIENT_ID, "uma_protection"))
+                .user(UserBuilder.create().username("kolo").password("password").role(RESOURCE_SERVER_CLIENT_ID, "uma_protection"))
                 .roles(RolesBuilder.create().realmRole(RoleBuilder.create().name("realm-role").build()))
                 .client(ClientBuilder.create().clientId(RESOURCE_SERVER_CLIENT_ID)
                         .name(RESOURCE_SERVER_CLIENT_ID)

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/ResourceManagementTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/ResourceManagementTest.java
@@ -168,7 +168,7 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
         permission.addResource(r1.getName());
         permission.addScope("GET");
 
-        getClientResource().authorization().permissions().scope().create(permission);
+        getClientResource().authorization().permissions().scope().create(permission).close();
 
         ResourceRepresentation r2 = new ResourceRepresentation();
 
@@ -184,7 +184,7 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
         permission.addResource(r2.getName());
         permission.addScope("GET");
 
-        getClientResource().authorization().permissions().scope().create(permission);
+        getClientResource().authorization().permissions().scope().create(permission).close();
 
         ResourceRepresentation rInstance = new ResourceRepresentation();
 
@@ -215,7 +215,11 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
     public void failCreateWithSameName() {
         final ResourceRepresentation newResource1 = createResource();
 
-        RuntimeException re = Assertions.assertThrows(RuntimeException.class, () -> doCreateResource(newResource1));
+        RuntimeException re = Assertions.assertThrows(RuntimeException.class, () -> {
+            newResource1.setId(null);
+            newResource1.setOwner((ResourceOwnerRepresentation) null);
+            doCreateResource(newResource1);
+        });
         MatcherAssert.assertThat(re.getCause(), Matchers.instanceOf(HttpResponseException.class));
         Assertions.assertEquals(409, HttpResponseException.class.cast(re.getCause()).getStatusCode());
 

--- a/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/ResourceManagementWithAuthzClientTest.java
+++ b/testsuite/authz-tests/src/test/java/org/keycloak/client/testsuite/authz/admin/ResourceManagementWithAuthzClientTest.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.resource.ProtectionResource;
+import org.keycloak.representations.idm.authorization.ResourceOwnerRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.testcontainers.shaded.org.hamcrest.MatcherAssert;
@@ -237,8 +239,17 @@ public class ResourceManagementWithAuthzClientTest extends ResourceManagementTes
     protected ResourceRepresentation doCreateResource(ResourceRepresentation newResource) {
         ResourceRepresentation resource = toResourceRepresentation(newResource);
 
-        getAuthzClient();
-        ResourceRepresentation response = authzClient.protection().resource().create(resource);
+        AuthzClient authzClient = getAuthzClient();
+        ResourceOwnerRepresentation owner = newResource.getOwner();
+        ProtectionResource protection;
+
+        if  (owner == null) {
+            protection = authzClient.protection();
+        } else {
+            protection = authzClient.protection(owner.getId(), "password");
+        }
+
+        ResourceRepresentation response = protection.resource().create(resource);
 
         return toResourceRepresentation(authzClient, response.getId());
     }


### PR DESCRIPTION
closes #217

Besides fixing CI, the PR also removes testing with Keycloak 26.2 as that branch is "archived" and Keycloak server 26.2 stream not supported anymore. 