### PR TITLE
Add Keycloak Admin client based on Jackson 3

### DIFF
--- a/.github/scripts/sync-keycloak-sources.sh
+++ b/.github/scripts/sync-keycloak-sources.sh
@@ -25,6 +25,7 @@ function syncFiles() {
   # Remove the existing files before sync
   rm -rf src/main/java/*
   rm -rf src/main/resources/*
+  mkdir -p src/main/java src/main/resources
 
   mvn clean install -Psync
   mv target/unpacked/* src/main/java/
@@ -36,11 +37,76 @@ function syncFiles() {
   cd ..
 }
 
+# unpack sources without compiling, apply post-processing, then compile
+function syncAndTransform() {
+  MODULE=$1;
+  TRANSFORM_FN=$2;
+  echo_header "Syncing files in the module $MODULE";
+  cd $MODULE
+
+  rm -rf src/main/java/*
+  rm -rf src/main/resources/*
+  mkdir -p src/main/java src/main/resources
+
+  mvn generate-sources -Psync
+  mv target/unpacked/* src/main/java/
+
+  if  [ -d target/unpacked-resources -a ! -z "$(ls -A target/unpacked-resources/* 2>/dev/null)" ]
+  then
+    mv target/unpacked-resources/* src/main/resources/
+  fi
+
+  $TRANSFORM_FN
+
+  mvn clean install
+  cd ..
+}
+
+# TODO: remove this revert once we accept the RawJsonValue breaking change (target: 27.x)
+# revert RawJsonValue -> JsonNode in all affected files (dynamic, not a hardcoded list)
+function revertRawJsonValue() {
+  for file in $(grep -rl "org\.keycloak\.json\.RawJsonValue" src/main/java/ 2>/dev/null); do
+      sed -i 's/import org.keycloak.json.RawJsonValue;/import com.fasterxml.jackson.databind.JsonNode;/g' "$file"
+      sed -i 's/import org.keycloak.json.KeycloakJsonMapperFactory;/import org.keycloak.util.JsonSerialization;/g' "$file"
+      sed -i 's/RawJsonValue/JsonNode/g' "$file"
+      sed -i 's/KeycloakJsonMapperFactory\.mapper()/JsonSerialization.mapper/g' "$file"
+  done
+  rm -f src/main/java/org/keycloak/json/RawJsonValue.java
+  rm -f src/main/java/org/keycloak/json/RawJsonValueSupport.java
+  rm -f src/main/java/org/keycloak/json/Jackson2RawJsonValueSupport.java
+  rm -f src/main/resources/META-INF/services/org.keycloak.json.RawJsonValueSupport
+
+  remaining=$(grep -rl "RawJsonValue" src/main/java/ 2>/dev/null || true)
+  if [ -n "$remaining" ]; then
+      error "Found un-reverted RawJsonValue references in: $remaining"
+  fi
+}
+
+# strip jackson 2 @JsonSerialize/@JsonDeserialize from meta-annotations;
+# jackson 3 handles them via KeycloakAnnotationIntrospector3
+function stripJackson2Annotations() {
+  for file in src/main/java/org/keycloak/json/StringOrArray.java \
+              src/main/java/org/keycloak/json/StringListMap.java \
+              src/main/java/org/keycloak/json/MultivaluedHashMapValue.java \
+              src/main/java/org/keycloak/json/ResourceTypeMap.java; do
+      if [ -f "$file" ]; then
+          sed -i '/import com\.fasterxml\.jackson\.databind/d' "$file"
+          sed -i '/import org\.keycloak\.json\.\(StringOrArray\|StringListMap\|ResourceTypeMap\)Serializer/d' "$file"
+          sed -i '/import org\.keycloak\.json\.\(StringOrArray\|StringListMap\|ResourceTypeMap\)Deserializer/d' "$file"
+          sed -i '/import org\.keycloak\.representations\.workflows\.MultivaluedHashMapValue/d' "$file"
+          sed -i '/@JsonSerialize/d' "$file"
+          sed -i '/@JsonDeserialize/d' "$file"
+      fi
+  done
+}
+
 # Check if inside keycloak-client directory
 if [[ ! $PWD == *keycloak-client ]]; then
   error "The script is supposed to be executed in the root of 'keycloak-client' repository";
 fi;
 
-syncFiles client-common-synced
+syncAndTransform client-common-synced revertRawJsonValue
+syncAndTransform client-common-synced-jackson3 stripJackson2Annotations
 syncFiles admin-client
+syncFiles admin-client-jackson3
 syncFiles authz-client

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,29 @@ jobs:
           mvn -B -f testsuite/admin-client-tests/pom.xml test -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}
           mvn -B -f testsuite/authz-tests/pom.xml test -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}
 
+  client-tests-jackson3:
+    name: Client tests (Jackson 3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        keycloak_server_version: [ "nightly" ]
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: test-setup
+        name: Test setup
+        uses: ./.github/actions/test-setup
+
+      - name: Run admin client tests with Jackson 3
+        run: |
+          if [ -z "$(find admin-client-jackson3/src/main/java -name '*.java' 2>/dev/null)" ]; then
+            echo "No Jackson 3 sources synced yet, skipping"
+            exit 0
+          fi
+          mvn -B -f testsuite/providers/pom.xml package -DskipTests=true
+          mvn -B -f testsuite/admin-client-tests/pom.xml test -Pjackson3 -Dkeycloak.version.docker.image=${{ matrix.keycloak_server_version }}
+
   client-tests-java-11:
     name: Client tests (Java 11)
     runs-on: ubuntu-latest

--- a/admin-client-jackson3/pom.xml
+++ b/admin-client-jackson3/pom.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
-  ~ and other contributors as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -27,34 +10,26 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>keycloak-admin-client</artifactId>
-    <name>Keycloak Admin REST Client</name>
-    <description>Keycloak Admin REST Client</description>
+    <artifactId>keycloak-admin-client-jackson3</artifactId>
+    <name>Keycloak Admin REST Client (Jackson 3)</name>
+    <description>Jackson 3 provider for the Keycloak Admin REST Client. Use this instead of keycloak-admin-client when your application uses Jackson 3.</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-client-common-synced</artifactId>
+            <artifactId>keycloak-client-common-synced-jackson3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-            <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
+            <groupId>dev.resteasy.providers</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
@@ -72,11 +47,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>${resteasy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
             <version>${resteasy.version}</version>
         </dependency>
@@ -86,6 +56,11 @@
         <profile>
             <id>sync</id>
             <build>
+                <resources>
+                    <resource>
+                        <directory>${project.build.directory}/unpacked-resources</directory>
+                    </resource>
+                </resources>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -108,25 +83,32 @@
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                                             <includes>
-                                                org/**/*,
-                                                META-INF/services/*
+                                                org/**/*
                                             </includes>
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>org.keycloak</groupId>
-                                            <artifactId>keycloak-admin-client-tests</artifactId>
+                                            <artifactId>keycloak-admin-client-jackson3</artifactId>
                                             <version>${keycloak.version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                                             <includes>
-                                                org/**/*,
-                                                META-INF/services/*
-                                            </includes>  <!-- unpack just source code and potential services -->
-                                            <excludes>
-                                                org/keycloak/admin/client/wrapper/*.java
-                                            </excludes>
+                                                org/**/*
+                                            </includes>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.keycloak</groupId>
+                                            <artifactId>keycloak-admin-client-jackson3</artifactId>
+                                            <version>${keycloak.version}</version>
+                                            <type>jar</type>
+                                            <classifier>sources</classifier>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/unpacked-resources</outputDirectory>
+                                            <includes>
+                                                META-INF/services/**/*
+                                            </includes>
                                         </artifactItem>
                                     </artifactItems>
                                     <overWriteReleases>false</overWriteReleases>

--- a/client-common-synced-jackson3/pom.xml
+++ b/client-common-synced-jackson3/pom.xml
@@ -1,84 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
-  ~ and other contributors as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>keycloak-client-parent</artifactId>
         <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-client-parent</artifactId>
         <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>keycloak-admin-client</artifactId>
-    <name>Keycloak Admin REST Client</name>
-    <description>Keycloak Admin REST Client</description>
+    <artifactId>keycloak-client-common-synced-jackson3</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Keycloak Client Common Synced (Jackson 3)</name>
+    <description>Jackson 3 variant of Keycloak Client Common Synced. Uses RawJsonValue instead of JsonNode
+        for Jackson-version-agnostic representations. Excludes Jackson 2 serializers and utilities.</description>
 
     <dependencies>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-client-common-synced</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-            <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${resteasy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
-            <version>${resteasy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>${resteasy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${resteasy.version}</version>
         </dependency>
     </dependencies>
 
@@ -101,31 +58,41 @@
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>org.keycloak</groupId>
-                                            <artifactId>keycloak-admin-client-core</artifactId>
+                                            <artifactId>keycloak-core</artifactId>
                                             <version>${keycloak.version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                                             <includes>
-                                                org/**/*,
-                                                META-INF/services/*
+                                                ${keycloak-core.sync.includes},
+                                                org/keycloak/json/*.java
                                             </includes>
+                                            <excludes>
+                                                org/keycloak/json/StringOrArrayDeserializer.java,
+                                                org/keycloak/json/StringOrArraySerializer.java,
+                                                org/keycloak/json/StringListMapDeserializer.java,
+                                                org/keycloak/json/ResourceTypeMapDeserializer.java,
+                                                org/keycloak/json/Jackson2RawJsonValueSupport.java,
+                                                org/keycloak/json/Jackson2JsonMapper.java,
+                                                org/keycloak/representations/workflows/MultivaluedHashMapValueSerializer.java,
+                                                org/keycloak/representations/workflows/MultivaluedHashMapValueDeserializer.java
+                                            </excludes>
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>org.keycloak</groupId>
-                                            <artifactId>keycloak-admin-client-tests</artifactId>
+                                            <artifactId>keycloak-common</artifactId>
                                             <version>${keycloak.version}</version>
                                             <type>jar</type>
                                             <classifier>sources</classifier>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                                             <includes>
-                                                org/**/*,
-                                                META-INF/services/*
-                                            </includes>  <!-- unpack just source code and potential services -->
+                                                org/keycloak/common/**/*.java
+                                            </includes>
                                             <excludes>
-                                                org/keycloak/admin/client/wrapper/*.java
+                                                org/keycloak/common/Version.java,
+                                                org/keycloak/common/util/MimeTypeUtil.java
                                             </excludes>
                                         </artifactItem>
                                     </artifactItems>
@@ -155,6 +122,50 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>jdk-15</id>
+            <activation>
+                <jdk>[15,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>compile-java15</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>org/keycloak/jose/jwk/EdECUtilsImpl.java</include>
+                                    </includes>
+                                    <excludes combine.self="override" />
+                                    <release>15</release>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>org/keycloak/jose/jwk/EdECUtilsImpl.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/client-common-synced/pom.xml
+++ b/client-common-synced/pom.xml
@@ -87,58 +87,9 @@
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                                             <includes>
-                                                org/keycloak/OAuth2Constants.java,
-                                                org/keycloak/TokenCategory.java,
-                                                org/keycloak/Token.java,
-                                                org/keycloak/TokenIdGenerator.java,
-                                                org/keycloak/AuthorizationContext.java,
-
+                                                ${keycloak-core.sync.includes},
                                                 org/keycloak/json/*.java,
-
-                                                org/keycloak/representations/adapters/action/GlobalRequestResult.java,
-                                                org/keycloak/representations/dpop/**/*.java,
-                                                org/keycloak/representations/idm/**/*.java,
-                                                org/keycloak/representations/info/*.java,
-                                                org/keycloak/representations/userprofile/config/*.java,
-                                                org/keycloak/representations/workflows/*.java,
-                                                org/keycloak/representations/AccessToken.java,
-                                                org/keycloak/representations/AccessTokenResponse.java,
-                                                org/keycloak/representations/AddressClaimSet.java,
-                                                org/keycloak/representations/AuthorizationDetailsJSONRepresentation.java,
-                                                org/keycloak/representations/IDToken.java,
-                                                org/keycloak/representations/JsonWebToken.java,
-                                                org/keycloak/representations/KeyStoreConfig.java,
-                                                org/keycloak/representations/adapters/config/*.java,
-                                                org/keycloak/representations/RefreshToken.java,
-
-                                                org/keycloak/util/AuthorizationDetailsParser.java,
-                                                org/keycloak/util/BasicAuthHelper.java,
-                                                org/keycloak/util/DPoPGenerator.java,
-                                                org/keycloak/util/EnumWithStableIndex.java,
-                                                org/keycloak/util/JsonSerialization.java,
-                                                org/keycloak/util/JWKSUtils.java,
-                                                org/keycloak/util/KeyWrapperUtil.java,
-                                                org/keycloak/util/SystemPropertiesJsonParserFactory.java,
-                                                org/keycloak/util/TokenUtil.java,
-
-                                                org/keycloak/jose/JOSE.java,
-                                                org/keycloak/jose/JOSEHeader.java,
-                                                org/keycloak/jose/jwe/**/*.java,
-                                                org/keycloak/jose/jws/**/*.java,
-                                                org/keycloak/jose/jwk/**/*.java,
-
-                                                org/keycloak/crypto/**/*.java,
-
-                                                org/keycloak/protocol/oidc/client/authentication/*.java,
-
-                                                org/keycloak/protocol/oidc/representations/**/*.java,
-
-                                                org/keycloak/constants/ServiceUrlConstants.java,
-
-                                                org/keycloak/exceptions/*.java,
-
-                                                org/keycloak/TokenVerifier.java,
-
+                                                org/keycloak/util/JsonSerialization.java
                                             </includes>
                                         </artifactItem>
                                         <artifactItem>

--- a/docs/guides/securing-apps/admin-client.adoc
+++ b/docs/guides/securing-apps/admin-client.adoc
@@ -7,18 +7,9 @@ priority=500
 summary="Using the {project_name} admin client to access the {project_name} Admin REST API">
 
 The {project_name} admin client is a Java library that facilitates the access and usage of the {project_name} Admin REST API.
-The library requires Java 11 or higher at runtime (RESTEasy dependency enforces this requirement).
-To use it from your application add a dependency on the `keycloak-admin-client` library.
-For example using Maven:
+It is available for either Jackson 2 or Jackson 3, both sharing the same API.
 
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>org.keycloak</groupId>
-    <artifactId>keycloak-admin-client</artifactId>
-    <version>${client_version}</version>
-</dependency>
-----
+== Usage
 
 The following example shows how to use the Java client library to get the details of the master realm:
 
@@ -40,8 +31,23 @@ RealmRepresentation realm = keycloak.realm("master").toRepresentation();
 
 Complete Javadoc for the admin client is available at {apidocs_link}[{apidocs_name}].
 
+== Admin client with Jackson 2
+
+The admin client with Jackson 2 requires Java 11 or higher.
+To use it from your application add a dependency on the `keycloak-admin-client` library.
+For example using Maven:
+
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-admin-client</artifactId>
+    <version>${client_version}</version>
+</dependency>
+----
+
 [[_admin_client_compatibility]]
-== Compatibility with {project_name} server
+=== Compatibility with {project_name} server
 
 The {project_name} admin client aims to work with multiple versions of the {project_name} server. For the details about supported {project_name} server versions, see <@links.securingapps id="upgrading" />.
 
@@ -77,5 +83,37 @@ Keycloak.getInstance(
 
 In this case, please make sure that your class `MyCustomJacksonProvider` extends from the class `org.keycloak.admin.client.JacksonProvider` or make sure to configure the `ObjectMapper` manually in a way described above.
 The similar care should be taken when using `KeycloakBuilder` to create the admin client and the RestEasy client is manually injected and created.
+
+== Admin client with Jackson 3
+
+The admin client with Jackson 3 requires Java 17 or higher.
+It is a drop-in replacement for applications that already use Jackson 3.
+To use it from your application replace the `keycloak-admin-client` dependency with `keycloak-admin-client-jackson3`:
+
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-admin-client-jackson3</artifactId>
+    <version>${client_version}</version>
+</dependency>
+----
+
+[[_admin_client_jackson3_compatibility]]
+=== Compatibility with {project_name} server
+
+The same <<_admin_client_compatibility,compatibility considerations>> apply here.
+With Jackson 3, the equivalent `tools.jackson.databind.json.JsonMapper` configuration is:
+
+[source,java]
+----
+JsonMapper mapper = JsonMapper.builder()
+        .changeDefaultPropertyInclusion(v -> JsonInclude.Value.construct(
+                JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .build();
+----
+
+If you are injecting a custom Jackson provider as described in the Jackson 2 section, extend `org.keycloak.admin.client.jackson3.JacksonProvider3` instead of `org.keycloak.admin.client.JacksonProvider`.
 
 </@tmpl.guide>

--- a/docs/guides/securing-apps/upgrading.adoc
+++ b/docs/guides/securing-apps/upgrading.adoc
@@ -9,10 +9,12 @@ summary="How to upgrade the {project_name} Client Libraries">
 
 The client libraries are those artifacts:
 
-* Java admin client - Maven artifact `org.keycloak:keycloak-admin-client`
+* Java admin client (Jackson 2) - Maven artifact `org.keycloak:keycloak-admin-client`
+* Java admin client (Jackson 3) - Maven artifact `org.keycloak:keycloak-admin-client-jackson3`
 * Java authorization client - Maven artifact `org.keycloak:keycloak-authz-client`
 * Java policy enforcer - Maven artifact `org.keycloak:keycloak-policy-enforcer`
-* Java common classes used by other client libraries above - Maven artifact `org.keycloak:keycloak-client-common-synced`
+* Java common classes shared by the client libraries (Jackson 2) - Maven artifact `org.keycloak:keycloak-client-common-synced`
+* Java common classes shared by the client libraries (Jackson 3) - Maven artifact `org.keycloak:keycloak-client-common-synced-jackson3`
 
 ifeval::[{project_community}==true]
 The last released client libraries are supported with the last supported {project_name} server version.

--- a/docs/release-notes/26_1_0.adoc
+++ b/docs/release-notes/26_1_0.adoc
@@ -1,0 +1,13 @@
+= Jackson 3 admin client support
+
+== `keycloak-admin-client-jackson3`
+
+Drop-in replacement for `keycloak-admin-client` for apps using Jackson 3 (e.g. Spring Boot 4). Requires Java 17+. No Jackson 2 dependencies.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-admin-client-jackson3</artifactId>
+</dependency>
+----

--- a/docs/release-notes/jackson3-support.adoc
+++ b/docs/release-notes/jackson3-support.adoc
@@ -1,0 +1,14 @@
+// TODO: rename to match release version (e.g. 27_0_0.adoc) per keycloak-js convention
+= Jackson 3 admin client support
+
+== `keycloak-admin-client-jackson3`
+
+Drop-in replacement for `keycloak-admin-client` for apps using Jackson 3 (e.g. Spring Boot 4). Requires Java 17+. No Jackson 2 dependencies.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.keycloak</groupId>
+    <artifactId>keycloak-admin-client-jackson3</artifactId>
+</dependency>
+----

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <resteasy.version>6.2.15.Final</resteasy.version>
         <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
         <com.fasterxml.jackson.annotation.version>2.21</com.fasterxml.jackson.annotation.version>
+        <version.tools.jackson>3.1.4</version.tools.jackson>
+        <version.resteasy.jackson3.provider>1.0.0.Alpha1</version.resteasy.jackson3.provider>
         <microprofile-openapi-api.version>4.1.1</microprofile-openapi-api.version>
         <jboss-logging.version>3.6.2.Final</jboss-logging.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
@@ -67,6 +69,59 @@
         <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
         <verifier.plugin.version>1.1</verifier.plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
+
+        <!-- Shared keycloak-core source includes for client-common-synced modules (Jackson 2 and Jackson 3).
+             Each module appends its own json-package and serialization-specific patterns. -->
+        <keycloak-core.sync.includes>
+            org/keycloak/OAuth2Constants.java,
+            org/keycloak/TokenCategory.java,
+            org/keycloak/Token.java,
+            org/keycloak/TokenIdGenerator.java,
+            org/keycloak/AuthorizationContext.java,
+
+            org/keycloak/representations/adapters/action/GlobalRequestResult.java,
+            org/keycloak/representations/dpop/**/*.java,
+            org/keycloak/representations/idm/**/*.java,
+            org/keycloak/representations/info/*.java,
+            org/keycloak/representations/userprofile/config/*.java,
+            org/keycloak/representations/workflows/*.java,
+            org/keycloak/representations/AccessToken.java,
+            org/keycloak/representations/AccessTokenResponse.java,
+            org/keycloak/representations/AddressClaimSet.java,
+            org/keycloak/representations/AuthorizationDetailsJSONRepresentation.java,
+            org/keycloak/representations/IDToken.java,
+            org/keycloak/representations/JsonWebToken.java,
+            org/keycloak/representations/KeyStoreConfig.java,
+            org/keycloak/representations/adapters/config/*.java,
+            org/keycloak/representations/RefreshToken.java,
+
+            org/keycloak/util/AuthorizationDetailsParser.java,
+            org/keycloak/util/BasicAuthHelper.java,
+            org/keycloak/util/DPoPGenerator.java,
+            org/keycloak/util/EnumWithStableIndex.java,
+            org/keycloak/util/JWKSUtils.java,
+            org/keycloak/util/KeyWrapperUtil.java,
+            org/keycloak/util/SystemPropertiesJsonParserFactory.java,
+            org/keycloak/util/TokenUtil.java,
+
+            org/keycloak/jose/JOSE.java,
+            org/keycloak/jose/JOSEHeader.java,
+            org/keycloak/jose/jwe/**/*.java,
+            org/keycloak/jose/jws/**/*.java,
+            org/keycloak/jose/jwk/**/*.java,
+
+            org/keycloak/crypto/**/*.java,
+
+            org/keycloak/protocol/oidc/client/authentication/*.java,
+
+            org/keycloak/protocol/oidc/representations/**/*.java,
+
+            org/keycloak/constants/ServiceUrlConstants.java,
+
+            org/keycloak/exceptions/*.java,
+
+            org/keycloak/TokenVerifier.java
+        </keycloak-core.sync.includes>
 
         <!-- Surefire Settings -->
         <surefire.memory.Xms>512m</surefire.memory.Xms>
@@ -121,7 +176,9 @@
 
     <modules>
         <module>client-common-synced</module>
+        <module>client-common-synced-jackson3</module>
         <module>admin-client</module>
+        <module>admin-client-jackson3</module>
         <module>authz-client</module>
         <module>policy-enforcer</module>
         <module>docs</module>
@@ -133,6 +190,11 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-client-common-synced</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-client-common-synced-jackson3</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -174,6 +236,16 @@
                 <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
                 <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
                 <version>${com.fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.tools.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.resteasy.providers</groupId>
+                <artifactId>resteasy-jackson-provider</artifactId>
+                <version>${version.resteasy.jackson3.provider}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>

--- a/testsuite/admin-client-tests/pom.xml
+++ b/testsuite/admin-client-tests/pom.xml
@@ -23,6 +23,46 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>jackson3</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-client-testsuite-framework</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.keycloak</groupId>
+                            <artifactId>keycloak-admin-client</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.keycloak</groupId>
+                            <artifactId>keycloak-client-common-synced</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.keycloak</groupId>
+                            <artifactId>keycloak-policy-enforcer</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-admin-client-jackson3</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-client-common-synced-jackson3</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/AbstractAdminClientTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/AbstractAdminClientTest.java
@@ -36,7 +36,7 @@ import org.keycloak.testsuite.util.ApiUtil;
 import org.keycloak.testsuite.util.RoleBuilder;
 import org.keycloak.testsuite.util.ServerURLs;
 import org.keycloak.testsuite.util.TestCleanup;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.client.testsuite.common.JsonMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -115,7 +115,7 @@ public abstract class AbstractAdminClientTest implements RealmRepsSupplier {
 
     public static <T> T loadJson(InputStream is, Class<T> type) {
         try {
-            return JsonSerialization.readValue(is, type);
+            return JsonMapper.readValue(is, type);
         } catch (IOException e) {
             throw new RuntimeException("Failed to parse json", e);
         }

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/RealmTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/RealmTest.java
@@ -39,7 +39,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.client.testsuite.common.JsonMapper;
 import org.testcontainers.shaded.org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
@@ -742,7 +742,7 @@ public class RealmTest extends AbstractAdminClientTest {
         description.setClientId("client-id");
         description.setRedirectUris(Collections.singletonList("http://localhost"));
 
-        ClientRepresentation converted = realm.convertClientDescription(JsonSerialization.writeValueAsString(description));
+        ClientRepresentation converted = realm.convertClientDescription(JsonMapper.writeValueAsString(description));
         assertEquals("client-id", converted.getClientId());
         assertEquals("http://localhost", converted.getRedirectUris().get(0));
     }

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/UserTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/UserTest.java
@@ -86,7 +86,7 @@ import org.keycloak.testsuite.util.GroupBuilder;
 import org.keycloak.testsuite.util.KeycloakModelUtils;
 import org.keycloak.testsuite.util.RoleBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.client.testsuite.common.JsonMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -145,7 +145,7 @@ public class UserTest extends AbstractAdminClientTest {
             upConfig.addOrReplaceAttribute(createAttributeMetadata(name));
         }
 
-        setUserProfileConfiguration(realm, JsonSerialization.writeValueAsString(upConfig));
+        setUserProfileConfiguration(realm, JsonMapper.writeValueAsString(upConfig));
     }
 
     @AfterEach
@@ -330,8 +330,8 @@ public class UserTest extends AbstractAdminClientTest {
         try {
             CredentialRepresentation hashedPassword = new CredentialRepresentation();
             hashedPassword.setType("password");
-            hashedPassword.setSecretData(JsonSerialization.writeValueAsString(secretData));
-            hashedPassword.setCredentialData(JsonSerialization.writeValueAsString(credentialData));
+            hashedPassword.setSecretData(JsonMapper.writeValueAsString(secretData));
+            hashedPassword.setCredentialData(JsonMapper.writeValueAsString(credentialData));
             hashedPassword.setCreatedDate(1001L);
             hashedPassword.setUserLabel("deviceX");
             hashedPassword.setType(CredentialRepresentation.PASSWORD);
@@ -363,7 +363,7 @@ public class UserTest extends AbstractAdminClientTest {
                 "      \"algorithm\" : \"" + credentialData.getAlgorithm() + "\"\n" +
                 "    }";
 
-        CredentialRepresentation deprecatedHashedPassword = JsonSerialization.readValue(deprecatedCredential, CredentialRepresentation.class);
+        CredentialRepresentation deprecatedHashedPassword = JsonMapper.readValue(deprecatedCredential, CredentialRepresentation.class);
         Assert.assertNotNull(deprecatedHashedPassword.getHashedSaltedValue());
         Assert.assertNull(deprecatedHashedPassword.getCredentialData());
 
@@ -2752,7 +2752,7 @@ public class UserTest extends AbstractAdminClientTest {
 
     public static UPConfig setUserProfileConfiguration(RealmResource testRealm, String configuration) {
         try {
-            UPConfig config = configuration == null ? null : JsonSerialization.readValue(configuration, UPConfig.class);
+            UPConfig config = configuration == null ? null : JsonMapper.readValue(configuration, UPConfig.class);
 
             if (config != null) {
                 UPAttribute username = config.getAttribute("username");

--- a/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/client/ClientScopeTest.java
+++ b/testsuite/admin-client-tests/src/test/java/org/keycloak/client/testsuite/client/ClientScopeTest.java
@@ -41,7 +41,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testsuite.util.ApiUtil;
 import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.RoleBuilder;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.client.testsuite.common.JsonMapper;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -695,7 +695,7 @@ public class ClientScopeTest extends AbstractClientTest {
             String respBody = resp.readEntity(String.class);
             Map<String, String> responseJson = null;
             try {
-                responseJson = JsonSerialization.readValue(respBody, Map.class);
+                responseJson = JsonMapper.readValue(respBody, Map.class);
                 assertEquals(expectedErrorMessage, responseJson.get("errorMessage"));
             } catch (IOException e) {
                 fail("Failed to extract the errorMessage from a CreateScope Response");

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/JsonMapper.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/JsonMapper.java
@@ -1,0 +1,87 @@
+package org.keycloak.client.testsuite.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+// TODO: remove this and use KeycloakJsonMapperFactory directly once keycloak/keycloak#50848 merges
+// and the nightly sync populates KeycloakJsonMapperFactory in client-common-synced
+/**
+ * Resolves a JSON mapper at runtime: prefers KeycloakJsonMapperFactory (jackson-agnostic)
+ * when available, falls back to JsonSerialization (jackson 2) otherwise.
+ */
+public final class JsonMapper {
+
+    private static final Object MAPPER;
+    private static final Method READ_VALUE_IS;
+    private static final Method READ_VALUE_STRING;
+    private static final Method READ_VALUE_BYTES;
+    private static final Method WRITE_VALUE_AS_STRING;
+
+    static {
+        Object mapper;
+        try {
+            Class<?> factory = Class.forName("org.keycloak.json.KeycloakJsonMapperFactory");
+            mapper = factory.getMethod("mapper").invoke(null);
+        } catch (Exception e) {
+            try {
+                Class<?> jsonSer = Class.forName("org.keycloak.util.JsonSerialization");
+                mapper = jsonSer.getField("mapper").get(null);
+            } catch (Exception ex) {
+                throw new RuntimeException("Neither KeycloakJsonMapperFactory nor JsonSerialization found", ex);
+            }
+        }
+        MAPPER = mapper;
+        try {
+            READ_VALUE_IS = MAPPER.getClass().getMethod("readValue", InputStream.class, Class.class);
+            READ_VALUE_STRING = MAPPER.getClass().getMethod("readValue", String.class, Class.class);
+            READ_VALUE_BYTES = MAPPER.getClass().getMethod("readValue", byte[].class, Class.class);
+            WRITE_VALUE_AS_STRING = MAPPER.getClass().getMethod("writeValueAsString", Object.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Mapper does not have expected methods", e);
+        }
+    }
+
+    private JsonMapper() {}
+
+    @SuppressWarnings("unchecked")
+    public static <T> T readValue(InputStream is, Class<T> type) throws IOException {
+        try {
+            return (T) READ_VALUE_IS.invoke(MAPPER, is, type);
+        } catch (Exception e) {
+            throw unwrap(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T readValue(String src, Class<T> type) throws IOException {
+        try {
+            return (T) READ_VALUE_STRING.invoke(MAPPER, src, type);
+        } catch (Exception e) {
+            throw unwrap(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T readValue(byte[] src, Class<T> type) throws IOException {
+        try {
+            return (T) READ_VALUE_BYTES.invoke(MAPPER, src, type);
+        } catch (Exception e) {
+            throw unwrap(e);
+        }
+    }
+
+    public static String writeValueAsString(Object value) throws IOException {
+        try {
+            return (String) WRITE_VALUE_AS_STRING.invoke(MAPPER, value);
+        } catch (Exception e) {
+            throw unwrap(e);
+        }
+    }
+
+    private static IOException unwrap(Exception e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof IOException) return (IOException) cause;
+        return new IOException(cause != null ? cause : e);
+    }
+}

--- a/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
+++ b/testsuite/framework/src/main/java/org/keycloak/client/testsuite/common/OAuthClient.java
@@ -40,7 +40,7 @@ import org.keycloak.jose.jwk.OKPPublicJWK;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testsuite.util.ServerURLs;
 import org.keycloak.util.BasicAuthHelper;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.client.testsuite.common.JsonMapper;
 import org.keycloak.util.TokenUtil;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -481,7 +481,7 @@ public class OAuthClient {
 
                 String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                 @SuppressWarnings("unchecked")
-                Map<String, Object> responseJson = JsonSerialization.readValue(s, Map.class);
+                Map<String, Object> responseJson = JsonMapper.readValue(s, Map.class);
 
                 if (statusCode == 200) {
                     otherClaims = new HashMap<>();
@@ -639,7 +639,7 @@ public class OAuthClient {
 
         HttpGet get = new HttpGet(certUrl);
         try (CloseableHttpResponse response = httpClient.execute(get)) {
-            return JsonSerialization.readValue(response.getEntity().getContent(), JSONWebKeySet.class);
+            return JsonMapper.readValue(response.getEntity().getContent(), JSONWebKeySet.class);
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/testsuite/framework/src/main/java/org/keycloak/testsuite/util/AdminClientUtil.java
+++ b/testsuite/framework/src/main/java/org/keycloak/testsuite/util/AdminClientUtil.java
@@ -25,9 +25,7 @@ import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
-import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.keycloak.OAuth2Constants;
-import org.keycloak.admin.client.JacksonProvider;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.client.testsuite.framework.TestRegistry;
@@ -94,9 +92,20 @@ public class AdminClientUtil {
         ResteasyClientBuilder resteasyClientBuilder = (ResteasyClientBuilder) ResteasyClientBuilder.newBuilder();
         resteasyClientBuilder.sslContext(buildSslContext());
 
-        // We need to use subclass (or anonymous class) to avoid the following error from RESTEasy:
-        // Provider class org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider is already registered.  2nd registration is being ignored.
-        ResteasyJackson2Provider jacksonProvider = new JacksonProvider();
+        // TODO: remove reflection once keycloak/keycloak#50848 merges and sync populates the providers
+        // try jackson 3 provider first, fall back to jackson 2
+        Object jacksonProvider;
+        try {
+            jacksonProvider = Class.forName("org.keycloak.admin.client.jackson3.JacksonProvider3")
+                    .getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            try {
+                jacksonProvider = Class.forName("org.keycloak.admin.client.JacksonProvider")
+                        .getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                throw new RuntimeException("No JacksonProvider found", ex);
+            }
+        }
         resteasyClientBuilder.register(jacksonProvider, 100);
 
         resteasyClientBuilder


### PR DESCRIPTION
* closes: https://github.com/keycloak/keycloak-client/issues/192

This is a follow-up for https://github.com/keycloak/keycloak/pull/50848. I tested it in my other fork:

- full flow: sync -> run Jackson 3 tests: https://github.com/michalvavrik-dev-automation/keycloak-client/actions/runs/30918708778
- this PR isn't introducing any breaking changes, instead it is postponing them to the 27.x release
- Jackson 3 module is entirely isolated from Jackson 2 data bindings